### PR TITLE
Feature/350941 sonarqube scan typescript

### DIFF
--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -87,7 +87,8 @@ steps:
     projectName: sh.devops.dorc
     projectVersion: '$(Build.BuildNumber)'
     extraProperties: |
-      sonar.sources=src/dorc-web,src
+      sonar.sources=src,dorc-web
+      sonar.exclusions=src/dorc-web/.gitignore
   # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: FileTransform@2

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -89,7 +89,7 @@ steps:
     extraProperties: |
       sonar.sources=src/dorc-web
       sonar.exclusions=src/dorc-web/.gitignore
-  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: FileTransform@2
   displayName: 'Transform settings for tests during build time'
@@ -122,7 +122,7 @@ steps:
 - task: sonarsource.sonarqube.6D01813A-9589-4B15-8491-8164AEB38055.SonarQubeAnalyze@6.3.2
   displayName: 'Complete the SonarQube analysis'
   continueOnError: true
-  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: richardfennellbm.BM-VSTS-FileCopier-Tasks.FileCopyTask.FileCopy@4
   displayName: 'Copy Install Scripts'

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -88,7 +88,7 @@ steps:
     projectVersion: '$(Build.BuildNumber)'
     extraProperties: |
       sonar.sources=src/dorc-web,src
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
+  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: FileTransform@2
   displayName: 'Transform settings for tests during build time'

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -121,7 +121,7 @@ steps:
 - task: sonarsource.sonarqube.6D01813A-9589-4B15-8491-8164AEB38055.SonarQubeAnalyze@6.3.2
   displayName: 'Complete the SonarQube analysis'
   continueOnError: true
-  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
+  # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: richardfennellbm.BM-VSTS-FileCopier-Tasks.FileCopyTask.FileCopy@4
   displayName: 'Copy Install Scripts'

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -86,6 +86,8 @@ steps:
     projectKey: sh.devops.dorc
     projectName: sh.devops.dorc
     projectVersion: '$(Build.BuildNumber)'
+    extraProperties: |
+      sonar.sources=src/dorc-web,src
   condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 
 - task: FileTransform@2

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -87,7 +87,7 @@ steps:
     projectName: sh.devops.dorc
     projectVersion: '$(Build.BuildNumber)'
     extraProperties: |
-      sonar.sources=src,dorc-web
+      sonar.sources=src/dorc-web
       sonar.exclusions=src/dorc-web/.gitignore
   # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.SourceBranch'], 'refs/heads/develop'),eq(variables['Build.Reason'], 'PullRequest')))
 


### PR DESCRIPTION
**MSBuild Scanner Behavior:** The MSBuild Scanner only scans directories containing *.csproj files. Since "dorc-web" is a Node.js project and does not contain a *.csproj file, it was excluded from the analysis by default.
**Explicit Inclusion:** The "sonar.sources" property was updated to explicitly include the "dorc-web" directory for analysis.