### PR TITLE
#216: add confirmation dialog when attaching a db

### DIFF
--- a/src/Dorc.PersistentData/Sources/EnvironmentsPersistentSource.cs
+++ b/src/Dorc.PersistentData/Sources/EnvironmentsPersistentSource.cs
@@ -387,6 +387,9 @@ namespace Dorc.PersistentData.Sources
 
         public EnvironmentApiModel GetEnvironment(string environmentName, IPrincipal user)
         {
+            if (string.IsNullOrEmpty(environmentName))
+                return null;
+
             string username = _claimsPrincipalReader.GetUserLogin(user);
             var userSids = _claimsPrincipalReader.GetSidsForUser(user);
             var sidSet = userSids.ToHashSet();

--- a/src/dorc-web/package-lock.json
+++ b/src/dorc-web/package-lock.json
@@ -18,6 +18,7 @@
         "@vaadin/button": "^24.7.6",
         "@vaadin/checkbox": "^24.7.6",
         "@vaadin/combo-box": "^24.7.6",
+        "@vaadin/confirm-dialog": "^24.7.6",
         "@vaadin/date-picker": "^24.7.6",
         "@vaadin/date-time-picker": "^24.7.6",
         "@vaadin/details": "^24.7.6",
@@ -2371,6 +2372,24 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
         "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/confirm-dialog": {
+      "version": "24.7.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/confirm-dialog/-/confirm-dialog-24.7.6.tgz",
+      "integrity": "sha512-KAMess/jSg9CvnSleXwkZhkCZlRoJ6QRfvc1g8D/3LA0uSYokQAvVyagSEE67rmEXmJSVOAdiXjBQDlpNr7Aog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/button": "~24.7.6",
+        "@vaadin/component-base": "~24.7.6",
+        "@vaadin/dialog": "~24.7.6",
+        "@vaadin/overlay": "~24.7.6",
+        "@vaadin/vaadin-lumo-styles": "~24.7.6",
+        "@vaadin/vaadin-material-styles": "~24.7.6",
+        "@vaadin/vaadin-themable-mixin": "~24.7.6",
         "lit": "^3.0.0"
       }
     },

--- a/src/dorc-web/package.json
+++ b/src/dorc-web/package.json
@@ -33,6 +33,7 @@
     "@vaadin/button": "^24.7.6",
     "@vaadin/checkbox": "^24.7.6",
     "@vaadin/combo-box": "^24.7.6",
+    "@vaadin/confirm-dialog": "^24.7.6",
     "@vaadin/date-picker": "^24.7.6",
     "@vaadin/date-time-picker": "^24.7.6",
     "@vaadin/details": "^24.7.6",

--- a/src/dorc-web/src/components/attach-database.ts
+++ b/src/dorc-web/src/components/attach-database.ts
@@ -1,5 +1,6 @@
 import { css, LitElement } from 'lit';
 import '@vaadin/combo-box';
+import '@vaadin/confirm-dialog';
 import { GridColumn } from '@vaadin/grid/vaadin-grid-column';
 import { GridItemModel } from '@vaadin/grid';
 import '@polymer/paper-dialog';
@@ -15,6 +16,9 @@ import {
 
 @customElement('attach-database')
 export class AttachDatabase extends LitElement {
+  @property({ type: Array })
+  public existingDatabases: Array<DatabaseApiModel> | undefined = [];
+
   @property({ type: Object })
   private selectedDatabase: DatabaseApiModel | undefined;
 
@@ -29,6 +33,12 @@ export class AttachDatabase extends LitElement {
 
   @property({ type: Object })
   private databaseMap: Map<number | undefined, DatabaseApiModel> | undefined;
+  
+  @property({ type: Boolean })
+  private confirmSameTagDialogOpened: boolean = false;
+
+  @property({ type: String })
+  private confirmSameTagDialogText: string = '';
 
   constructor() {
     super();
@@ -49,6 +59,19 @@ export class AttachDatabase extends LitElement {
 
   render() {
     return html`
+      <vaadin-confirm-dialog
+          id="sameTagExistsConfirmDialog"
+          header="Existing database tag"
+          cancel-button-visible
+          .opened="${this.confirmSameTagDialogOpened}"
+          .message="${this.confirmSameTagDialogText}"
+          confirm-text="Yes, attach"
+          cancel-text="Cancel"
+          @confirm="${this._submit}"
+          @cancel="${() => {
+            this.confirmSameTagDialogOpened = false;
+          }}"
+        ></vaadin-confirm-dialog>
       <div style="padding: 10px;">
         <div class="inline">
           <vaadin-combo-box
@@ -90,11 +113,23 @@ export class AttachDatabase extends LitElement {
           </h3>
         </div>
 
-        <vaadin-button .disabled="${!this.canSubmit}" @click="${this._submit}"
+        <vaadin-button .disabled="${!this.canSubmit}" @click="${this.onAttachClick}"
           >Attach</vaadin-button
         >
       </div>
     `;
+  }
+
+  onAttachClick() {
+    const existingTag = this.existingDatabases?.find(db => db.Type === this.selectedDatabase?.Type);
+
+    if (!existingTag) {
+      this._submit();
+    }
+    else {
+      this.confirmSameTagDialogText = `Do you really want to attach another database with tag '${this.selectedDatabase?.Type}'? A database '${existingTag?.Name}' with such tag is already attached`;
+      this.confirmSameTagDialogOpened = true;
+    }
   }
 
   setSelectedDatabase(data: any) {

--- a/src/dorc-web/src/components/attach-database.ts
+++ b/src/dorc-web/src/components/attach-database.ts
@@ -127,7 +127,7 @@ export class AttachDatabase extends LitElement {
       this._submit();
     }
     else {
-      this.confirmSameTagDialogText = `Do you really want to attach another database with tag '${this.selectedDatabase?.Type}'? A database '${existingTag?.Name}' with such tag is already attached`;
+      this.confirmSameTagDialogText = `Do you really want to attach another database with tag '${this.selectedDatabase?.Type}'? The database '${existingTag?.Name}' with such tag is already attached`;
       this.confirmSameTagDialogOpened = true;
     }
   }

--- a/src/dorc-web/src/components/environment-tabs/env-databases.ts
+++ b/src/dorc-web/src/components/environment-tabs/env-databases.ts
@@ -98,6 +98,7 @@ export class EnvDatabases extends PageEnvBase {
             ? html` <div class="center-aligned">
                 <attach-database
                   .envId="${this.environmentId}"
+                  .existingDatabases="${this.databases}"
                   @database-attached="${this._dbAttached}"
                 ></attach-database>
               </div>`

--- a/src/dorc-web/src/pages/page-variables.ts
+++ b/src/dorc-web/src/pages/page-variables.ts
@@ -689,6 +689,10 @@ export class PageVariables extends PageElement {
     if (data) {
       const combo = data.target as ComboBox;
       this.newVariableScope = combo.value;
+      if (!this.newVariableScope)
+      {
+        return;
+      }
       this.loadingScopeOptions = true;
 
       const api = new PropertyValuesApi();


### PR DESCRIPTION
- add confirmation dialog when attaching a db with the same tag as an already attached dbs in the list
- fix small issue of endless spinner on variables page, showing loading scope options