### PR TITLE
Add Dependabot config for NuGet, npm, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      nuget-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /src/dorc-web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering NuGet (`/src`), npm (`/src/dorc-web`), and GitHub Actions (`/`)
- Weekly schedule with minor/patch updates grouped into single PRs to limit noise; majors still raised individually
- Open-PR limit of 10 per ecosystem

## Test plan
- [ ] Merge and confirm Dependabot runs (Insights → Dependency graph → Dependabot)
- [ ] Check that grouped PRs appear for minor/patch bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)