### PR TITLE
fix of filter by username in monitor page

### DIFF
--- a/src/Dorc.Api.Tests/DataPagerExtensionTests.cs
+++ b/src/Dorc.Api.Tests/DataPagerExtensionTests.cs
@@ -68,7 +68,7 @@ namespace Dorc.Api.Tests
         {
             public int Id { get; set; }
             public string Name { get; set; }
-            public DateTime CreatedDate { get; set; }
+            public DateTime CreatedDate { get; set; } // this is needed to test unsupported by filter property type (DateTime)
         }
 
         [TestMethod]

--- a/src/Dorc.Api.Tests/DataPagerExtensionTests.cs
+++ b/src/Dorc.Api.Tests/DataPagerExtensionTests.cs
@@ -68,6 +68,7 @@ namespace Dorc.Api.Tests
         {
             public int Id { get; set; }
             public string Name { get; set; }
+            public DateTime CreatedDate { get; set; }
         }
 
         [TestMethod]
@@ -139,18 +140,14 @@ namespace Dorc.Api.Tests
         }
 
         [TestMethod]
-        public void ContainsExpression_ShouldReturnNullForInvalidPropertyName()
+        [ExpectedException(typeof(ArgumentException))]
+        public void ContainsExpression_ShouldThrowForInvalidPropertyName()
         {
             // Arrange
             var data = new List<TestModel>().AsQueryable();
-            string propertyName = "InvalidProperty";
-            string propertyValue = "Test";
 
             // Act
-            var expression = data.ContainsExpression(propertyName, propertyValue);
-
-            // Assert
-            Assert.IsNull(expression);
+            var expression = data.ContainsExpression("InvalidProperty", "Test");
         }
     }
 }

--- a/src/Dorc.PersistentData/Extensions/DataPagerExtension.cs
+++ b/src/Dorc.PersistentData/Extensions/DataPagerExtension.cs
@@ -38,7 +38,7 @@ namespace Dorc.PersistentData.Extensions
 
             if (typeof(T).GetProperty(propertyName) == null)
             {
-                return null; // propertyName not exists in T
+                throw new ArgumentException($"Filter by '{propertyName}' has failed: type '{typeof(T).Name}' does not have property '{propertyName}'"); // propertyName not exists in T
             }
 
             var propertyExp = Expression.Property(parameterExp, propertyName);

--- a/src/dorc-web/src/pages/page-monitor-requests.ts
+++ b/src/dorc-web/src/pages/page-monitor-requests.ts
@@ -484,7 +484,7 @@ export class PageMonitorRequests extends PageElement {
     render(
       html`
         User
-        <vaadin-grid-filter path="Username">
+        <vaadin-grid-filter path="UserName">
           <vaadin-text-field
             clear-button-visible
             slot="filter"
@@ -612,13 +612,13 @@ export class PageMonitorRequests extends PageElement {
     }
 
     const usernameIdx = params.filters.findIndex(
-      filter => filter.path === 'Username'
+      filter => filter.path === 'UserName'
     );
     if (usernameIdx !== -1) {
       const usernameValue = params.filters[usernameIdx].value;
       params.filters.splice(usernameIdx, 1);
       if (usernameValue !== '') {
-        params.filters.push({ path: 'Username', value: usernameValue });
+        params.filters.push({ path: 'UserName', value: usernameValue });
       }
     }
 


### PR DESCRIPTION
fix, make BE to throw meaningful exception next time when trying to filter by non-existent property