### PR TITLE
Fix/317 duplicated groups access control

### DIFF
--- a/src/dorc-web/src/components/add-edit-access-control.ts
+++ b/src/dorc-web/src/components/add-edit-access-control.ts
@@ -415,6 +415,16 @@ export class AddEditAccessControl extends LitElement {
     const user = cbSelectedUser.selectedItem
 
     if (user !== undefined) {
+      const existing = this.Privileges?.find(item => (item.Sid && item.Sid === user.Sid) || (item.Pid && item.Pid === user.Pid));
+      if (existing) {
+        Notification.show(`User is already in the list`, {
+          theme: 'warning',
+          position: 'bottom-start',
+          duration: 3000
+        });
+        return;
+      }
+
       const acam: AccessControlApiModel = {
         Name: user.DisplayName,
         Allow: 0,


### PR DESCRIPTION
- added displaying id of the item in AccessControl dialog
- fix issue with possibility to add the same group\user several times
- fix issue of impossibility to add duplicated group (it was always adding the first one by name)