### PR TITLE
S-003: IWindowsWorkerClient contract + null-impl + worker-absence detection

### DIFF
--- a/docs/api-split/SPEC-S-003-worker-client.md
+++ b/docs/api-split/SPEC-S-003-worker-client.md
@@ -1,0 +1,139 @@
+---
+name: SPEC-S-003 — IWindowsWorkerClient contract + null-impl + worker-absence detection
+description: JIT Specification for S-003 — defines IWindowsWorkerClient as the seam every later worker-move step extends, ships a typed HttpClient implementation, a null implementation for Linux installs, the WindowsWorker:Enabled config flag, and the typed-exception → 503 ExceptionFilter that turns worker-unavailable into a documented client response.
+type: spec
+status: APPROVED
+---
+
+# SPEC-S-003 — `IWindowsWorkerClient` contract + null-impl + worker-absence detection
+
+| Field       | Value                                              |
+|-------------|----------------------------------------------------|
+| **Status**  | APPROVED (auto-pilot per user direction)           |
+| **Step**    | S-003                                              |
+| **Author**  | Agent                                              |
+| **Date**    | 2026-05-28                                         |
+| **IS**      | [IS-api-split.md](IS-api-split.md) (APPROVED)      |
+| **HLPS**    | [HLPS-api-split.md](HLPS-api-split.md) (APPROVED)  |
+
+---
+
+## 1. Context
+
+S-003 establishes the abstraction every later worker-move step (S-004 / S-005 / S-006) extends. It also resolves three non-blocking unknowns from the HLPS:
+
+- **U-6** — worker URL discovery: config-file (`WindowsWorker:Url`).
+- **U-7** — contract-test strategy: shared-DTO via `Dorc.ApiModel`.
+- **U-11** — worker-absence detection: explicit `WindowsWorker:Enabled` boolean config flag; when `false`, register the null implementation.
+
+The interface starts empty — concrete methods (e.g. `ResetPasswordAsync`, `GetRemoteServerInfoAsync`, `GetServiceStatusAsync`) arrive in their respective S-step PRs. This step just lands the seam.
+
+## 2. Production code change
+
+### 2.1 `Dorc.Api/Interfaces/IWindowsWorkerClient.cs` (new)
+
+Empty marker interface — concrete methods added by later steps:
+
+```csharp
+namespace Dorc.Api.Interfaces
+{
+    // Seam for the Linux-incompatible Windows-worker calls. Concrete methods are
+    // added by later S-steps as their endpoints move (S-004 registry, S-005 WMI,
+    // S-006 password reset). Two implementations:
+    //   - HttpWindowsWorkerClient: real HTTP loopback caller (Windows installs).
+    //   - WorkerUnavailableClient: throws WorkerUnavailableException so the global
+    //     ExceptionFilter translates it to 503 (Linux installs).
+    public interface IWindowsWorkerClient { }
+}
+```
+
+### 2.2 `Dorc.Api/Services/HttpWindowsWorkerClient.cs` (new)
+
+- Takes an injected `HttpClient` (typed via `AddHttpClient<...>` in DI).
+- Constructor reads `WindowsWorker:Url` from config (used as base address).
+- A `DelegatingHandler` (registered alongside) injects the `X-Worker-Key` header on outbound calls.
+
+### 2.3 `Dorc.Api/Services/WorkerKeyDelegatingHandler.cs` (new)
+
+`DelegatingHandler` that reads `WindowsWorker:SharedKey` from `IConfiguration` and adds `X-Worker-Key` to outbound requests. Constant string, not derived from caller state.
+
+### 2.4 `Dorc.Api/Services/WorkerUnavailableClient.cs` (new)
+
+Throws `WorkerUnavailableException` from every interface method (none yet; per-method overrides added in later steps via partial class or by extending the interface).
+
+### 2.5 `Dorc.Api/Exceptions/WorkerUnavailableException.cs` (new)
+
+Typed exception carrying the endpoint name. Caught by the ExceptionFilter and translated to:
+
+```
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+{"error":"windows_worker_unavailable","endpoint":"<name>"}
+```
+
+### 2.6 `Dorc.Api/Services/WorkerUnavailableExceptionFilter.cs` (new)
+
+`IExceptionFilter` (synchronous; sufficient for this concern). Registered globally in `Program.cs`. Translates `WorkerUnavailableException` → the documented `503` body.
+
+### 2.7 DI wiring in `Program.cs`
+
+```csharp
+var workerEnabled = builder.Configuration.GetValue<bool>("WindowsWorker:Enabled");
+if (workerEnabled)
+{
+    builder.Services.AddTransient<WorkerKeyDelegatingHandler>();
+    builder.Services
+        .AddHttpClient<IWindowsWorkerClient, HttpWindowsWorkerClient>(client =>
+        {
+            var url = builder.Configuration["WindowsWorker:Url"]
+                ?? throw new InvalidOperationException("WindowsWorker:Enabled=true but WindowsWorker:Url is missing");
+            client.BaseAddress = new Uri(url);
+        })
+        .AddHttpMessageHandler<WorkerKeyDelegatingHandler>();
+}
+else
+{
+    builder.Services.AddSingleton<IWindowsWorkerClient, WorkerUnavailableClient>();
+}
+```
+
+And register the filter:
+
+```csharp
+builder.Services.AddControllers(opts => opts.Filters.Add<WorkerUnavailableExceptionFilter>());
+```
+
+### 2.8 `Dorc.Api/appsettings.json` additions
+
+```json
+"WindowsWorker": {
+  "Enabled": false,
+  "Url": "http://127.0.0.1:5005",
+  "SharedKey": ""
+}
+```
+
+`Enabled` defaults to `false` so the existing Windows-install topology continues to work unchanged at this commit (no worker process to call yet). The flag flips to `true` in S-008 when the installer provisions the worker.
+
+## 3. Test plan
+
+`src/Dorc.Api.Tests/WindowsWorkerClientTests.cs`:
+
+- `WorkerKeyDelegatingHandler_AddsHeader` — exercises the handler against a mock inner handler; asserts the outbound request carries `X-Worker-Key` with the configured value.
+- `WorkerUnavailableExceptionFilter_Translates503` — instantiates the filter, exercises against an `ExceptionContext` carrying a `WorkerUnavailableException`, asserts the `503` body shape.
+- `WorkerUnavailableClient_HasNoMethodsYet` — placeholder assertion that the type compiles and is constructable; this is the seam, not the surface.
+
+No tests against `HttpWindowsWorkerClient` itself yet — it has no methods. S-004/S-005/S-006 add per-method contract tests as they extend the interface.
+
+## 4. Verification
+
+- `dotnet build src/Dorc.Api/Dorc.Api.csproj` succeeds.
+- `dotnet test src/Dorc.Api.Tests/` — three new tests pass; no existing-test regressions.
+- On a Linux install (worker disabled): existing endpoints continue to behave identically. The new `WorkerUnavailableClient` is injected but no controller has called it yet.
+
+## 5. Out of scope
+
+- Concrete worker methods (S-004 / S-005 / S-006 add them).
+- The actual `Dorc.Api.WindowsWorker` project (S-002 — shipped separately).
+- Installer wiring (S-008).
+- Documentation (S-010).

--- a/src/Dorc.Api.Tests/WindowsWorkerClientTests.cs
+++ b/src/Dorc.Api.Tests/WindowsWorkerClientTests.cs
@@ -1,0 +1,106 @@
+using Dorc.Api.Exceptions;
+using Dorc.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+
+namespace Dorc.Api.Tests
+{
+    [TestClass]
+    public class WindowsWorkerClientTests
+    {
+        [TestMethod]
+        public async Task WorkerKeyDelegatingHandler_AddsXWorkerKeyHeader()
+        {
+            const string secret = "the-shared-secret-from-config";
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["WindowsWorker:SharedKey"] = secret })
+                .Build();
+
+            var capture = new HeaderCaptureHandler();
+            var handler = new WorkerKeyDelegatingHandler(config) { InnerHandler = capture };
+
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+            await client.GetAsync("/health");
+
+            Assert.IsNotNull(capture.LastRequest);
+            Assert.IsTrue(capture.LastRequest.Headers.TryGetValues(WorkerKeyDelegatingHandler.HeaderName, out var values));
+            CollectionAssert.AreEqual(new[] { secret }, values!.ToArray());
+        }
+
+        [TestMethod]
+        public async Task WorkerKeyDelegatingHandler_OmitsHeaderWhenSecretIsEmpty()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["WindowsWorker:SharedKey"] = "" })
+                .Build();
+
+            var capture = new HeaderCaptureHandler();
+            var handler = new WorkerKeyDelegatingHandler(config) { InnerHandler = capture };
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+
+            await client.GetAsync("/health");
+
+            Assert.IsFalse(capture.LastRequest!.Headers.Contains(WorkerKeyDelegatingHandler.HeaderName));
+        }
+
+        [TestMethod]
+        public void WorkerUnavailableExceptionFilter_Translates503_WithDocumentedBody()
+        {
+            var filter = new WorkerUnavailableExceptionFilter();
+            var context = NewExceptionContext(new WorkerUnavailableException("reset-password"));
+
+            filter.OnException(context);
+
+            Assert.IsTrue(context.ExceptionHandled);
+            var result = context.Result as ObjectResult;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(StatusCodes.Status503ServiceUnavailable, result!.StatusCode);
+
+            // Body is anonymous: {error="windows_worker_unavailable", endpoint="reset-password"}
+            var body = result.Value!.GetType();
+            Assert.AreEqual("windows_worker_unavailable", body.GetProperty("error")!.GetValue(result.Value));
+            Assert.AreEqual("reset-password", body.GetProperty("endpoint")!.GetValue(result.Value));
+        }
+
+        [TestMethod]
+        public void WorkerUnavailableExceptionFilter_IgnoresOtherExceptions()
+        {
+            var filter = new WorkerUnavailableExceptionFilter();
+            var context = NewExceptionContext(new InvalidOperationException("something else"));
+
+            filter.OnException(context);
+
+            Assert.IsFalse(context.ExceptionHandled);
+            Assert.IsNull(context.Result);
+        }
+
+        private static ExceptionContext NewExceptionContext(Exception ex)
+        {
+            var actionContext = new ActionContext(
+                new DefaultHttpContext(),
+                new RouteData(),
+                new ActionDescriptor(),
+                new ModelStateDictionary());
+            return new ExceptionContext(actionContext, new List<IFilterMetadata>())
+            {
+                Exception = ex
+            };
+        }
+
+        private sealed class HeaderCaptureHandler : DelegatingHandler
+        {
+            public HttpRequestMessage? LastRequest { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            }
+        }
+    }
+}

--- a/src/Dorc.Api/Exceptions/WorkerUnavailableException.cs
+++ b/src/Dorc.Api/Exceptions/WorkerUnavailableException.cs
@@ -1,0 +1,17 @@
+namespace Dorc.Api.Exceptions
+{
+    // Thrown by WorkerUnavailableClient to signal that a Windows-only operation was
+    // attempted on a host without the Windows worker. The global
+    // WorkerUnavailableExceptionFilter catches this and renders the documented 503
+    // body { "error": "windows_worker_unavailable", "endpoint": "<name>" }.
+    public class WorkerUnavailableException : Exception
+    {
+        public string Endpoint { get; }
+
+        public WorkerUnavailableException(string endpoint)
+            : base($"Operation '{endpoint}' requires the Windows worker, which is not available on this host.")
+        {
+            Endpoint = endpoint;
+        }
+    }
+}

--- a/src/Dorc.Api/Interfaces/IWindowsWorkerClient.cs
+++ b/src/Dorc.Api/Interfaces/IWindowsWorkerClient.cs
@@ -1,0 +1,18 @@
+namespace Dorc.Api.Interfaces
+{
+    // Seam for the Linux-incompatible Windows-worker calls. Per HLPS-api-split D-1/D-3
+    // and SPEC-S-003. Concrete methods are added by later S-steps as endpoints move:
+    //   S-004 — registry/remote-server probing
+    //   S-005 — WMI service status
+    //   S-006 — password reset impersonation
+    //
+    // Two implementations exist:
+    //   - HttpWindowsWorkerClient: real HTTP loopback caller (Windows installs;
+    //     WindowsWorker:Enabled=true).
+    //   - WorkerUnavailableClient: throws WorkerUnavailableException so the global
+    //     WorkerUnavailableExceptionFilter translates it to a documented 503 body
+    //     (Linux installs; WindowsWorker:Enabled=false).
+    public interface IWindowsWorkerClient
+    {
+    }
+}

--- a/src/Dorc.Api/Program.cs
+++ b/src/Dorc.Api/Program.cs
@@ -280,10 +280,33 @@ static void AddSwaggerGen(IServiceCollection services, IConfigurationSettings co
     });
 }
 
+// Windows-worker client (HLPS-api-split D-1/D-3, SPEC-S-003). Enabled flag controls
+// which IWindowsWorkerClient implementation is registered. On Linux installs (or any
+// install where the worker isn't deployed) the null impl throws WorkerUnavailableException
+// from every method, and WorkerUnavailableExceptionFilter renders the documented 503 body.
+var workerEnabled = builder.Configuration.GetValue<bool>("WindowsWorker:Enabled");
+if (workerEnabled)
+{
+    builder.Services.AddTransient<WorkerKeyDelegatingHandler>();
+    builder.Services
+        .AddHttpClient<IWindowsWorkerClient, HttpWindowsWorkerClient>(client =>
+        {
+            var url = builder.Configuration["WindowsWorker:Url"]
+                ?? throw new InvalidOperationException("WindowsWorker:Enabled=true but WindowsWorker:Url is missing");
+            client.BaseAddress = new Uri(url);
+        })
+        .AddHttpMessageHandler<WorkerKeyDelegatingHandler>();
+}
+else
+{
+    builder.Services.AddSingleton<IWindowsWorkerClient, WorkerUnavailableClient>();
+}
+
 builder.Services
     .AddControllers(opts =>
     {
         opts.OutputFormatters.RemoveType<StringOutputFormatter>(); // never return plain text
+        opts.Filters.Add<WorkerUnavailableExceptionFilter>();
         //opts.Filters.Add(new RequireHttpsAttribute());
     })
     .AddJsonOptions(opts =>

--- a/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
+++ b/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
@@ -1,0 +1,21 @@
+using Dorc.Api.Interfaces;
+
+namespace Dorc.Api.Services
+{
+    // Real implementation of IWindowsWorkerClient used on Windows installs with
+    // WindowsWorker:Enabled=true. Concrete worker methods are added in later
+    // S-steps (S-004 registry, S-005 WMI, S-006 password reset).
+    //
+    // The injected HttpClient is configured via AddHttpClient<...>() in Program.cs:
+    // BaseAddress is set from WindowsWorker:Url and a WorkerKeyDelegatingHandler
+    // is added so every outbound call carries the X-Worker-Key header.
+    public class HttpWindowsWorkerClient : IWindowsWorkerClient
+    {
+        private readonly HttpClient _http;
+
+        public HttpWindowsWorkerClient(HttpClient http)
+        {
+            _http = http;
+        }
+    }
+}

--- a/src/Dorc.Api/Services/WorkerKeyDelegatingHandler.cs
+++ b/src/Dorc.Api/Services/WorkerKeyDelegatingHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Dorc.Api.Services
+{
+    // DelegatingHandler that attaches the X-Worker-Key shared secret to every
+    // outbound HTTP call to the Windows worker. Constant string read from
+    // WindowsWorker:SharedKey config — never derived from caller state.
+    public class WorkerKeyDelegatingHandler : DelegatingHandler
+    {
+        public const string HeaderName = "X-Worker-Key";
+
+        private readonly string? _sharedKey;
+
+        public WorkerKeyDelegatingHandler(IConfiguration configuration)
+        {
+            _sharedKey = configuration["WindowsWorker:SharedKey"];
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(_sharedKey))
+            {
+                request.Headers.Remove(HeaderName);
+                request.Headers.Add(HeaderName, _sharedKey);
+            }
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/Dorc.Api/Services/WorkerUnavailableClient.cs
+++ b/src/Dorc.Api/Services/WorkerUnavailableClient.cs
@@ -1,0 +1,16 @@
+using Dorc.Api.Interfaces;
+
+namespace Dorc.Api.Services
+{
+    // Null implementation of IWindowsWorkerClient used on Linux installs (or any
+    // host with WindowsWorker:Enabled=false). Every method on the interface (none
+    // yet, see SPEC-S-003 §2.1) throws WorkerUnavailableException, which the
+    // WorkerUnavailableExceptionFilter translates to the documented 503 body.
+    //
+    // Later S-steps that add methods to IWindowsWorkerClient must add matching
+    // throwing overrides here. Keep the throw site name (the endpoint argument)
+    // identical to the route segment so the 503 body's `endpoint` field is useful.
+    public class WorkerUnavailableClient : IWindowsWorkerClient
+    {
+    }
+}

--- a/src/Dorc.Api/Services/WorkerUnavailableExceptionFilter.cs
+++ b/src/Dorc.Api/Services/WorkerUnavailableExceptionFilter.cs
@@ -1,0 +1,26 @@
+using Dorc.Api.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Dorc.Api.Services
+{
+    // Catches WorkerUnavailableException from any controller and renders the
+    // documented 503 body. Registered globally in Program.cs.
+    public class WorkerUnavailableExceptionFilter : IExceptionFilter
+    {
+        public void OnException(ExceptionContext context)
+        {
+            if (context.Exception is not WorkerUnavailableException ex) return;
+
+            context.Result = new ObjectResult(new
+            {
+                error = "windows_worker_unavailable",
+                endpoint = ex.Endpoint
+            })
+            {
+                StatusCode = StatusCodes.Status503ServiceUnavailable
+            };
+            context.ExceptionHandled = true;
+        }
+    }
+}

--- a/src/Dorc.Api/appsettings.json
+++ b/src/Dorc.Api/appsettings.json
@@ -136,5 +136,10 @@
   },
   "OpenTelemetry": {
     "OtlpEndpoint": ""
+  },
+  "WindowsWorker": {
+    "Enabled": false,
+    "Url": "http://127.0.0.1:5005",
+    "SharedKey": ""
   }
 }


### PR DESCRIPTION
## Summary

- IS step S-003 from the [API split work](https://github.com/sefe/dorc/pull/706). Establishes the seam every later worker-move step (S-004 / S-005 / S-006) extends.
- New `IWindowsWorkerClient` interface (empty marker for now; later steps add methods).
- Two implementations: real `HttpWindowsWorkerClient` (typed HttpClient with `WorkerKeyDelegatingHandler` injecting `X-Worker-Key`), and `WorkerUnavailableClient` (null impl that throws `WorkerUnavailableException` → global filter renders `503 {"error":"windows_worker_unavailable","endpoint":"…"}`).
- New `WindowsWorker:Enabled` config flag selects the implementation. Defaults to `false` so existing Windows installs behave unchanged at this commit (flag flips `true` in S-008 when the installer wires the worker).
- Resolves HLPS U-6 (URL discovery — config-file), U-7 (contract via shared DTOs in `Dorc.ApiModel` — to be exercised by later steps), U-11 (worker-absence detection — explicit config flag).

## Test plan

- [x] `Dorc.Api.Tests/WindowsWorkerClientTests.cs` — 4 new tests covering the delegating handler's header injection (with and without configured secret) and the global exception filter's behaviour (translate + ignore).
- [x] `Dorc.Api.Tests`: 194 / 194 pass (4 new + 190 existing).
- [x] `Dorc.Api` builds clean.

Independent of PR #706 / #710 / #711 per IS multi-PR plan. S-004 / S-005 / S-006 stack on this once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)