### PR TITLE
Register IDaemonObservationPersistentSource in Monitor DI

### DIFF
--- a/src/Dorc.Monitor/Registry/PersistentSourcesRegistry.cs
+++ b/src/Dorc.Monitor/Registry/PersistentSourcesRegistry.cs
@@ -17,6 +17,7 @@ namespace Dorc.Monitor.Registry
             collection.AddTransient<IPropertiesPersistentSource, PropertiesPersistentSource>();
             collection.AddTransient<IServersPersistentSource, ServersPersistentSource>();
             collection.AddTransient<IDaemonsPersistentSource, DaemonsPersistentSource>();
+            collection.AddTransient<IDaemonObservationPersistentSource, DaemonObservationPersistentSource>();
             collection.AddTransient<IDatabasesPersistentSource, DatabasesPersistentSource>();
             collection.AddTransient<IUserPermsPersistentSource, UserPermsPersistentSource>();
             collection.AddTransient<IAccessControlPersistentSource, AccessControlPersistentSource>();


### PR DESCRIPTION
## Summary

`DaemonsPersistentSource` grew an `IDaemonObservationPersistentSource` constructor dependency in the daemons-modernisation work (#651). The new registration was added to `Dorc.PersistentData/PersistentDataRegistry.cs` (Lamar) but the Monitor's pure-MS.DI registry at `Dorc.Monitor/Registry/PersistentSourcesRegistry.cs` was not kept in sync.

Any resolution path that transitively reaches `DaemonsPersistentSource` therefore throws `InvalidOperationException` at activation. The deploy flow does reach it (`IPendingRequestProcessor` → `ManageProjectsPersistentSource` → … → `DaemonsPersistentSource`), so every deploy on the live monitor errors at lookup and the request hangs at status `Requesting` until the next monitor restart triggers `CancelStaleRequests`.

Observed against requests 1883432 and 1883433 on DOrc DV 03 on 2026-04-28 14:14–14:15.

## Change

One line in `src/Dorc.Monitor/Registry/PersistentSourcesRegistry.cs`:

```csharp
collection.AddTransient<IDaemonObservationPersistentSource, DaemonObservationPersistentSource>();
```

Cherry-picked from `42e6f354` on `claude/github-azure-devops-interop-vhDvn` (PR #584), narrowed to the registry hunk only.

> Note: the underlying duplication of two parallel DI registries (Lamar + MS.DI) is the real risk. Tracked separately for migrating remaining Lamar consumers (Dorc.Api, Dorc.Core, Dorc.PersistentData, Dorc.OpenSearchData, Dorc.Runner, Tools.*CLI) onto MS.DI.

## Test Plan

- [x] `Dorc.Monitor` library builds clean.
- [ ] `dotnet test src/Dorc.Monitor.Tests` — **blocked by a pre-existing compile error on main** in `DistributedLockServiceTests.cs:659` (`RabbitMqDistributedLockService.BuildLockQueueArguments()` called as static where the method is now instance). Repros on `main` without this patch and is unrelated. Out of scope here.
- [ ] Manual: deploy any project on a non-prod monitor and verify it leaves `Requesting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)