### PR TITLE
Added sonar.sources property to explicitly add dorc-web directory for scan

### DIFF
--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -88,7 +88,7 @@ steps:
     projectVersion: '$(Build.BuildNumber)'
     extraProperties: |
       sonar.sources=src/dorc-web,src
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
+  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: FileTransform@2
   displayName: 'Transform settings for tests during build time'

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -86,6 +86,8 @@ steps:
     projectKey: sh.devops.dorc
     projectName: sh.devops.dorc
     projectVersion: '$(Build.BuildNumber)'
+    extraProperties: |
+      sonar.sources=src/dorc-web,src
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: FileTransform@2


### PR DESCRIPTION
This change related to PBI #350941 DOrc Build pipeline doesn't scan Typescript in sonarqube