### PR TITLE
Fix RabbitMQ connection leak causing environments stuck in pending

### DIFF
--- a/src/Dorc.Monitor.Tests/DistributedLockServiceTests.cs
+++ b/src/Dorc.Monitor.Tests/DistributedLockServiceTests.cs
@@ -1,6 +1,10 @@
 using Dorc.Monitor.HighAvailability;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using RabbitMQ.Client.Exceptions;
 using System.Net;
 
 namespace Dorc.Monitor.Tests.HighAvailability
@@ -444,6 +448,115 @@ namespace Dorc.Monitor.Tests.HighAvailability
 
             // Assert - the configuration property returns the expected value
             Assert.AreEqual(15, mockConfiguration.LockAcquisitionTimeoutSeconds);
+        }
+    }
+
+    [TestClass]
+    public class RabbitMqDistributedLockTests
+    {
+        private ILogger<RabbitMqDistributedLockService> mockLogger;
+        private IMonitorConfiguration mockConfiguration;
+        private IChannel mockChannel;
+        private RabbitMqDistributedLockService lockService;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            mockLogger = Substitute.For<ILogger<RabbitMqDistributedLockService>>();
+            mockConfiguration = Substitute.For<IMonitorConfiguration>();
+            mockConfiguration.HighAvailabilityEnabled.Returns(false);
+            mockChannel = Substitute.For<IChannel>();
+            lockService = new RabbitMqDistributedLockService(mockLogger, mockConfiguration);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            lockService.Dispose();
+        }
+
+        [TestMethod]
+        public async Task DisposeAsync_WhenChannelIsHealthy_DeletesQueueDirectly()
+        {
+            // Arrange
+            var lockObj = new RabbitMqDistributedLock(
+                mockLogger, mockChannel, "lock.env:TestEnv", "env:TestEnv", "consumer-1", lockService);
+
+            // Act
+            await lockObj.DisposeAsync();
+
+            // Assert - queue was deleted via the original channel, no fallback needed
+            await mockChannel.Received(1).BasicCancelAsync(
+                "consumer-1", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            await mockChannel.Received(1).QueuePurgeAsync(
+                "lock.env:TestEnv", Arg.Any<CancellationToken>());
+            await mockChannel.Received(1).QueueDeleteAsync(
+                "lock.env:TestEnv", Arg.Is(false), Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task DisposeAsync_WhenChannelIsDead_AttemptsQueueDeleteViaFallback()
+        {
+            // Arrange - simulate the channel being dead (connection was refreshed concurrently)
+            mockChannel.BasicCancelAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
+            mockChannel.QueuePurgeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
+            mockChannel.QueueDeleteAsync(Arg.Any<string>(), Arg.Is<bool>(x => true), Arg.Is<bool>(x => true), Arg.Is<bool>(x => true), Arg.Any<CancellationToken>())
+                .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
+
+            var lockObj = new RabbitMqDistributedLock(
+                mockLogger, mockChannel, "lock.env:TestEnv", "env:TestEnv", "consumer-1", lockService);
+
+            // Act - should not throw despite all channel operations failing
+            await lockObj.DisposeAsync();
+
+            // Assert - original channel operations were attempted
+            await mockChannel.Received(1).BasicCancelAsync(
+                "consumer-1", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            await mockChannel.Received(1).QueueDeleteAsync(
+                "lock.env:TestEnv", Arg.Is(false), Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            // Fallback was attempted (logged as warning about attempting fallback cleanup)
+            // Since lockService has no active connection, fallback will also fail gracefully
+        }
+
+        [TestMethod]
+        public async Task DisposeAsync_CalledTwice_OnlyDisposesOnce()
+        {
+            // Arrange
+            var lockObj = new RabbitMqDistributedLock(
+                mockLogger, mockChannel, "lock.env:TestEnv", "env:TestEnv", "consumer-1", lockService);
+
+            // Act
+            await lockObj.DisposeAsync();
+            await lockObj.DisposeAsync();
+
+            // Assert - operations only called once due to Interlocked guard
+            await mockChannel.Received(1).BasicCancelAsync(
+                "consumer-1", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task DisposeAsync_WhenQueueDeleteSucceeds_DoesNotCallFallback()
+        {
+            // Arrange - cancel and purge fail but delete succeeds
+            mockChannel.BasicCancelAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
+            mockChannel.QueuePurgeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
+            // QueueDeleteAsync succeeds (default mock behavior returns completed task)
+
+            var lockObj = new RabbitMqDistributedLock(
+                mockLogger, mockChannel, "lock.env:TestEnv", "env:TestEnv", "consumer-1", lockService);
+
+            // Act
+            await lockObj.DisposeAsync();
+
+            // Assert - queue delete succeeded, so no fallback should be attempted.
+            // The fallback logs a specific warning message; absence of that log means no fallback.
+            // We verify by checking QueueDeleteAsync was called exactly once (on original channel only)
+            await mockChannel.Received(1).QueueDeleteAsync(
+                "lock.env:TestEnv", Arg.Is(false), Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         }
     }
 }

--- a/src/Dorc.Monitor.Tests/DistributedLockServiceTests.cs
+++ b/src/Dorc.Monitor.Tests/DistributedLockServiceTests.cs
@@ -516,8 +516,16 @@ namespace Dorc.Monitor.Tests.HighAvailability
                 "consumer-1", Arg.Any<bool>(), Arg.Any<CancellationToken>());
             await mockChannel.Received(1).QueueDeleteAsync(
                 "lock.env:TestEnv", Arg.Is(false), Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>());
-            // Fallback was attempted (logged as warning about attempting fallback cleanup)
-            // Since lockService has no active connection, fallback will also fail gracefully
+
+            // Assert - fallback path was triggered: verify the warning log indicating
+            // fallback cleanup was attempted. The lock logs "was not deleted via original
+            // channel - attempting fallback cleanup" before calling TryDeleteQueueAsync.
+            mockLogger.Received().Log(
+                LogLevel.Warning,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("was not deleted via original channel")),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>());
         }
 
         [TestMethod]

--- a/src/Dorc.Monitor.Tests/DistributedLockServiceTests.cs
+++ b/src/Dorc.Monitor.Tests/DistributedLockServiceTests.cs
@@ -502,7 +502,7 @@ namespace Dorc.Monitor.Tests.HighAvailability
                 .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
             mockChannel.QueuePurgeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
-            mockChannel.QueueDeleteAsync(Arg.Any<string>(), Arg.Is<bool>(x => true), Arg.Is<bool>(x => true), Arg.Is<bool>(x => true), Arg.Any<CancellationToken>())
+            mockChannel.QueueDeleteAsync(Arg.Any<string>(), Arg.Is(false), Arg.Is(false), Arg.Any<bool>(), Arg.Any<CancellationToken>())
                 .ThrowsAsync(new AlreadyClosedException(new ShutdownEventArgs(ShutdownInitiator.Application, 200, "Already closed")));
 
             var lockObj = new RabbitMqDistributedLock(

--- a/src/Dorc.Monitor/HighAvailability/RabbitMqDistributedLockService.cs
+++ b/src/Dorc.Monitor/HighAvailability/RabbitMqDistributedLockService.cs
@@ -555,12 +555,21 @@ namespace Dorc.Monitor.HighAvailability
                     return false;
                 }
 
-                using var channel = await currentConnection.CreateChannelAsync(cancellationToken: CancellationToken.None);
-                await channel.QueuePurgeAsync(queueName, CancellationToken.None);
-                await channel.QueueDeleteAsync(queue: queueName, ifUnused: false, ifEmpty: false, cancellationToken: CancellationToken.None);
-                await channel.CloseAsync(CancellationToken.None);
+                // Use a short timeout to prevent indefinite hangs if the broker is unhealthy
+                using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                var ct = timeoutCts.Token;
+
+                await using var channel = await currentConnection.CreateChannelAsync(cancellationToken: ct);
+                await channel.QueuePurgeAsync(queueName, ct);
+                await channel.QueueDeleteAsync(queue: queueName, ifUnused: false, ifEmpty: false, cancellationToken: ct);
+                await channel.CloseAsync(ct);
                 logger.LogInformation("Deleted orphaned lock queue '{QueueName}' for resource '{ResourceKey}' via fallback channel", queueName, resourceKey);
                 return true;
+            }
+            catch (OperationCanceledException)
+            {
+                logger.LogWarning("Timeout (10s) deleting orphaned lock queue '{QueueName}' for resource '{ResourceKey}' via fallback channel", queueName, resourceKey);
+                return false;
             }
             catch (Exception ex)
             {

--- a/src/Dorc.Monitor/HighAvailability/RabbitMqDistributedLockService.cs
+++ b/src/Dorc.Monitor/HighAvailability/RabbitMqDistributedLockService.cs
@@ -529,13 +529,33 @@ namespace Dorc.Monitor.HighAvailability
         {
             try
             {
-                if (connection == null || !connection.IsOpen)
+                // Safely capture the current connection reference under the semaphore
+                // to avoid a race with ForceConnectionRefreshAsync setting connection to null.
+                IConnection? currentConnection = null;
+
+                var semaphoreAcquired = await connectionSemaphore.WaitAsync(TimeSpan.FromSeconds(5));
+                if (!semaphoreAcquired)
+                {
+                    logger.LogWarning("Timeout waiting to acquire connection semaphore when deleting orphaned lock queue '{QueueName}'", queueName);
+                    return false;
+                }
+
+                try
+                {
+                    currentConnection = connection;
+                }
+                finally
+                {
+                    connectionSemaphore.Release();
+                }
+
+                if (currentConnection == null || !currentConnection.IsOpen)
                 {
                     logger.LogWarning("Cannot delete orphaned lock queue '{QueueName}' - no active connection", queueName);
                     return false;
                 }
 
-                using var channel = await connection.CreateChannelAsync(cancellationToken: CancellationToken.None);
+                using var channel = await currentConnection.CreateChannelAsync(cancellationToken: CancellationToken.None);
                 await channel.QueuePurgeAsync(queueName, CancellationToken.None);
                 await channel.QueueDeleteAsync(queue: queueName, ifUnused: false, ifEmpty: false, cancellationToken: CancellationToken.None);
                 await channel.CloseAsync(CancellationToken.None);

--- a/src/Dorc.Monitor/HighAvailability/RabbitMqDistributedLockService.cs
+++ b/src/Dorc.Monitor/HighAvailability/RabbitMqDistributedLockService.cs
@@ -219,7 +219,7 @@ namespace Dorc.Monitor.HighAvailability
                         logger.LogDebug("Successfully acquired distributed lock for resource '{ResourceKey}' using quorum queue with single-active consumer", 
                             resourceKey);
 
-                        return new RabbitMqDistributedLock(logger, channel, queueName, resourceKey, consumerTag);
+                        return new RabbitMqDistributedLock(logger, channel, queueName, resourceKey, consumerTag, this);
                     }
                     catch (OperationInterruptedException opEx) when (opEx.Message.Contains("ACCESS_REFUSED") && retry < maxRetries - 1)
                     {
@@ -271,19 +271,34 @@ namespace Dorc.Monitor.HighAvailability
                 }
                 
                 // Close and dispose existing connection if any
+                // IMPORTANT: CloseAsync and Dispose must be in separate try blocks.
+                // If CloseAsync throws (e.g. TaskCanceledException during token refresh),
+                // Dispose must still be called to release the underlying TCP socket and
+                // deregister consumers. A leaked connection keeps old consumers alive on
+                // RabbitMQ, permanently blocking single-active-consumer lock queues.
                 if (connection != null)
                 {
+                    var connToDispose = connection;
+                    connection = null;
+
                     try
                     {
-                        await connection.CloseAsync(cancellationToken);
-                        connection.Dispose();
-                        logger.LogDebug("Closed existing RabbitMQ connection for refresh");
+                        await connToDispose.CloseAsync(cancellationToken);
                     }
                     catch (Exception ex)
                     {
                         logger.LogWarning(ex, "Error closing connection during forced refresh");
                     }
-                    connection = null;
+
+                    try
+                    {
+                        connToDispose.Dispose();
+                        logger.LogDebug("Disposed existing RabbitMQ connection for refresh");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Error disposing connection during forced refresh");
+                    }
                 }
 
                 // Clear cached credentials and token expiry to force new token acquisition
@@ -504,6 +519,36 @@ namespace Dorc.Monitor.HighAvailability
             };
         }
 
+        /// <summary>
+        /// Attempts to delete a lock queue using the current connection.
+        /// Called by RabbitMqDistributedLock.DisposeAsync as a fallback when the lock's
+        /// original channel is dead (e.g. due to a concurrent connection refresh).
+        /// This prevents orphaned lock queues that permanently block environments.
+        /// </summary>
+        internal async Task<bool> TryDeleteQueueAsync(string queueName, string resourceKey)
+        {
+            try
+            {
+                if (connection == null || !connection.IsOpen)
+                {
+                    logger.LogWarning("Cannot delete orphaned lock queue '{QueueName}' - no active connection", queueName);
+                    return false;
+                }
+
+                using var channel = await connection.CreateChannelAsync(cancellationToken: CancellationToken.None);
+                await channel.QueuePurgeAsync(queueName, CancellationToken.None);
+                await channel.QueueDeleteAsync(queue: queueName, ifUnused: false, ifEmpty: false, cancellationToken: CancellationToken.None);
+                await channel.CloseAsync(CancellationToken.None);
+                logger.LogInformation("Deleted orphaned lock queue '{QueueName}' for resource '{ResourceKey}' via fallback channel", queueName, resourceKey);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to delete orphaned lock queue '{QueueName}' for resource '{ResourceKey}' via fallback channel", queueName, resourceKey);
+                return false;
+            }
+        }
+
         public async ValueTask DisposeAsync()
         {
             if (disposed)
@@ -607,17 +652,19 @@ namespace Dorc.Monitor.HighAvailability
         private readonly string queueName;
         private readonly string resourceKey;
         private readonly string consumerTag;
+        private readonly RabbitMqDistributedLockService lockService;
         private int disposedFlag = 0;  // Use int for Interlocked operations
 
         public string ResourceKey => resourceKey;
 
-        public RabbitMqDistributedLock(ILogger logger, IChannel channel, string queueName, string resourceKey, string consumerTag)
+        public RabbitMqDistributedLock(ILogger logger, IChannel channel, string queueName, string resourceKey, string consumerTag, RabbitMqDistributedLockService lockService)
         {
             this.logger = logger;
             this.channel = channel;
             this.queueName = queueName;
             this.resourceKey = resourceKey;
             this.consumerTag = consumerTag;
+            this.lockService = lockService;
         }
 
         public async ValueTask DisposeAsync()
@@ -625,6 +672,8 @@ namespace Dorc.Monitor.HighAvailability
             // Thread-safe disposal check and set using Interlocked
             if (Interlocked.Exchange(ref disposedFlag, 1) == 1)
                 return;
+
+            bool queueDeleted = false;
 
             try
             {
@@ -654,6 +703,7 @@ namespace Dorc.Monitor.HighAvailability
                 // This prevents accumulation of unused lock queues
                 await channel.QueueDeleteAsync(queue: queueName, ifUnused: false, ifEmpty: false);
                 logger.LogInformation("Deleted lock queue '{QueueName}' for resource '{ResourceKey}' after deployment completed", queueName, resourceKey);
+                queueDeleted = true;
             }
             catch (Exception ex)
             {
@@ -670,6 +720,16 @@ namespace Dorc.Monitor.HighAvailability
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Error closing channel for lock '{ResourceKey}'", resourceKey);
+            }
+
+            // Fallback: if queue deletion failed (e.g. because the connection was refreshed
+            // concurrently and our channel is dead), try to delete the queue using a fresh
+            // channel from the lock service's current connection. Without this, the orphaned
+            // queue retains the lock message and permanently blocks the environment.
+            if (!queueDeleted)
+            {
+                logger.LogWarning("Lock queue '{QueueName}' for resource '{ResourceKey}' was not deleted via original channel - attempting fallback cleanup", queueName, resourceKey);
+                await lockService.TryDeleteQueueAsync(queueName, resourceKey);
             }
         }
 


### PR DESCRIPTION
## Summary
- **Fix connection leak in `ForceConnectionRefreshAsync`**: `CloseAsync()` and `Dispose()` were in the same try block. If `CloseAsync` threw (e.g. `TaskCanceledException` during OAuth token refresh), `Dispose` was skipped — leaking the connection and keeping old consumers alive on RabbitMQ, permanently blocking single-active-consumer lock queues.
- **Add fallback queue cleanup in `RabbitMqDistributedLock.DisposeAsync`**: When the lock's original channel is dead (due to concurrent connection refresh), a fresh channel from the lock service's current connection is used to delete the orphaned queue — preventing environments from getting permanently stuck.

## Root cause
A race condition between the OAuth token refresh timer and lock disposal: the timer closes the shared RabbitMQ connection while the lock is trying to clean up its queue via a channel on that same connection. All cleanup operations fail with `AlreadyClosedException`, and the connection itself is never disposed (leaked). The leaked connection's consumer stays registered as the "single active consumer" on the quorum queue, causing all future lock acquisitions for that environment to time out indefinitely.

## Test plan
- [ ] Verify `Dorc.Monitor` project builds cleanly
- [ ] Deploy to non-prod and confirm environments no longer get permanently stuck after OAuth token refresh
- [ ] Verify lock queues are properly cleaned up in RabbitMQ management UI after deployments complete
- [ ] Simulate concurrent token refresh during lock disposal to confirm fallback cleanup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)