### PR TITLE
Fix daemons list Last Seen column always showing Never

### DIFF
--- a/src/Dorc.Api/Controllers/RefDataDaemonsController.cs
+++ b/src/Dorc.Api/Controllers/RefDataDaemonsController.cs
@@ -43,21 +43,7 @@ namespace Dorc.Api.Controllers
         [HttpGet]
         public IActionResult Get()
         {
-            var output = _daemonsPersistentSource
-                .GetDaemons()
-                .Select(service =>
-                    new DaemonApiModel
-                    {
-                        Id = service.Id,
-                        AccountName = service.AccountName,
-                        DisplayName = service.DisplayName,
-                        Name = service.Name,
-                        ServiceType = service.ServiceType
-                    }
-                )
-                .ToList();
-
-            return Ok(output);
+            return Ok(_daemonsPersistentSource.GetDaemons().ToList());
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #673

## Summary
- `RefDataDaemonsController.Get()` re-projected each item from `IDaemonsPersistentSource.GetDaemons()` into a brand-new `DaemonApiModel` that copied only `Id`, `Name`, `DisplayName`, `AccountName`, `ServiceType` — silently dropping the `LastSeenDate` / `LastSeenStatus` the persistent source had just populated.
- The Daemons list grid (`page-daemons-list.ts`) therefore always saw `LastSeenDate == null` and rendered "Never" for every row.
- Fix: return the persistent-source result directly. The source already returns `DaemonApiModel` instances with the correct shape and the last-seen data attached.

## Test plan
- [ ] Open the Daemons list page and confirm rows that have observations show a relative time (e.g. "5 min ago") instead of "Never", and the tooltip surfaces the absolute timestamp + status.
- [ ] Confirm rows with no observations still render "Never".
- [ ] Sort by Last Seen still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)