### PR TITLE
Feature/171 toggle access control ad sids or azure pids

### DIFF
--- a/src/Dorc.Api/Controllers/RefDataProjectsController.cs
+++ b/src/Dorc.Api/Controllers/RefDataProjectsController.cs
@@ -104,7 +104,7 @@ namespace Dorc.Api.Controllers
                 var adSearch = _activeDirectorySearcher.GetUserData(username);
 
                 _accessControlPersistentSource.AddAccessControl(new AccessControlApiModel
-                { Pid = adSearch.Pid, Name = adSearch.DisplayName, Allow = (int)(AccessLevel.Write | AccessLevel.ReadSecrets), Deny = 0 }, securityObject.ObjectId);
+                { Sid = adSearch.Sid, Pid = adSearch.Pid, Name = adSearch.DisplayName, Allow = (int)(AccessLevel.Write | AccessLevel.ReadSecrets), Deny = 0 }, securityObject.ObjectId);
 
                 return StatusCode(StatusCodes.Status200OK, _projectsPersistentSource.GetProject(project.ProjectName));
             }

--- a/src/Dorc.Api/Security/ClaimsPrincipalReaderFactory.cs
+++ b/src/Dorc.Api/Security/ClaimsPrincipalReaderFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Dorc.Api.Interfaces;
+using Dorc.Core.Configuration;
 using Dorc.PersistentData;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using System.Security.Claims;
@@ -8,15 +9,18 @@ namespace Dorc.Api.Security
 {
     public class ClaimsPrincipalReaderFactory : IClaimsPrincipalReader
     {
+        private readonly IConfigurationSettings _config;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly OAuthClaimsPrincipalReader _oauthReader;
         private readonly WinAuthClaimsPrincipalReader _winAuthReader;
 
         public ClaimsPrincipalReaderFactory(
+            IConfigurationSettings config,
             IHttpContextAccessor httpContextAccessor,
             IUserGroupsReaderFactory userGroupsReaderFactory
             )
         {
+            _config = config;
             _httpContextAccessor = httpContextAccessor;
 
             _oauthReader = new OAuthClaimsPrincipalReader(userGroupsReaderFactory.GetOAuthUserGroupsReader());
@@ -68,6 +72,11 @@ namespace Dorc.Api.Security
 
         public List<string> GetSidsForUser(IPrincipal user)
         {
+            if (_config.GetIsUseAdSidsForAccessControl())
+            {
+                return _winAuthReader.GetSidsForUser(user);
+            }
+
             var reader = ResolveReader();
             return reader.GetSidsForUser(user);
         }

--- a/src/Dorc.Api/appsettings.json
+++ b/src/Dorc.Api/appsettings.json
@@ -27,7 +27,8 @@
     "AzureEndpoint": "dev.azure.com",
     "ADUserCacheTimeMinutes": "30",
     "IdentityServerClientId": "",
-    "IsUseIdentityServerAsSearcher": "true",
+    "IsUseAdAsSearcher": "false",
+    "IsUseAdSidsForAccessControl": "false",
     "OnePassword": {
       "BaseUrl": "",
       "ApiKey": "",

--- a/src/Dorc.ApiModel/UserElementApiModel.cs
+++ b/src/Dorc.ApiModel/UserElementApiModel.cs
@@ -1,8 +1,12 @@
-﻿namespace Dorc.ApiModel
+﻿using System;
+
+namespace Dorc.ApiModel
 {
     public class UserElementApiModel
     {
         public string DisplayName { get; set; }
+        [Obsolete("Use Pid, this exists only for backward compatibility with AD")]
+        public string Sid { get; set; }
         public string Pid { get; set; }
         public string Username { get; set; }
         public bool IsGroup { get; set; }

--- a/src/Dorc.Core/ActiveDirectorySearcher.cs
+++ b/src/Dorc.Core/ActiveDirectorySearcher.cs
@@ -210,10 +210,10 @@ namespace Dorc.Core
             throw new ArgumentException("Failed to locate a valid user account for requested user!");
         }
 
-        public List<string> GetSidsForUser(string username)
+        public List<string> GetSidsForUser(string samAccountName)
         {
             var result = new HashSet<string>();
-            var name = username;
+            var name = samAccountName;
 
             DirectorySearcher ds = new DirectorySearcher();
 
@@ -229,7 +229,7 @@ namespace Dorc.Core
                 result.Add(sid.ToString());
             }
 
-            var f = new NTAccount(username);
+            var f = new NTAccount(samAccountName);
             var s = (SecurityIdentifier)f.Translate(typeof(SecurityIdentifier));
             var sidString = s.ToString();
 

--- a/src/Dorc.Core/ActiveDirectorySearcher.cs
+++ b/src/Dorc.Core/ActiveDirectorySearcher.cs
@@ -90,7 +90,7 @@ namespace Dorc.Core
             {
                 Username = GetSafeString(de.Properties, "SAMAccountName"),
                 DisplayName = displayName,
-                Pid = GetSidString((byte[])de.Properties["objectSid"].Value),
+                Sid = GetSidString((byte[])de.Properties["objectSid"].Value),
                 IsGroup = de.Properties["objectClass"]?.Contains("group") == true,
                 Email = de.Properties["mail"].Value != null ? de.Properties["mail"].Value?.ToString() : de.Properties["UserPrincipalName"].Value?.ToString()
             };
@@ -159,7 +159,7 @@ namespace Dorc.Core
 
                         var entity = GetModelFromDirectoryEntry(de);
 
-                        entity.Pid = sid;
+                        entity.Sid = sid;
 
                         return entity;
                     }
@@ -200,7 +200,7 @@ namespace Dorc.Core
                         { continue; }
 
                         var user = GetModelFromDirectoryEntry(de);
-                        user.Pid = Sid;
+                        user.Sid = Sid;
 
                         return user;
                     }

--- a/src/Dorc.Core/CompositeDirectorySearcher.cs
+++ b/src/Dorc.Core/CompositeDirectorySearcher.cs
@@ -27,8 +27,9 @@ namespace Dorc.Core
                     var searcherResults = searcher.Search(objectName);
                     foreach (var result in searcherResults)
                     {
-                        // Only add if we haven't seen this PID before
-                        if (!string.IsNullOrEmpty(result.Pid) && seenPids.Add(result.Pid))
+                        // Only add if we haven't seen this PID or Sid before
+                        if ((!string.IsNullOrEmpty(result.Pid) && seenPids.Add(result.Pid)) || 
+                            (!string.IsNullOrEmpty(result.Sid) && seenPids.Add(result.Sid)))
                         {
                             results.Add(result);
                         }

--- a/src/Dorc.Core/Configuration/ConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/ConfigurationSettings.cs
@@ -122,5 +122,11 @@ namespace Dorc.Core.Configuration
             var isUseIdentityServerAsSearcherConfig = _configuration.GetSection("AppSettings")["IsUseIdentityServerAsSearcher"];
             return bool.TryParse(isUseIdentityServerAsSearcherConfig, out bool isUseIdentityServerAsSearcher) && isUseIdentityServerAsSearcher;
         }
+
+        public bool GetIsUseAdSidsForAccessControl()
+        {
+            var isUseAdSidsForAccessControlConfig = _configuration.GetSection("AppSettings")["IsUseAdSidsForAccessControl"];
+            return bool.TryParse(isUseAdSidsForAccessControlConfig, out bool isUseAdSidsForAccessControl) && isUseAdSidsForAccessControl;
+        }
     }
 }

--- a/src/Dorc.Core/Configuration/ConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/ConfigurationSettings.cs
@@ -117,9 +117,9 @@ namespace Dorc.Core.Configuration
             return _configuration.GetSection("AppSettings:OnePassword")["IdentityServerApiSecretItemId"];
         }
 
-        public bool GetIsUseIdentityServerAsSearcher()
+        public bool GetIsUseAdAsSearcher()
         {
-            var isUseIdentityServerAsSearcherConfig = _configuration.GetSection("AppSettings")["IsUseIdentityServerAsSearcher"];
+            var isUseIdentityServerAsSearcherConfig = _configuration.GetSection("AppSettings")["IsUseAdAsSearcher"];
             return bool.TryParse(isUseIdentityServerAsSearcherConfig, out bool isUseIdentityServerAsSearcher) && isUseIdentityServerAsSearcher;
         }
 

--- a/src/Dorc.Core/Configuration/IConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/IConfigurationSettings.cs
@@ -20,6 +20,7 @@
         string? GetIdentityServerClientId();
         string? GetOnePasswordIdentityServerApiSecretItemId();
         bool GetIsUseIdentityServerAsSearcher();
+        bool GetIsUseAdSidsForAccessControl();
 
         string GetAzureEntraTenantId();
         string GetAzureEntraClientId();

--- a/src/Dorc.Core/Configuration/IConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/IConfigurationSettings.cs
@@ -19,7 +19,7 @@
         string? GetOnePasswordItemId();
         string? GetIdentityServerClientId();
         string? GetOnePasswordIdentityServerApiSecretItemId();
-        bool GetIsUseIdentityServerAsSearcher();
+        bool GetIsUseAdAsSearcher();
         bool GetIsUseAdSidsForAccessControl();
 
         string GetAzureEntraTenantId();

--- a/src/Dorc.PersistentData/Sources/AccessControlPersistentSource.cs
+++ b/src/Dorc.PersistentData/Sources/AccessControlPersistentSource.cs
@@ -57,6 +57,7 @@ namespace Dorc.PersistentData.Sources
                 if (existingAccessControl == null) return null;
 
                 existingAccessControl.Pid = accessControl.Pid;
+                existingAccessControl.Sid = accessControl.Sid;
                 existingAccessControl.Name = accessControl.Name;
                 existingAccessControl.Allow = accessControl.Allow;
                 existingAccessControl.Deny = accessControl.Deny;
@@ -129,6 +130,7 @@ namespace Dorc.PersistentData.Sources
                 Name = ac.Name,
                 ObjectId = objectId,
                 Pid = ac.Pid,
+                Sid = ac.Sid,
             };
         }
     }

--- a/src/Dorc.PersistentData/Sources/EnvironmentsPersistentSource.cs
+++ b/src/Dorc.PersistentData/Sources/EnvironmentsPersistentSource.cs
@@ -164,6 +164,7 @@ namespace Dorc.PersistentData.Sources
                     {
                         ObjectId = envDetail.ObjectId,
                         Name = user.DisplayName,
+                        Sid = user.Sid,
                         Pid = user.Pid,
                         Allow = (int)AccessLevel.Owner
                     };
@@ -716,6 +717,7 @@ namespace Dorc.PersistentData.Sources
             {
                 ownerAccess.Name = env.Details.EnvironmentOwner;
                 ownerAccess.Pid = env.Details.EnvironmentOwnerId;
+                ownerAccess.Sid = env.Details.EnvironmentOwnerId;
             }
             else
             {
@@ -724,6 +726,7 @@ namespace Dorc.PersistentData.Sources
                     ObjectId = e.ObjectId,
                     Name = env.Details.EnvironmentOwner,
                     Pid = env.Details.EnvironmentOwnerId,
+                    Sid = env.Details.EnvironmentOwnerId,
                     Allow = (int)AccessLevel.Owner
                 });
             }

--- a/src/dorc-web/src/apis/dorc-api/models/UserElementApiModel.ts
+++ b/src/dorc-web/src/apis/dorc-api/models/UserElementApiModel.ts
@@ -25,6 +25,11 @@ export interface UserElementApiModel {
      * @type {string}
      * @memberof UserElementApiModel
      */
+    Sid?: string | null;
+    /**
+     * @type {string}
+     * @memberof UserElementApiModel
+     */
     Pid?: string | null;
     /**
      * @type {string}

--- a/src/dorc-web/src/components/add-edit-access-control.ts
+++ b/src/dorc-web/src/components/add-edit-access-control.ts
@@ -324,7 +324,7 @@ export class AddEditAccessControl extends LitElement {
 
   removeAccessControl(accessControl: AccessControlApiModel) {
     const actual = this.Privileges?.find(
-      value => value.Pid === accessControl.Pid
+      value => value.Pid === accessControl.Pid || value.Sid === accessControl.Sid
     );
 
     if (actual !== undefined) {
@@ -402,7 +402,8 @@ export class AddEditAccessControl extends LitElement {
         Name: user.DisplayName,
         Allow: 0,
         Deny: 0,
-        Pid: user.Pid
+        Pid: user.Pid,
+        Sid: user.Sid,
       };
       this.Privileges?.push(acam);
       this.Privileges = JSON.parse(JSON.stringify(this.Privileges));


### PR DESCRIPTION
add two settings to control if AD should be used instead of Azure 
-  'IsUseAdAsSearcher': for searching users
-  'IsUseAdSidsForAccessControl': for calculating access control permissions of users\groups
