### PR TITLE
feat(audit): add scroll overview ruler to projects-audit diff

### DIFF
--- a/src/dorc-web/src/pages/page-projects-audit.test.ts
+++ b/src/dorc-web/src/pages/page-projects-audit.test.ts
@@ -182,6 +182,54 @@ describe('PageProjectsAudit overview ruler', () => {
       // Should not throw and there's nothing to assert other than no crash.
       expect(() => (el as any).onOverviewClick(ev)).not.toThrow();
     });
+
+    it('does nothing when the ruler has zero height (avoids NaN scrollTo)', () => {
+      // A collapsed ruler would yield ratio = clientY / 0 = ±Infinity / NaN
+      // and taint the scrollTo target. The handler must early-return instead.
+      const pane = makePane(1000, 200);
+      const wrapper = document.createElement('div');
+      const overview = document.createElement('div');
+      overview.className = 'diff-overview';
+      overview.getBoundingClientRect = () =>
+        ({ top: 0, height: 0, left: 0, right: 0, bottom: 0, width: 12, x: 0, y: 0, toJSON: () => ({}) } as DOMRect);
+      wrapper.appendChild(pane);
+      wrapper.appendChild(overview);
+      document.body.appendChild(wrapper);
+      const ev = { currentTarget: overview, clientY: 50 } as unknown as MouseEvent;
+
+      (el as any).onOverviewClick(ev);
+
+      expect(pane.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('clamps clientY above the ruler to the top of the scrollable range', () => {
+      // clientY = -50 is above the ruler — ratio would be negative; clamp to 0
+      // so the target is computed at the very top (pre-clamp 0 - 100 = -100,
+      // post-clamp 0).
+      const pane = makePane(1000, 200);
+      const overview = mountOverview(pane);
+      const ev = { currentTarget: overview, clientY: -50 } as unknown as MouseEvent;
+
+      (el as any).onOverviewClick(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 0, behavior: 'smooth' })
+      );
+    });
+
+    it('clamps clientY below the ruler to the bottom of the scrollable range', () => {
+      // clientY = 9999 is far below the ruler — ratio would be > 1; clamp to 1
+      // so target = 1000 - 100 = 900, then bottom-clamped to 800.
+      const pane = makePane(1000, 200);
+      const overview = mountOverview(pane);
+      const ev = { currentTarget: overview, clientY: 9999 } as unknown as MouseEvent;
+
+      (el as any).onOverviewClick(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 800, behavior: 'smooth' })
+      );
+    });
   });
 
   // -------------------------------------------------------

--- a/src/dorc-web/src/pages/page-projects-audit.test.ts
+++ b/src/dorc-web/src/pages/page-projects-audit.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// --- Hoisted mock values (available before vi.mock factories run) ---
+const { mockRefDataProjectAuditPut } = vi.hoisted(() => {
+  const mockSubscribe = vi.fn();
+  const mockRefDataProjectAuditPut = vi.fn(() => ({ subscribe: mockSubscribe }));
+  return { mockRefDataProjectAuditPut };
+});
+
+// --- Mock heavy dependencies (Vaadin web components, helpers, API) ---
+vi.mock('@vaadin/button', () => ({}));
+vi.mock('@vaadin/grid', () => ({}));
+vi.mock('@vaadin/grid/vaadin-grid-column', () => ({}));
+vi.mock('@vaadin/grid/vaadin-grid-sort-column', () => ({}));
+vi.mock('@vaadin/grid/vaadin-grid-sorter', () => ({}));
+vi.mock('@vaadin/horizontal-layout', () => ({}));
+vi.mock('@vaadin/icons/vaadin-icons', () => ({}));
+vi.mock('@vaadin/icon', () => ({}));
+vi.mock('@vaadin/text-field', () => ({}));
+
+vi.mock('../helpers/user-extensions', () => ({
+  getShortLogonName: vi.fn((name: string) => name)
+}));
+vi.mock('../helpers/html-meta-manager', () => ({
+  updateMetadata: vi.fn()
+}));
+vi.mock('../router/routes.ts', () => ({}));
+vi.mock('@vaadin/router', () => ({}));
+
+vi.mock('../apis/dorc-api', () => ({
+  RefDataProjectAuditApi: class {
+    refDataProjectAuditPut = mockRefDataProjectAuditPut;
+  },
+  PagedDataSorting: class {}
+}));
+
+// --- Import component after mocks are defined ---
+import { PageProjectsAudit } from './page-projects-audit';
+
+/** Helper: build a fake scroll pane with controlled metrics. */
+function makePane(scrollHeight: number, clientHeight: number, scrollTop = 0) {
+  const pane = document.createElement('div');
+  pane.className = 'diff-pane-scroll';
+  Object.defineProperty(pane, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(pane, 'clientHeight', { value: clientHeight, configurable: true });
+  pane.scrollTop = scrollTop;
+  pane.scrollTo = vi.fn(({ top }: { top: number }) => {
+    pane.scrollTop = top;
+  }) as unknown as typeof pane.scrollTo;
+  return pane;
+}
+
+describe('PageProjectsAudit overview ruler', () => {
+  let el: PageProjectsAudit;
+
+  beforeEach(async () => {
+    el = new PageProjectsAudit();
+    document.body.appendChild(el);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    el.remove();
+    document.body.innerHTML = '';
+  });
+
+  // -------------------------------------------------------
+  // updateOverviewViewport — viewport indicator sizing
+  // -------------------------------------------------------
+  describe('updateOverviewViewport', () => {
+    it('hides the viewport indicator when content fits without scrolling', () => {
+      const pane = makePane(100, 100);
+      const viewport = document.createElement('div');
+      viewport.style.display = '';
+
+      (el as any).updateOverviewViewport(pane, viewport);
+
+      expect(viewport.style.display).toBe('none');
+    });
+
+    it('hides the viewport indicator when scrollHeight is less than clientHeight', () => {
+      const pane = makePane(50, 100);
+      const viewport = document.createElement('div');
+
+      (el as any).updateOverviewViewport(pane, viewport);
+
+      expect(viewport.style.display).toBe('none');
+    });
+
+    it('shows the viewport indicator and sizes it proportionally when scrollable', () => {
+      // 1000px content, 200px visible window — viewport box should be 20%
+      // tall and start at 0% (scrollTop=0).
+      const pane = makePane(1000, 200, 0);
+      const viewport = document.createElement('div');
+      viewport.style.display = 'none';
+
+      (el as any).updateOverviewViewport(pane, viewport);
+
+      expect(viewport.style.display).toBe('');
+      expect(viewport.style.top).toBe('0%');
+      expect(viewport.style.height).toBe('20%');
+    });
+
+    it('positions the viewport indicator according to scrollTop', () => {
+      // Scrolled halfway down a 1000px content with a 200px window:
+      // top = 500/1000 = 50%, height = 200/1000 = 20%
+      const pane = makePane(1000, 200, 500);
+      const viewport = document.createElement('div');
+
+      (el as any).updateOverviewViewport(pane, viewport);
+
+      expect(viewport.style.top).toBe('50%');
+      expect(viewport.style.height).toBe('20%');
+    });
+  });
+
+  // -------------------------------------------------------
+  // onOverviewClick — click-to-jump
+  // -------------------------------------------------------
+  describe('onOverviewClick', () => {
+    /** Wire a fake overview ruler with a sibling pane the handler can find. */
+    function mountOverview(pane: HTMLDivElement) {
+      const wrapper = document.createElement('div');
+      const overview = document.createElement('div');
+      overview.className = 'diff-overview';
+      overview.getBoundingClientRect = () =>
+        ({ top: 0, height: 100, left: 0, right: 0, bottom: 100, width: 12, x: 0, y: 0, toJSON: () => ({}) } as DOMRect);
+      wrapper.appendChild(pane);
+      wrapper.appendChild(overview);
+      document.body.appendChild(wrapper);
+      return overview;
+    }
+
+    it('scrolls to (ratio * scrollHeight) - clientHeight/2 on click', () => {
+      // Click at 50% of a 100px-tall ruler, content is 1000px tall, window 200px:
+      // target = 0.5 * 1000 - 100 = 400
+      const pane = makePane(1000, 200);
+      const overview = mountOverview(pane);
+      const ev = { currentTarget: overview, clientY: 50 } as unknown as MouseEvent;
+
+      (el as any).onOverviewClick(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 400, behavior: 'smooth' })
+      );
+    });
+
+    it('clamps the scroll target to 0 when the click would land above the top', () => {
+      // Click near the top: target = 0.05 * 1000 - 100 = -50 → clamp to 0.
+      const pane = makePane(1000, 200);
+      const overview = mountOverview(pane);
+      const ev = { currentTarget: overview, clientY: 5 } as unknown as MouseEvent;
+
+      (el as any).onOverviewClick(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 0, behavior: 'smooth' })
+      );
+    });
+
+    it('clamps the scroll target to (scrollHeight - clientHeight) at the bottom', () => {
+      // Click at the very bottom: raw target = 1000 - 100 = 900, but max
+      // useful scroll position is scrollHeight - clientHeight = 800.
+      const pane = makePane(1000, 200);
+      const overview = mountOverview(pane);
+      const ev = { currentTarget: overview, clientY: 100 } as unknown as MouseEvent;
+
+      (el as any).onOverviewClick(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 800, behavior: 'smooth' })
+      );
+    });
+
+    it('does nothing when no scroll pane sibling is present', () => {
+      const overview = document.createElement('div');
+      const wrapper = document.createElement('div');
+      wrapper.appendChild(overview);
+      document.body.appendChild(wrapper);
+      const ev = { currentTarget: overview, clientY: 50 } as unknown as MouseEvent;
+
+      // Should not throw and there's nothing to assert other than no crash.
+      expect(() => (el as any).onOverviewClick(ev)).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------
+  // onOverviewKeydown — keyboard cycling through markers
+  // -------------------------------------------------------
+  describe('onOverviewKeydown', () => {
+    /** Build an overview with markers at the given top% values. */
+    function mountWithMarkers(pane: HTMLDivElement, markerTopPercents: number[]) {
+      const wrapper = document.createElement('div');
+      const overview = document.createElement('div');
+      overview.className = 'diff-overview';
+      for (const pct of markerTopPercents) {
+        const m = document.createElement('div');
+        m.className = 'diff-overview-marker';
+        m.style.top = `${pct}%`;
+        overview.appendChild(m);
+      }
+      wrapper.appendChild(pane);
+      wrapper.appendChild(overview);
+      document.body.appendChild(wrapper);
+      return overview;
+    }
+
+    it('Enter jumps to the next change marker after the viewport centre', () => {
+      // Markers at 100, 500, 900 px (10/50/90% of a 1000px content).
+      // Viewport at scrollTop=0, clientHeight=200 → centre=100.
+      // Next marker > 101 is 500 → scroll target = 500 - 100 = 400.
+      const pane = makePane(1000, 200, 0);
+      const overview = mountWithMarkers(pane, [10, 50, 90]);
+      const ev = new KeyboardEvent('keydown', { key: 'Enter' });
+      Object.defineProperty(ev, 'currentTarget', { value: overview });
+
+      (el as any).onOverviewKeydown(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 400 })
+      );
+    });
+
+    it('ArrowUp jumps to the previous change marker', () => {
+      // scrollTop=600 → centre=700. Previous marker < 699 is 500 → target=400.
+      const pane = makePane(1000, 200, 600);
+      const overview = mountWithMarkers(pane, [10, 50, 90]);
+      const ev = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+      Object.defineProperty(ev, 'currentTarget', { value: overview });
+
+      (el as any).onOverviewKeydown(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 400 })
+      );
+    });
+
+    it('Enter cycles to the first marker when past the last', () => {
+      // scrollTop=900 → centre=1000. No marker > 1001, cycle to 100 → target=0.
+      const pane = makePane(1000, 200, 900);
+      const overview = mountWithMarkers(pane, [10, 50, 90]);
+      const ev = new KeyboardEvent('keydown', { key: 'Enter' });
+      Object.defineProperty(ev, 'currentTarget', { value: overview });
+
+      (el as any).onOverviewKeydown(ev);
+
+      expect(pane.scrollTo).toHaveBeenCalledWith(
+        expect.objectContaining({ top: 0 })
+      );
+    });
+
+    it('ignores keys other than navigation keys', () => {
+      const pane = makePane(1000, 200, 0);
+      const overview = mountWithMarkers(pane, [10, 50, 90]);
+      const ev = new KeyboardEvent('keydown', { key: 'a' });
+      Object.defineProperty(ev, 'currentTarget', { value: overview });
+
+      (el as any).onOverviewKeydown(ev);
+
+      expect(pane.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there are no markers', () => {
+      const pane = makePane(1000, 200, 0);
+      const overview = mountWithMarkers(pane, []);
+      const ev = new KeyboardEvent('keydown', { key: 'Enter' });
+      Object.defineProperty(ev, 'currentTarget', { value: overview });
+
+      (el as any).onOverviewKeydown(ev);
+
+      expect(pane.scrollTo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/dorc-web/src/pages/page-projects-audit.ts
+++ b/src/dorc-web/src/pages/page-projects-audit.ts
@@ -217,6 +217,10 @@ export class PageProjectsAudit extends PageElement {
         cursor: pointer;
         overflow: hidden;
       }
+      .diff-overview:focus-visible {
+        outline: 2px solid var(--dorc-link-color);
+        outline-offset: -2px;
+      }
       .diff-overview-marker {
         position: absolute;
         left: 1px;
@@ -648,8 +652,12 @@ export class PageProjectsAudit extends PageElement {
             </div>
             <div
               class="diff-overview"
-              title="${markers.length} changed row${markers.length === 1 ? '' : 's'} · click to jump"
+              role="button"
+              tabindex="0"
+              aria-label="Diff overview, ${markers.length} changed row${markers.length === 1 ? '' : 's'}. Press Enter or Down Arrow to jump to the next change, Up Arrow for previous."
+              title="${markers.length} changed row${markers.length === 1 ? '' : 's'} · click or press Enter to jump"
               @click="${this.onOverviewClick}"
+              @keydown="${this.onOverviewKeydown}"
             >
               ${markerEls}
               <div class="diff-overview-viewport"></div>
@@ -706,6 +714,59 @@ export class PageProjectsAudit extends PageElement {
     const target = ratio * pane.scrollHeight - pane.clientHeight / 2;
     pane.scrollTo({
       top: Math.max(0, Math.min(target, pane.scrollHeight - pane.clientHeight)),
+      behavior: 'smooth'
+    });
+  };
+
+  // Keyboard equivalent of clicking the ruler: cycles through the change
+  // markers so the ruler remains usable without a mouse. Enter/Space/Down
+  // jump to the next change, Up jumps to the previous, Home/End to the
+  // first/last. Marker pixel positions are derived from the rendered
+  // marker DOM (style.top is set as a percentage of pane.scrollHeight).
+  private onOverviewKeydown = (e: KeyboardEvent) => {
+    const key = e.key;
+    if (
+      key !== 'Enter' &&
+      key !== ' ' &&
+      key !== 'ArrowDown' &&
+      key !== 'ArrowUp' &&
+      key !== 'Home' &&
+      key !== 'End'
+    ) {
+      return;
+    }
+    e.preventDefault();
+    const overview = e.currentTarget as HTMLElement;
+    const pane = overview.parentElement?.querySelector(
+      '.diff-pane-scroll'
+    ) as HTMLElement | null;
+    if (!pane) return;
+    const markers = Array.from(
+      overview.querySelectorAll<HTMLElement>('.diff-overview-marker')
+    );
+    if (markers.length === 0) return;
+
+    const positions = markers
+      .map(m => (parseFloat(m.style.top) / 100) * pane.scrollHeight)
+      .sort((a, b) => a - b);
+
+    const viewCenter = pane.scrollTop + pane.clientHeight / 2;
+    let target: number;
+    if (key === 'Home') {
+      target = positions[0];
+    } else if (key === 'End') {
+      target = positions[positions.length - 1];
+    } else if (key === 'ArrowUp') {
+      const prev = [...positions].reverse().find(p => p < viewCenter - 1);
+      target = prev ?? positions[positions.length - 1];
+    } else {
+      // Enter, Space, ArrowDown — next change, cycling at the end.
+      const next = positions.find(p => p > viewCenter + 1);
+      target = next ?? positions[0];
+    }
+    const top = target - pane.clientHeight / 2;
+    pane.scrollTo({
+      top: Math.max(0, Math.min(top, pane.scrollHeight - pane.clientHeight)),
       behavior: 'smooth'
     });
   };

--- a/src/dorc-web/src/pages/page-projects-audit.ts
+++ b/src/dorc-web/src/pages/page-projects-audit.ts
@@ -710,7 +710,12 @@ export class PageProjectsAudit extends PageElement {
     ) as HTMLElement | null;
     if (!pane) return;
     const rect = overview.getBoundingClientRect();
-    const ratio = (e.clientY - rect.top) / rect.height;
+    // Bail on a degenerate (collapsed) ruler — dividing by 0 would taint the
+    // scrollTo target with NaN/Infinity.
+    if (rect.height <= 0) return;
+    // Clamp into [0, 1] so a clientY outside the ruler (synthetic events,
+    // racy resize) still produces a sensible target.
+    const ratio = Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height));
     const target = ratio * pane.scrollHeight - pane.clientHeight / 2;
     pane.scrollTo({
       top: Math.max(0, Math.min(target, pane.scrollHeight - pane.clientHeight)),

--- a/src/dorc-web/src/pages/page-projects-audit.ts
+++ b/src/dorc-web/src/pages/page-projects-audit.ts
@@ -191,9 +191,57 @@ export class PageProjectsAudit extends PageElement {
       .diff-header > div.right {
         border-right: none;
       }
-      .diff-pane-scroll {
+      /* Wrapper around the scrollable diff and the overview ruler. The
+         max-height moves here so both children share the same vertical box
+         and the ruler can position markers as a percentage of total content. */
+      .diff-viewport {
+        display: flex;
+        position: relative;
         max-height: 60vh;
+      }
+      .diff-pane-scroll {
+        flex: 1 1 auto;
+        min-width: 0;
         overflow: auto;
+      }
+      /* Scroll overview ruler: a thin column to the right of the scroll pane
+         showing every changed row as a coloured tick at its proportional
+         vertical position, with a translucent box marking the visible
+         viewport. Clicking jumps the diff to that point. */
+      .diff-overview {
+        position: relative;
+        flex: 0 0 12px;
+        width: 12px;
+        background: var(--dorc-bg-secondary);
+        border-left: 1px solid var(--dorc-border-color);
+        cursor: pointer;
+        overflow: hidden;
+      }
+      .diff-overview-marker {
+        position: absolute;
+        left: 1px;
+        right: 1px;
+        min-height: 2px;
+        border-radius: 1px;
+        pointer-events: none;
+      }
+      .diff-overview-marker.marker-add {
+        background-color: var(--dorc-success-color, #4caf50);
+      }
+      .diff-overview-marker.marker-remove {
+        background-color: var(--dorc-error-color);
+      }
+      .diff-overview-marker.marker-change {
+        background-color: var(--dorc-link-color);
+      }
+      .diff-overview-viewport {
+        position: absolute;
+        left: 0;
+        right: 0;
+        background: color-mix(in srgb, var(--dorc-text-secondary) 18%, transparent);
+        border-top: 1px solid color-mix(in srgb, var(--dorc-text-secondary) 45%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--dorc-text-secondary) 45%, transparent);
+        pointer-events: none;
       }
       vaadin-icon.chevron {
         cursor: pointer;
@@ -539,7 +587,15 @@ export class PageProjectsAudit extends PageElement {
     const ops = this.computeLineDiff(prev, curr);
     const rows = this.buildSideBySide(ops);
     const cells: unknown[] = [];
-    for (const r of rows) {
+    // Markers are emitted in row order so the overview ruler can render each
+    // change at its proportional vertical position (idx / totalRows). Keep
+    // rows produce no marker.
+    const markers: { idx: number; cls: string }[] = [];
+    rows.forEach((r, idx) => {
+      if (r.kind === 'change') markers.push({ idx, cls: 'marker-change' });
+      else if (r.kind === 'insert') markers.push({ idx, cls: 'marker-add' });
+      else if (r.kind === 'delete') markers.push({ idx, cls: 'marker-remove' });
+
       // Pure insert/delete lines: tint the whole cell — there's no paired
       // counterpart to diff against, so the entire line is what changed.
       // 'change' rows (a delete paired with an insert) get character-level
@@ -567,7 +623,18 @@ export class PageProjectsAudit extends PageElement {
         cells.push(html`<div class="${leftCls}">${r.left ?? ''}</div>`);
         cells.push(html`<div class="${rightCls}">${r.right ?? ''}</div>`);
       }
-    }
+    });
+
+    const totalRows = rows.length;
+    const markerEls = markers.map(m => {
+      const top = (m.idx / totalRows) * 100;
+      const height = (1 / totalRows) * 100;
+      return html`<div
+        class="diff-overview-marker ${m.cls}"
+        style="top: ${top}%; height: ${height}%;"
+      ></div>`;
+    });
+
     render(
       html`
         <div class="details-pane">
@@ -575,13 +642,72 @@ export class PageProjectsAudit extends PageElement {
             <div>Before</div>
             <div class="right">After</div>
           </div>
-          <div class="diff-pane-scroll">
-            <div class="diff-grid">${cells}</div>
+          <div class="diff-viewport">
+            <div class="diff-pane-scroll" @scroll="${this.onDiffScroll}">
+              <div class="diff-grid">${cells}</div>
+            </div>
+            <div
+              class="diff-overview"
+              title="${markers.length} changed row${markers.length === 1 ? '' : 's'} · click to jump"
+              @click="${this.onOverviewClick}"
+            >
+              ${markerEls}
+              <div class="diff-overview-viewport"></div>
+            </div>
           </div>
         </div>
       `,
       root
     );
+
+    // Layout isn't measured until the next frame, so defer the initial
+    // viewport-indicator sizing until then.
+    requestAnimationFrame(() => {
+      const pane = root.querySelector('.diff-pane-scroll') as HTMLElement | null;
+      const viewport = root.querySelector('.diff-overview-viewport') as HTMLElement | null;
+      if (pane && viewport) this.updateOverviewViewport(pane, viewport);
+    });
+  };
+
+  // Sync the translucent viewport box on the overview ruler with the diff
+  // pane's current scroll position. Hidden when content fits without
+  // scrolling so the ruler doesn't suggest a scroll that isn't possible.
+  private updateOverviewViewport(pane: HTMLElement, viewport: HTMLElement) {
+    if (pane.scrollHeight <= pane.clientHeight) {
+      viewport.style.display = 'none';
+      return;
+    }
+    viewport.style.display = '';
+    const top = (pane.scrollTop / pane.scrollHeight) * 100;
+    const height = (pane.clientHeight / pane.scrollHeight) * 100;
+    viewport.style.top = `${top}%`;
+    viewport.style.height = `${height}%`;
+  }
+
+  private onDiffScroll = (e: Event) => {
+    const pane = e.currentTarget as HTMLElement;
+    const viewport = pane.parentElement?.querySelector(
+      '.diff-overview-viewport'
+    ) as HTMLElement | null;
+    if (viewport) this.updateOverviewViewport(pane, viewport);
+  };
+
+  // Click anywhere on the overview ruler to centre the diff scroll on that
+  // proportional point — the same interaction model as VS Code's overview
+  // ruler / GitHub's diff minimap.
+  private onOverviewClick = (e: MouseEvent) => {
+    const overview = e.currentTarget as HTMLElement;
+    const pane = overview.parentElement?.querySelector(
+      '.diff-pane-scroll'
+    ) as HTMLElement | null;
+    if (!pane) return;
+    const rect = overview.getBoundingClientRect();
+    const ratio = (e.clientY - rect.top) / rect.height;
+    const target = ratio * pane.scrollHeight - pane.clientHeight / 2;
+    pane.scrollTo({
+      top: Math.max(0, Math.min(target, pane.scrollHeight - pane.clientHeight)),
+      behavior: 'smooth'
+    });
   };
 
   // Convert the line-LCS ops into a side-by-side row stream. Within each run


### PR DESCRIPTION
The expanded diff in the Project Audit page can run hundreds of lines, but
only a handful are usually changes. Without a positional cue, the user has
to scroll the whole way to find each change.

Add a 12px overview column to the right of the diff scroll pane that ticks
every changed row at its proportional position (green/red/blue for
insert/delete/change), with a translucent box marking the visible
viewport. Clicking the ruler centres the diff on that point, matching the
overview-ruler pattern used by VS Code and GitHub diffs.