### PR TITLE
Fixed the missing image on dorc signout page #467

### DIFF
--- a/src/dorc-web/signin.html
+++ b/src/dorc-web/signin.html
@@ -79,7 +79,9 @@
 <body>
   <div class="signin-container">
     <div class="logo">
-      <img src="https://www.sefe.eu/typo3temp/assets/_processed_/a/9/csm_SEFE_GROUP_logo_d4a06ffb59.png" />
+      <img
+        src="/hegsie_white_background_cartoon_dork_code_markdown_simple_icon__ef4f70a2-200b-4a67-82ba-73b12eb495d3.png"
+        alt="DOrc mascot" style="height: 150px;" />
       <h2>You are not signed in</h2>
     </div>
     <div class="signin-title">Sign in to your account</div>


### PR DESCRIPTION
Fixes #467

The signin.html contained a reference to an external image URL (https://www.sefe.eu/typo3temp/assets/_processed_/a/9/csm_SEFE_GROUP_logo_d4a06ffb59.png) which was likely broken or incorrect for the Dorc application.
I replaced this external image with the local Dorc mascot image available in the project, consistent with the main application header.