### PR TITLE
S-002: Dorc.Api.WindowsWorker scaffold + loopback host + shared-secret auth

### DIFF
--- a/docs/api-split/SPEC-S-002-worker-scaffold.md
+++ b/docs/api-split/SPEC-S-002-worker-scaffold.md
@@ -1,0 +1,115 @@
+---
+name: SPEC-S-002 — Windows worker project scaffold + loopback host + shared-secret auth
+description: JIT Specification for S-002 — creates the Dorc.Api.WindowsWorker project with a 127.0.0.1-only Kestrel host, X-Worker-Key authentication scheme, FromPrimary authorization policy, /health endpoint, and unit tests covering the auth scheme. No Windows operations yet.
+type: spec
+status: APPROVED
+---
+
+# SPEC-S-002 — `Dorc.Api.WindowsWorker` project scaffold
+
+| Field       | Value                                              |
+|-------------|----------------------------------------------------|
+| **Status**  | APPROVED (auto-pilot per user direction)           |
+| **Step**    | S-002                                              |
+| **Author**  | Agent                                              |
+| **Date**    | 2026-05-28                                         |
+| **IS**      | [IS-api-split.md](IS-api-split.md) (APPROVED)      |
+| **HLPS**    | [HLPS-api-split.md](HLPS-api-split.md) (APPROVED)  |
+
+---
+
+## 1. Context
+
+S-002 is the worker-scaffold step: a new ASP.NET Core project with the host, auth scheme, and health endpoint in place, ready for S-004/S-005/S-006 to add Windows-only controllers. The worker is intentionally endpoint-empty for actual Windows operations.
+
+Per HLPS D-1, the worker is a separate Windows-only process bound to `127.0.0.1` only. Per HLPS D-3, requests are authenticated via a shared-secret header `X-Worker-Key`; missing or wrong header returns `401` with `{"error":"worker_key_invalid"}`. Authorization decisions are made in the primary; the worker trusts that any call reaching it has already been authz'd.
+
+This step resolves HLPS U-4 (project name): the project is named `Dorc.Api.WindowsWorker` for specificity.
+
+## 2. Production code change
+
+### 2.1 Project file `src/Dorc.Api.WindowsWorker/Dorc.Api.WindowsWorker.csproj`
+
+- `Microsoft.NET.Sdk.Web` SDK.
+- TargetFramework: `net8.0-windows` (Windows-only, matching HLPS Scope B).
+- Nullable enabled.
+- Project references: `Dorc.Core`, `Dorc.ApiModel`. (No reference to `Dorc.Api`. The two run as separate processes.)
+- Package references: only what's needed for the host + auth scheme (`Swashbuckle.AspNetCore` deferred to later — no public API surface yet).
+
+### 2.2 `Program.cs` — worker host
+
+- `WebApplication.CreateBuilder(args)`.
+- Kestrel configured to listen on `127.0.0.1` only, port read from `WindowsWorker:Port` config (default 5005).
+- DI: `IConfiguration`, logging, the `WorkerKey` authentication scheme (see 2.3), the `FromPrimary` authorization policy (see 2.4).
+- `MapHealthChecks("/health")` returns 200 with body `Healthy` — does **not** require the `FromPrimary` policy (the primary may poll without the key to detect process liveness; the loopback bind is the security control).
+- Controllers (none in this step) gain `[Authorize(Policy = "FromPrimary")]` via convention or per-class attribute. For S-002 we add convention-based `RequireAuthorization(...)` only on controller routes.
+
+### 2.3 Authentication scheme `WorkerKey`
+
+`src/Dorc.Api.WindowsWorker/Authentication/WorkerKeyAuthenticationHandler.cs`:
+
+- `AuthenticationHandler<WorkerKeyAuthenticationOptions>`.
+- Reads `Request.Headers["X-Worker-Key"]`. Missing header → `AuthenticateResult.NoResult()` (so the authorization layer can emit a clean 401 with the documented body).
+- Compares (constant-time, via `CryptographicOperations.FixedTimeEquals` on UTF-8 bytes) the incoming key against `WindowsWorker:SharedKey` from configuration. Mismatch → `AuthenticateResult.Fail("worker_key_invalid")`.
+- On success: emits a `ClaimsPrincipal` with a single claim `"WorkerCaller"="primary"` so endpoints can `[Authorize(Policy = "FromPrimary")]` and reach `User.Identity.IsAuthenticated == true`.
+- On failure: a custom `OnChallenge` handler writes `{"error":"worker_key_invalid"}` JSON to the response body alongside the 401.
+
+`src/Dorc.Api.WindowsWorker/Authentication/WorkerKeyAuthenticationOptions.cs`:
+- Empty options class extending `AuthenticationSchemeOptions`. Reserved for future expansion (e.g. per-route policy data).
+
+### 2.4 Authorization policy `FromPrimary`
+
+In `Program.cs`:
+```
+services.AddAuthorization(opt =>
+    opt.AddPolicy("FromPrimary", p =>
+        p.AddAuthenticationSchemes("WorkerKey").RequireAuthenticatedUser()));
+```
+
+### 2.5 `appsettings.json`
+
+```
+{
+  "WindowsWorker": {
+    "Port": 5005,
+    "SharedKey": ""   // populated at install time per S-008
+  },
+  "Logging": { ... default minimal ... }
+}
+```
+
+`appsettings.Development.json` is **not** added — the worker is not run in Development mode against fake data; tests cover the auth path directly.
+
+### 2.6 Solution wiring
+
+Add the project to `src/Dorc.sln`. Two `Project(...)` / `EndProject` blocks plus the standard `GlobalSection` configuration rows for Debug|Any CPU and Release|Any CPU.
+
+## 3. Test plan
+
+`src/Dorc.Api.WindowsWorker.Tests/Dorc.Api.WindowsWorker.Tests.csproj`:
+- MSTest + `Microsoft.AspNetCore.Mvc.Testing` (for `WebApplicationFactory<Program>`).
+- Reference `Dorc.Api.WindowsWorker`.
+
+`WorkerKeyAuthenticationTests.cs`:
+- `Health_NoHeader_Returns200` — `/health` doesn't require the policy.
+- `Health_AnyHeader_Returns200` — same (health always open).
+- `Protected_NoHeader_Returns401` — using a test controller registered in a per-test factory, asserts 401 + body `{"error":"worker_key_invalid"}` when no header is sent.
+- `Protected_WrongHeader_Returns401_SameBody` — same 401 + body on mismatched key.
+- `Protected_CorrectHeader_Returns200` — confirms a request with the right key passes the policy.
+- `Loopback_Only_NonLocalAccess` — defer to integration / smoke testing in S-010; documented as out of scope here.
+
+The "test controller" used by the auth tests is added as an internal `[ApiController]` exposed only to the test assembly via `InternalsVisibleTo`. This isolates the auth-scheme test from any real Windows endpoint (which arrive in later S-steps).
+
+## 4. Verification
+
+- `dotnet build src/Dorc.Api.WindowsWorker/Dorc.Api.WindowsWorker.csproj` succeeds (Windows-only — pipeline runs on `windows-latest`).
+- `dotnet test src/Dorc.Api.WindowsWorker.Tests/` — all five auth tests pass.
+- The new project appears in `src/Dorc.sln` and the Windows CI workflow's solution-level build picks it up.
+
+## 5. Out of scope
+
+- Any Windows-only controllers (S-004 / S-005 / S-006).
+- MSI installer wiring (S-008).
+- `IWindowsWorkerClient` on the primary side (S-003).
+- Health-check that actually probes Windows operations (S-005 may add).
+- Documentation of customer-facing config (S-010).

--- a/src/Dorc.Api.WindowsWorker.Tests/Dorc.Api.WindowsWorker.Tests.csproj
+++ b/src/Dorc.Api.WindowsWorker.Tests/Dorc.Api.WindowsWorker.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dorc.Api.WindowsWorker\Dorc.Api.WindowsWorker.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dorc.Api.WindowsWorker.Tests/WorkerKeyAuthenticationTests.cs
+++ b/src/Dorc.Api.WindowsWorker.Tests/WorkerKeyAuthenticationTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Text;
+using System.Text.Encodings.Web;
+using Dorc.Api.WindowsWorker.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Dorc.Api.WindowsWorker.Tests
+{
+    // Two layers of coverage:
+    //   1. Handler-level unit tests (instantiate the handler directly with a
+    //      DefaultHttpContext and a stub IConfiguration). These exercise the actual
+    //      auth logic — header parsing, constant-time comparison, success/failure
+    //      ticket shapes, and the 401 body emitted by HandleChallengeAsync.
+    //   2. Host-level smoke tests against /health via WebApplicationFactory.
+    //      Confirms the worker binds, the unauthenticated /health endpoint is
+    //      reachable, and the auth scheme registration doesn't break startup.
+    //
+    // Full-pipeline coverage of protected controllers will come in S-004/S-005/S-006
+    // when those endpoints are added.
+    [TestClass]
+    public class WorkerKeyAuthenticationTests
+    {
+        private const string TestSharedKey = "test-shared-key-1234567890ABCDEF";
+
+        // -------------------- Handler-level unit tests --------------------
+
+        [TestMethod]
+        public async Task Handler_NoHeader_NoResult_ThenChallengeWritesDocumentedBody()
+        {
+            var handler = await NewHandler(configuredKey: TestSharedKey, withHeader: null);
+
+            var auth = await handler.AuthenticateAsync();
+            Assert.IsFalse(auth.Succeeded);
+            Assert.IsNull(auth.Failure, "missing header should be NoResult, not Fail");
+
+            await handler.ChallengeAsync(new AuthenticationProperties());
+
+            var (status, body) = ReadResponse(handler);
+            Assert.AreEqual(StatusCodes.Status401Unauthorized, status);
+            Assert.AreEqual("{\"error\":\"worker_key_invalid\"}", body);
+        }
+
+        [TestMethod]
+        public async Task Handler_WrongKey_FailsThenChallengeWritesDocumentedBody()
+        {
+            var handler = await NewHandler(configuredKey: TestSharedKey, withHeader: "nope-wrong-key");
+
+            var auth = await handler.AuthenticateAsync();
+            Assert.IsFalse(auth.Succeeded);
+            Assert.IsNotNull(auth.Failure);
+            StringAssert.Contains(auth.Failure!.Message, "worker_key_invalid");
+
+            await handler.ChallengeAsync(new AuthenticationProperties());
+
+            var (status, body) = ReadResponse(handler);
+            Assert.AreEqual(StatusCodes.Status401Unauthorized, status);
+            Assert.AreEqual("{\"error\":\"worker_key_invalid\"}", body);
+        }
+
+        [TestMethod]
+        public async Task Handler_DifferentLengthKey_Fails()
+        {
+            // FixedTimeEquals requires equal length — the constant-time check is
+            // bypassed for mismatched lengths but must still reject.
+            var handler = await NewHandler(configuredKey: TestSharedKey, withHeader: "short");
+
+            var auth = await handler.AuthenticateAsync();
+            Assert.IsFalse(auth.Succeeded);
+            Assert.IsNotNull(auth.Failure);
+        }
+
+        [TestMethod]
+        public async Task Handler_CorrectKey_Succeeds_WithCallerClaim()
+        {
+            var handler = await NewHandler(configuredKey: TestSharedKey, withHeader: TestSharedKey);
+
+            var auth = await handler.AuthenticateAsync();
+            Assert.IsTrue(auth.Succeeded);
+            Assert.IsNotNull(auth.Principal);
+            Assert.IsTrue(auth.Principal!.HasClaim(
+                WorkerKeyAuthenticationHandler.CallerClaimType,
+                WorkerKeyAuthenticationHandler.CallerClaimValue));
+            Assert.AreEqual(WorkerKeyAuthenticationOptions.SchemeName, auth.Ticket!.AuthenticationScheme);
+        }
+
+        [TestMethod]
+        public async Task Handler_NoConfiguredSecret_FailsClosed()
+        {
+            // If the host is misconfigured (empty SharedKey), even matching a header
+            // value must fail. Fail-closed is the correct behaviour.
+            var handler = await NewHandler(configuredKey: null, withHeader: "anything");
+
+            var auth = await handler.AuthenticateAsync();
+            Assert.IsFalse(auth.Succeeded);
+            Assert.IsNotNull(auth.Failure);
+        }
+
+        // -------------------- Host smoke tests --------------------
+
+        [TestMethod]
+        public async Task Health_NoHeader_Returns200()
+        {
+            using var factory = NewFactory();
+            using var client = factory.CreateClient();
+
+            var resp = await client.GetAsync("/health");
+            Assert.AreEqual(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task Health_AnyHeader_Returns200()
+        {
+            using var factory = NewFactory();
+            using var client = factory.CreateClient();
+            client.DefaultRequestHeaders.Add(WorkerKeyAuthenticationOptions.HeaderName, "anything");
+
+            var resp = await client.GetAsync("/health");
+            Assert.AreEqual(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        // ---------- Helpers ----------
+
+        private static async Task<WorkerKeyAuthenticationHandler> NewHandler(string? configuredKey, string? withHeader)
+        {
+            var configDict = new Dictionary<string, string?>();
+            if (configuredKey != null) configDict["WindowsWorker:SharedKey"] = configuredKey;
+            var config = new ConfigurationBuilder().AddInMemoryCollection(configDict).Build();
+
+            var options = Options.Create(new WorkerKeyAuthenticationOptions());
+            var optionsMonitor = new TestOptionsMonitor<WorkerKeyAuthenticationOptions>(options.Value);
+
+            var handler = new WorkerKeyAuthenticationHandler(
+                optionsMonitor,
+                NullLoggerFactory.Instance,
+                UrlEncoder.Default,
+                config);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Response.Body = new MemoryStream();
+            if (withHeader != null)
+            {
+                httpContext.Request.Headers[WorkerKeyAuthenticationOptions.HeaderName] = withHeader;
+            }
+
+            var scheme = new AuthenticationScheme(
+                WorkerKeyAuthenticationOptions.SchemeName,
+                WorkerKeyAuthenticationOptions.SchemeName,
+                typeof(WorkerKeyAuthenticationHandler));
+            await handler.InitializeAsync(scheme, httpContext);
+            return handler;
+        }
+
+        private static (int status, string body) ReadResponse(WorkerKeyAuthenticationHandler handler)
+        {
+            // Pull the captured response from the handler's HttpContext via reflection
+            // on its `Context` property (protected). Cleaner than re-routing the stream.
+            var context = (HttpContext)handler.GetType()
+                .GetProperty("Context", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)!
+                .GetValue(handler)!;
+
+            context.Response.Body.Position = 0;
+            using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+            return (context.Response.StatusCode, reader.ReadToEnd());
+        }
+
+        private static WorkerWebAppFactory NewFactory() => new();
+
+        private sealed class WorkerWebAppFactory : WebApplicationFactory<Program>
+        {
+            protected override IHost CreateHost(IHostBuilder builder)
+            {
+                builder.ConfigureHostConfiguration(cfg =>
+                {
+                    cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["WindowsWorker:SharedKey"] = TestSharedKey,
+                    });
+                });
+                return base.CreateHost(builder);
+            }
+        }
+
+        private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T> where T : class
+        {
+            private readonly T _value;
+            public TestOptionsMonitor(T value) { _value = value; }
+            public T CurrentValue => _value;
+            public T Get(string? name) => _value;
+            public IDisposable? OnChange(Action<T, string?> listener) => null;
+        }
+    }
+}

--- a/src/Dorc.Api.WindowsWorker/Authentication/WorkerKeyAuthenticationHandler.cs
+++ b/src/Dorc.Api.WindowsWorker/Authentication/WorkerKeyAuthenticationHandler.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Dorc.Api.WindowsWorker.Authentication
+{
+    // X-Worker-Key authentication. Per HLPS-api-split D-3:
+    // - The worker binds loopback-only, so the in-scope adversary is a co-located process.
+    // - The shared secret is a defence-in-depth check, validated in constant time.
+    // - Missing OR wrong header => 401 with body {"error":"worker_key_invalid"}.
+    public class WorkerKeyAuthenticationHandler : AuthenticationHandler<WorkerKeyAuthenticationOptions>
+    {
+        public const string CallerClaimType = "WorkerCaller";
+        public const string CallerClaimValue = "primary";
+
+        private readonly string? _configuredKey;
+
+        public WorkerKeyAuthenticationHandler(
+            IOptionsMonitor<WorkerKeyAuthenticationOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            IConfiguration configuration)
+            : base(options, logger, encoder)
+        {
+            _configuredKey = configuration["WindowsWorker:SharedKey"];
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(WorkerKeyAuthenticationOptions.HeaderName, out var header) || header.Count == 0)
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            if (string.IsNullOrEmpty(_configuredKey))
+            {
+                // Configuration missing the secret entirely — fail closed.
+                return Task.FromResult(AuthenticateResult.Fail("worker_key_invalid"));
+            }
+
+            var incoming = header.ToString();
+            var incomingBytes = Encoding.UTF8.GetBytes(incoming);
+            var expectedBytes = Encoding.UTF8.GetBytes(_configuredKey);
+
+            if (incomingBytes.Length != expectedBytes.Length ||
+                !CryptographicOperations.FixedTimeEquals(incomingBytes, expectedBytes))
+            {
+                return Task.FromResult(AuthenticateResult.Fail("worker_key_invalid"));
+            }
+
+            var identity = new ClaimsIdentity(
+                new[] { new Claim(CallerClaimType, CallerClaimValue) },
+                WorkerKeyAuthenticationOptions.SchemeName);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, WorkerKeyAuthenticationOptions.SchemeName);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+
+        protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
+        {
+            Response.StatusCode = StatusCodes.Status401Unauthorized;
+            Response.ContentType = "application/json";
+            await Response.WriteAsync("{\"error\":\"worker_key_invalid\"}");
+        }
+    }
+}

--- a/src/Dorc.Api.WindowsWorker/Authentication/WorkerKeyAuthenticationOptions.cs
+++ b/src/Dorc.Api.WindowsWorker/Authentication/WorkerKeyAuthenticationOptions.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace Dorc.Api.WindowsWorker.Authentication
+{
+    // Scheme constants and options for the X-Worker-Key authentication scheme.
+    // Reserved as a class (rather than just a constants holder) so future per-route
+    // options can be added without changing the registration site.
+    public class WorkerKeyAuthenticationOptions : AuthenticationSchemeOptions
+    {
+        public const string SchemeName = "WorkerKey";
+        public const string HeaderName = "X-Worker-Key";
+    }
+}

--- a/src/Dorc.Api.WindowsWorker/Dorc.Api.WindowsWorker.csproj
+++ b/src/Dorc.Api.WindowsWorker/Dorc.Api.WindowsWorker.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dorc-api-windowsworker</UserSecretsId>
+    <RootNamespace>Dorc.Api.WindowsWorker</RootNamespace>
+    <AssemblyName>Dorc.Api.WindowsWorker</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dorc.Core\Dorc.Core.csproj" />
+    <ProjectReference Include="..\Dorc.ApiModel\Dorc.ApiModel.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Dorc.Api.WindowsWorker.Tests" />
+  </ItemGroup>
+</Project>

--- a/src/Dorc.Api.WindowsWorker/Program.cs
+++ b/src/Dorc.Api.WindowsWorker/Program.cs
@@ -1,0 +1,43 @@
+using Dorc.Api.WindowsWorker;
+using Dorc.Api.WindowsWorker.Authentication;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var port = builder.Configuration.GetValue<int?>("WindowsWorker:Port") ?? 5005;
+builder.WebHost.ConfigureKestrel(opts =>
+{
+    // Loopback-only bind — the security boundary in HLPS D-3's threat model.
+    opts.Listen(System.Net.IPAddress.Loopback, port);
+});
+
+builder.Services.AddControllers();
+builder.Services.AddHealthChecks();
+
+builder.Services
+    .AddAuthentication(WorkerKeyAuthenticationOptions.SchemeName)
+    .AddScheme<WorkerKeyAuthenticationOptions, WorkerKeyAuthenticationHandler>(
+        WorkerKeyAuthenticationOptions.SchemeName, _ => { });
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy(WorkerKeyAuthorizationPolicies.FromPrimary, policy =>
+    {
+        policy.AddAuthenticationSchemes(WorkerKeyAuthenticationOptions.SchemeName);
+        policy.RequireAuthenticatedUser();
+    });
+});
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+// Health is intentionally unauthenticated — the primary uses it to detect liveness,
+// and the loopback bind already prevents off-host access.
+app.MapHealthChecks("/health");
+app.MapControllers().RequireAuthorization(WorkerKeyAuthorizationPolicies.FromPrimary);
+
+app.Run();
+
+// Exposed as partial so WebApplicationFactory<Program> in the test project can find it.
+public partial class Program { }

--- a/src/Dorc.Api.WindowsWorker/WorkerKeyAuthorizationPolicies.cs
+++ b/src/Dorc.Api.WindowsWorker/WorkerKeyAuthorizationPolicies.cs
@@ -1,0 +1,7 @@
+namespace Dorc.Api.WindowsWorker
+{
+    public static class WorkerKeyAuthorizationPolicies
+    {
+        public const string FromPrimary = "FromPrimary";
+    }
+}

--- a/src/Dorc.Api.WindowsWorker/appsettings.json
+++ b/src/Dorc.Api.WindowsWorker/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "WindowsWorker": {
+    "Port": 5005,
+    "SharedKey": ""
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Dorc.sln
+++ b/src/Dorc.sln
@@ -93,6 +93,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dorc.Kafka.Lock.HATests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tools.RequestCLI.Tests", "Tools.RequestCLI.Tests\Tools.RequestCLI.Tests.csproj", "{D56A1C72-344F-4F1B-8BD0-4023DBB0C48E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dorc.Api.WindowsWorker", "Dorc.Api.WindowsWorker\Dorc.Api.WindowsWorker.csproj", "{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dorc.Api.WindowsWorker.Tests", "Dorc.Api.WindowsWorker.Tests\Dorc.Api.WindowsWorker.Tests.csproj", "{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -721,6 +725,38 @@ Global
 		{D56A1C72-344F-4F1B-8BD0-4023DBB0C48E}.Release|x64.Build.0 = Release|Any CPU
 		{D56A1C72-344F-4F1B-8BD0-4023DBB0C48E}.Release|x86.ActiveCfg = Release|Any CPU
 		{D56A1C72-344F-4F1B-8BD0-4023DBB0C48E}.Release|x86.Build.0 = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|ARM64.Build.0 = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|x64.Build.0 = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{5AF34CE0-6DCF-4929-B267-C970D94F6C8E}.Release|x86.Build.0 = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|x64.Build.0 = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Debug|x86.Build.0 = Debug|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|ARM64.Build.0 = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|x64.ActiveCfg = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|x64.Build.0 = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|x86.ActiveCfg = Release|Any CPU
+		{85C1087E-DCE2-4CB9-8938-1A2E60C9DB16}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

- IS step S-002 from the [API split work](https://github.com/sefe/dorc/pull/706). Creates the empty Windows worker project — endpoint-empty for Windows operations; S-004 / S-005 / S-006 add the controllers.
- New project `src/Dorc.Api.WindowsWorker` (`net8.0-windows`, `Microsoft.NET.Sdk.Web`). Kestrel binds 127.0.0.1 only (HLPS D-1).
- `WorkerKey` authentication scheme reads `X-Worker-Key` header, validates constant-time vs `WindowsWorker:SharedKey`. Missing/wrong → `401` + body `{"error":"worker_key_invalid"}` (HLPS D-3).
- `FromPrimary` authorization policy gates controller routes; `/health` is intentionally unauthenticated (loopback bind is the security boundary).
- Independent of PR #706 per IS multi-PR plan.

## Test plan

- [x] `Dorc.Api.WindowsWorker.Tests`: 7 / 7 pass (5 handler unit tests + 2 host smoke tests on `/health`)
- [x] Worker project + test project build on Windows
- [x] Both projects added to `src/Dorc.sln`
- [ ] Full-pipeline coverage of protected controllers will land in S-004/S-005/S-006 when the actual Windows endpoints are added
- [ ] Worker is intentionally NOT yet built on Linux (TargetFramework `net8.0-windows`); the Linux build CI gate from S-001 only checks the primary's compile graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)