### PR TITLE
ci: add Publish Release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -27,13 +27,15 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VERSION: ${{ inputs.version }}
+      DRAFT: ${{ inputs.draft }}
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Locate build artifact
         id: artifact
         run: |
           set -euo pipefail
-          payload=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=dorc-release-${VERSION}&per_page=1")
+          payload=$(gh api "repos/${REPO}/actions/artifacts?name=dorc-release-${VERSION}&per_page=1")
           count=$(echo "$payload" | jq '.total_count')
           if [ "$count" -eq 0 ]; then
             echo "::error::No artifact named dorc-release-${VERSION} found. Has release.yml run for that version?"
@@ -50,18 +52,22 @@ jobs:
           exit 1
 
       - name: Download artifact zip
+        env:
+          ARTIFACT_ID: ${{ steps.artifact.outputs.id }}
         run: |
           set -euo pipefail
           mkdir -p ./release
-          gh api "repos/${{ github.repository }}/actions/artifacts/${{ steps.artifact.outputs.id }}/zip" \
+          gh api "repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" \
             > "./release/dorc-release-${VERSION}.zip"
           ls -lh "./release/dorc-release-${VERSION}.zip"
 
       - name: Create release
+        env:
+          HEAD_SHA: ${{ steps.artifact.outputs.head_sha }}
         run: |
           set -euo pipefail
-          flags=(--target "${{ steps.artifact.outputs.head_sha }}" --title "v${VERSION}" --generate-notes)
-          if [ "${{ inputs.draft }}" = "true" ]; then
+          flags=(--target "$HEAD_SHA" --title "v${VERSION}" --generate-notes)
+          if [ "$DRAFT" = "true" ]; then
             flags+=(--draft)
           fi
           gh release create "v${VERSION}" "${flags[@]}" "./release/dorc-release-${VERSION}.zip"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,67 @@
+name: Publish Release
+
+# Manually publish a draft GitHub Release for a build produced by release.yml.
+# Looks up the workflow artifact named `dorc-release-<version>`, downloads its
+# zip, and attaches it to a draft release tagged `v<version>` at the same
+# commit the build was produced from.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Build version to publish (e.g. 26.05.05.1988)'
+        required: true
+        type: string
+      draft:
+        description: 'Create as draft (uncheck to publish immediately)'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Locate build artifact
+        id: artifact
+        run: |
+          set -euo pipefail
+          payload=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=dorc-release-${VERSION}&per_page=1")
+          count=$(echo "$payload" | jq '.total_count')
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No artifact named dorc-release-${VERSION} found. Has release.yml run for that version?"
+            exit 1
+          fi
+          echo "id=$(echo "$payload" | jq -r '.artifacts[0].id')" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(echo "$payload" | jq -r '.artifacts[0].workflow_run.head_sha')" >> "$GITHUB_OUTPUT"
+          echo "expired=$(echo "$payload" | jq -r '.artifacts[0].expired')" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if artifact has expired
+        if: steps.artifact.outputs.expired == 'true'
+        run: |
+          echo "::error::Artifact dorc-release-${VERSION} has expired and can no longer be downloaded."
+          exit 1
+
+      - name: Download artifact zip
+        run: |
+          set -euo pipefail
+          mkdir -p ./release
+          gh api "repos/${{ github.repository }}/actions/artifacts/${{ steps.artifact.outputs.id }}/zip" \
+            > "./release/dorc-release-${VERSION}.zip"
+          ls -lh "./release/dorc-release-${VERSION}.zip"
+
+      - name: Create release
+        run: |
+          set -euo pipefail
+          flags=(--target "${{ steps.artifact.outputs.head_sha }}" --title "v${VERSION}" --generate-notes)
+          if [ "${{ inputs.draft }}" = "true" ]; then
+            flags+=(--draft)
+          fi
+          gh release create "v${VERSION}" "${flags[@]}" "./release/dorc-release-${VERSION}.zip"


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release-publish.yml` — a `workflow_dispatch` workflow that automates what we just did manually for v26.05.05.1988.

Given a build version (e.g. `26.05.05.1988`), the workflow:
1. Looks up the workflow artifact named `dorc-release-<version>` produced by `release.yml`.
2. Pulls its run's `head_sha`.
3. Downloads the artifact zip.
4. Creates a release tagged `v<version>` targeting that SHA, with the zip attached and auto-generated notes (diffed against the most recent prior release tag).

Defaults to **draft**; an input toggles immediate publication.

### Usage
GitHub UI → Actions → "Publish Release" → Run workflow → enter version (e.g. `26.05.05.1988`) → Run.

### Notes
- Fails fast with a clear message if no artifact matches the version (build never ran or wrong version typed).
- Fails if the artifact has expired (retention is 400 days for `main` builds, 14 days otherwise — see `release.yml`).
- Uses `secrets.GITHUB_TOKEN` with `contents: write` + `actions: read`. No additional secrets required.

## Test plan
- [ ] Merge, then run the workflow against an existing build version (e.g. `26.05.05.1988`) with **draft** enabled and verify a draft release is produced with the correct asset, tag target, and changelog.
- [ ] Run with a bogus version and confirm the "no artifact" error path triggers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)