### PR TITLE
S-004: Move RefDataServers registry probe to Windows worker (proof-of-pattern)

### DIFF
--- a/.github/workflows/linux-build-gate.yml
+++ b/.github/workflows/linux-build-gate.yml
@@ -157,8 +157,10 @@ jobs:
         run: |
           set -euo pipefail
           dotnet build src/Dorc.Api/Dorc.Api.csproj -c Release --no-restore --nologo 2>&1 | tee api-build.log
-          # Known Windows-only sites awaiting S-005 (WMI / service control).
-          backlog='WmiUtil\.cs|RefDataServersController\.cs|CoreRegistry\.cs|Program\.cs'
+          # Known Windows-only sites awaiting S-005 (WMI). This list must only ever shrink:
+          # S-004 moved the RefDataServers registry probe to the worker, so
+          # RefDataServersController and CoreRegistry came off it here.
+          backlog='WmiUtil\.cs|Program\.cs'
           # NOTE: `grep -vE ""` matches nothing, so an EMPTY backlog would silently turn this
           # into a permanent pass — i.e. reaching SC-1b's terminal state would DISABLE the
           # gate. Handle the empty case explicitly: with no backlog, any CA1416 is a failure.

--- a/src/Dorc.Api.Tests/WindowsWorkerClientTests.cs
+++ b/src/Dorc.Api.Tests/WindowsWorkerClientTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Dorc.Api.Tests
 {
@@ -51,7 +52,7 @@ namespace Dorc.Api.Tests
         [TestMethod]
         public void WorkerUnavailableExceptionFilter_Translates503_WithDocumentedBody()
         {
-            var filter = new WorkerUnavailableExceptionFilter();
+            var filter = new WorkerUnavailableExceptionFilter(NullLogger<WorkerUnavailableExceptionFilter>.Instance);
             var context = NewExceptionContext(new WorkerUnavailableException("reset-password"));
 
             filter.OnException(context);
@@ -70,13 +71,87 @@ namespace Dorc.Api.Tests
         [TestMethod]
         public void WorkerUnavailableExceptionFilter_IgnoresOtherExceptions()
         {
-            var filter = new WorkerUnavailableExceptionFilter();
+            var filter = new WorkerUnavailableExceptionFilter(NullLogger<WorkerUnavailableExceptionFilter>.Instance);
             var context = NewExceptionContext(new InvalidOperationException("something else"));
 
             filter.OnException(context);
 
             Assert.IsFalse(context.ExceptionHandled);
             Assert.IsNull(context.Result);
+        }
+
+        [TestMethod]
+        public async Task HttpWindowsWorkerClient_ConnectionFailure_ThrowsWorkerUnavailable()
+        {
+            // Worker configured (Enabled=true) but the process is not listening. Previously
+            // EnsureSuccessStatusCode/HttpRequestException escaped as a 500, so the documented
+            // 503 only ever fired for the config-disabled case.
+            var handler = new ThrowingHandler(new HttpRequestException("Connection refused"));
+            var http = new HttpClient(handler) { BaseAddress = new Uri("http://127.0.0.1:5005/") };
+            var client = new HttpWindowsWorkerClient(http);
+
+            var ex = await Assert.ThrowsExactlyAsync<WorkerUnavailableException>(
+                () => client.GetServerOperatingSystemAsync("SERVER01"));
+            Assert.AreEqual("remote-server/operating-system", ex.Endpoint);
+        }
+
+        [TestMethod]
+        public async Task HttpWindowsWorkerClient_Timeout_ThrowsWorkerUnavailable()
+        {
+            var handler = new ThrowingHandler(new TaskCanceledException("timed out"));
+            var http = new HttpClient(handler) { BaseAddress = new Uri("http://127.0.0.1:5005/") };
+            var client = new HttpWindowsWorkerClient(http);
+
+            await Assert.ThrowsExactlyAsync<WorkerUnavailableException>(
+                () => client.GetServerOperatingSystemAsync("SERVER01"));
+        }
+
+        [TestMethod]
+        public async Task HttpWindowsWorkerClient_WorkerBadRequest_SurfacesAsRejection()
+        {
+            // The worker answers 400 for real user-facing failures; collapsing that into a
+            // 500 loses the actionable message the endpoint documents.
+            var handler = new CannedHandler(System.Net.HttpStatusCode.BadRequest,
+                "{\"error\":\"Unable to open the target machine\"}");
+            var http = new HttpClient(handler) { BaseAddress = new Uri("http://127.0.0.1:5005/") };
+            var client = new HttpWindowsWorkerClient(http);
+
+            await Assert.ThrowsExactlyAsync<WorkerRequestRejectedException>(
+                () => client.GetServerOperatingSystemAsync("SERVER01"));
+        }
+
+        [TestMethod]
+        public void WorkerUnavailableExceptionFilter_RejectionBecomes400()
+        {
+            var filter = new WorkerUnavailableExceptionFilter(NullLogger<WorkerUnavailableExceptionFilter>.Instance);
+            var context = NewExceptionContext(new WorkerRequestRejectedException("Unable to open the target machine"));
+
+            filter.OnException(context);
+
+            Assert.IsTrue(context.ExceptionHandled);
+            var result = context.Result as BadRequestObjectResult;
+            Assert.IsNotNull(result);
+            Assert.AreEqual(StatusCodes.Status400BadRequest, result!.StatusCode);
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            private readonly Exception _ex;
+            public ThrowingHandler(Exception ex) => _ex = ex;
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromException<HttpResponseMessage>(_ex);
+        }
+
+        private sealed class CannedHandler : HttpMessageHandler
+        {
+            private readonly System.Net.HttpStatusCode _status;
+            private readonly string _body;
+            public CannedHandler(System.Net.HttpStatusCode status, string body) { _status = status; _body = body; }
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body, System.Text.Encoding.UTF8, "application/json")
+                });
         }
 
         private static ExceptionContext NewExceptionContext(Exception ex)

--- a/src/Dorc.Api.Tests/WindowsWorkerClientTests.cs
+++ b/src/Dorc.Api.Tests/WindowsWorkerClientTests.cs
@@ -116,8 +116,13 @@ namespace Dorc.Api.Tests
             var http = new HttpClient(handler) { BaseAddress = new Uri("http://127.0.0.1:5005/") };
             var client = new HttpWindowsWorkerClient(http);
 
-            await Assert.ThrowsExactlyAsync<WorkerRequestRejectedException>(
+            var ex = await Assert.ThrowsExactlyAsync<WorkerRequestRejectedException>(
                 () => client.GetServerOperatingSystemAsync("SERVER01"));
+
+            // The worker's body is already {"error":"..."} — the message must be the inner
+            // text, not the whole JSON, or the filter re-wraps it into
+            // {"error":"{\"error\":\"...\"}"} and the client shows escaped JSON to the user.
+            Assert.AreEqual("Unable to open the target machine", ex.Message);
         }
 
         [TestMethod]

--- a/src/Dorc.Api.WindowsWorker/Controllers/RemoteServerController.cs
+++ b/src/Dorc.Api.WindowsWorker/Controllers/RemoteServerController.cs
@@ -1,0 +1,50 @@
+using Dorc.ApiModel;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Win32;
+
+namespace Dorc.Api.WindowsWorker.Controllers
+{
+    // Windows-only remote-server probing. Currently exposes registry-based OS
+    // detection (S-004 — moved from Dorc.Api/Controllers/RefDataServersController).
+    [ApiController]
+    [Route("remote-server")]
+    public class RemoteServerController : ControllerBase
+    {
+        private readonly ILogger<RemoteServerController> _logger;
+
+        public RemoteServerController(ILogger<RemoteServerController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet("operating-system")]
+        public ActionResult<ServerOperatingSystemApiModel> GetOperatingSystem([FromQuery] string serverName)
+        {
+            if (string.IsNullOrWhiteSpace(serverName))
+            {
+                return BadRequest(new { error = "serverName is required" });
+            }
+
+            try
+            {
+                using var reg = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, serverName);
+                using var key = reg.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\");
+                if (key == null)
+                {
+                    return BadRequest(new { error = "Unable to open the target machine" });
+                }
+
+                return Ok(new ServerOperatingSystemApiModel
+                {
+                    ProductName = key.GetValue("ProductName")?.ToString() ?? string.Empty,
+                    CurrentVersion = key.GetValue("CurrentVersion")?.ToString() ?? string.Empty
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to read remote registry for server");
+                return BadRequest(new { error = "Failed to read remote registry for server" });
+            }
+        }
+    }
+}

--- a/src/Dorc.Api/Controllers/RefDataServersController.cs
+++ b/src/Dorc.Api/Controllers/RefDataServersController.cs
@@ -185,8 +185,10 @@ namespace Dorc.Api.Controllers
         /// <param name="serverName"></param>
         /// <returns></returns>
         [HttpGet]
-        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
-        [SwaggerResponse(StatusCodes.Status503ServiceUnavailable, Type = typeof(object), Description = "On Linux installs (Windows worker absent)")]
+        // Body is { "error": "<message>" } — reshaped from a bare string when the probe moved
+        // to the worker. Carved out of Out of Scope under HLPS U-20.
+        [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(object), Description = "Target machine could not be read")]
+        [SwaggerResponse(StatusCodes.Status503ServiceUnavailable, Type = typeof(object), Description = "Windows worker unavailable (Linux install, or worker not running)")]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(ServerOperatingSystemApiModel))]
         [Route("GetServerOperatingFromTarget")]
         public async Task<IActionResult> GetServerOperatingFromTarget(string serverName, CancellationToken cancellationToken)

--- a/src/Dorc.Api/Controllers/RefDataServersController.cs
+++ b/src/Dorc.Api/Controllers/RefDataServersController.cs
@@ -1,11 +1,11 @@
-﻿using Dorc.ApiModel;
+﻿using Dorc.Api.Interfaces;
+using Dorc.ApiModel;
 using Dorc.Core.Interfaces;
 using Dorc.PersistentData;
 using Dorc.PersistentData.Model;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Win32;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Net;
 using System.Text.Json;
@@ -23,6 +23,7 @@ namespace Dorc.Api.Controllers
         private readonly IEnvironmentsPersistentSource _environmentsPersistentSource;
         private readonly IDaemonsPersistentSource _daemonsPersistentSource;
         private readonly IClaimsPrincipalReader _claimsPrincipalReader;
+        private readonly IWindowsWorkerClient _windowsWorkerClient;
 
         public RefDataServersController(
             ISecurityPrivilegesChecker securityPrivilegesChecker,
@@ -30,7 +31,8 @@ namespace Dorc.Api.Controllers
             IServersAuditPersistentSource serversAuditPersistentSource,
             IEnvironmentsPersistentSource environmentsPersistentSource,
             IDaemonsPersistentSource daemonsPersistentSource,
-            IClaimsPrincipalReader claimsPrincipalReader)
+            IClaimsPrincipalReader claimsPrincipalReader,
+            IWindowsWorkerClient windowsWorkerClient)
         {
             _environmentsPersistentSource = environmentsPersistentSource;
             _serversPersistentSource = serversPersistentSource;
@@ -38,6 +40,7 @@ namespace Dorc.Api.Controllers
             _securityPrivilegesChecker = securityPrivilegesChecker;
             _daemonsPersistentSource = daemonsPersistentSource;
             _claimsPrincipalReader = claimsPrincipalReader;
+            _windowsWorkerClient = windowsWorkerClient;
         }
 
         /// <summary>
@@ -183,20 +186,15 @@ namespace Dorc.Api.Controllers
         /// <returns></returns>
         [HttpGet]
         [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+        [SwaggerResponse(StatusCodes.Status503ServiceUnavailable, Type = typeof(object), Description = "On Linux installs (Windows worker absent)")]
         [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(ServerOperatingSystemApiModel))]
         [Route("GetServerOperatingFromTarget")]
-        public IActionResult GetServerOperatingFromTarget(string serverName)
+        public async Task<IActionResult> GetServerOperatingFromTarget(string serverName, CancellationToken cancellationToken)
         {
-            var output = new ServerOperatingSystemApiModel();
-            using (var reg = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, serverName))
-            using (var key = reg.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\"))
-            {
-                if (key == null)
-                    return BadRequest("Unable to open the target machine");
-
-                output.ProductName = key.GetValue("ProductName").ToString();
-                output.CurrentVersion = key.GetValue("CurrentVersion").ToString();
-            }
+            // Delegated to Dorc.Api.WindowsWorker per HLPS Scope D / SPEC-S-004.
+            // On Linux installs the WorkerUnavailableClient throws and the global
+            // WorkerUnavailableExceptionFilter renders a 503 with the documented body.
+            var output = await _windowsWorkerClient.GetServerOperatingSystemAsync(serverName, cancellationToken);
             return Ok(output);
         }
 

--- a/src/Dorc.Api/Exceptions/WorkerRequestRejectedException.cs
+++ b/src/Dorc.Api/Exceptions/WorkerRequestRejectedException.cs
@@ -1,0 +1,14 @@
+namespace Dorc.Api.Exceptions
+{
+    // The Windows worker answered 400: the request itself was rejected (e.g. the target
+    // machine could not be opened), as opposed to the worker being unavailable. Rendered
+    // as a 400 by WorkerUnavailableExceptionFilter so the caller keeps the actionable
+    // error the endpoint documented, instead of an opaque 500.
+    public class WorkerRequestRejectedException : Exception
+    {
+        public WorkerRequestRejectedException(string detail)
+            : base(string.IsNullOrWhiteSpace(detail) ? "The Windows worker rejected the request." : detail)
+        {
+        }
+    }
+}

--- a/src/Dorc.Api/Exceptions/WorkerUnavailableException.cs
+++ b/src/Dorc.Api/Exceptions/WorkerUnavailableException.cs
@@ -13,5 +13,11 @@ namespace Dorc.Api.Exceptions
         {
             Endpoint = endpoint;
         }
+
+        public WorkerUnavailableException(string endpoint, Exception innerException)
+            : base($"Operation '{endpoint}' requires the Windows worker, which is not available on this host.", innerException)
+        {
+            Endpoint = endpoint;
+        }
     }
 }

--- a/src/Dorc.Api/Interfaces/IWindowsWorkerClient.cs
+++ b/src/Dorc.Api/Interfaces/IWindowsWorkerClient.cs
@@ -1,8 +1,10 @@
+using Dorc.ApiModel;
+
 namespace Dorc.Api.Interfaces
 {
     // Seam for the Linux-incompatible Windows-worker calls. Per HLPS-api-split D-1/D-3
     // and SPEC-S-003. Concrete methods are added by later S-steps as endpoints move:
-    //   S-004 — registry/remote-server probing
+    //   S-004 — registry/remote-server probing (this contract)
     //   S-005 — WMI service status
     //   S-006 — password reset impersonation
     //
@@ -14,5 +16,9 @@ namespace Dorc.Api.Interfaces
     //     (Linux installs; WindowsWorker:Enabled=false).
     public interface IWindowsWorkerClient
     {
+        // S-004 (HLPS Scope D — registry probe move). Reads the target server's
+        // ProductName + CurrentVersion from its remote Windows registry. Worker-side
+        // implementation lives in Dorc.Api.WindowsWorker/Controllers/RemoteServerController.cs.
+        Task<ServerOperatingSystemApiModel> GetServerOperatingSystemAsync(string serverName, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Dorc.Api/Program.cs
+++ b/src/Dorc.Api/Program.cs
@@ -287,14 +287,43 @@ static void AddSwaggerGen(IServiceCollection services, IConfigurationSettings co
 var workerEnabled = builder.Configuration.GetValue<bool>("WindowsWorker:Enabled");
 if (workerEnabled)
 {
+    // Fail at startup rather than on the first user request: an empty key made the
+    // delegating handler omit the header entirely, so the worker answered 401 and the
+    // operator saw a 500 with no hint that the key was missing.
+    var sharedKey = builder.Configuration["WindowsWorker:SharedKey"];
+    if (string.IsNullOrWhiteSpace(sharedKey))
+    {
+        throw new InvalidOperationException(
+            "WindowsWorker:Enabled=true but WindowsWorker:SharedKey is missing or blank. " +
+            "Set a shared secret matching the worker's WindowsWorker:SharedKey.");
+    }
+
     builder.Services.AddTransient<WorkerKeyDelegatingHandler>();
     builder.Services
         .AddHttpClient<IWindowsWorkerClient, HttpWindowsWorkerClient>(client =>
         {
             var url = builder.Configuration["WindowsWorker:Url"]
                 ?? throw new InvalidOperationException("WindowsWorker:Enabled=true but WindowsWorker:Url is missing");
-            client.BaseAddress = new Uri(url);
+            var uri = new Uri(url);
+
+            // The worker's entire threat model is "reachable on loopback only". If the URL
+            // can name an arbitrary host, anyone able to write config exfiltrates the shared
+            // secret in cleartext on every call.
+            if (!uri.IsLoopback)
+            {
+                throw new InvalidOperationException(
+                    $"WindowsWorker:Url must be a loopback address (got '{uri.Host}'). " +
+                    "The worker is only ever addressed on the local machine.");
+            }
+
+            client.BaseAddress = new Uri(uri.GetLeftPart(UriPartial.Authority) + "/");
+            // Default HttpClient timeout is 100s; a blocked remote-registry probe would pin
+            // a request that long before failing.
+            client.Timeout = TimeSpan.FromSeconds(30);
         })
+        // Without this, raising the log level to Trace to debug worker connectivity writes
+        // the shared secret into the log sinks.
+        .RedactLoggedHeaders(new[] { WorkerKeyDelegatingHandler.HeaderName })
         .AddHttpMessageHandler<WorkerKeyDelegatingHandler>();
 }
 else

--- a/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
+++ b/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
@@ -1,14 +1,14 @@
+using System.Net.Http.Json;
+using Dorc.Api.Exceptions;
 using Dorc.Api.Interfaces;
+using Dorc.ApiModel;
 
 namespace Dorc.Api.Services
 {
     // Real implementation of IWindowsWorkerClient used on Windows installs with
-    // WindowsWorker:Enabled=true. Concrete worker methods are added in later
-    // S-steps (S-004 registry, S-005 WMI, S-006 password reset).
-    //
-    // The injected HttpClient is configured via AddHttpClient<...>() in Program.cs:
-    // BaseAddress is set from WindowsWorker:Url and a WorkerKeyDelegatingHandler
-    // is added so every outbound call carries the X-Worker-Key header.
+    // WindowsWorker:Enabled=true. The injected HttpClient is configured via
+    // AddHttpClient<...>() in Program.cs (BaseAddress from WindowsWorker:Url +
+    // WorkerKeyDelegatingHandler attaching X-Worker-Key).
     public class HttpWindowsWorkerClient : IWindowsWorkerClient
     {
         private readonly HttpClient _http;
@@ -16,6 +16,16 @@ namespace Dorc.Api.Services
         public HttpWindowsWorkerClient(HttpClient http)
         {
             _http = http;
+        }
+
+        public async Task<ServerOperatingSystemApiModel> GetServerOperatingSystemAsync(string serverName, CancellationToken cancellationToken = default)
+        {
+            using var resp = await _http.GetAsync(
+                $"/remote-server/operating-system?serverName={Uri.EscapeDataString(serverName)}",
+                cancellationToken);
+            resp.EnsureSuccessStatusCode();
+            var body = await resp.Content.ReadFromJsonAsync<ServerOperatingSystemApiModel>(cancellationToken: cancellationToken);
+            return body ?? throw new WorkerUnavailableException("remote-server/operating-system");
         }
     }
 }

--- a/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
+++ b/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
@@ -57,8 +57,11 @@ namespace Dorc.Api.Services
                 // 500, which is what EnsureSuccessStatusCode did.
                 if (resp.StatusCode == HttpStatusCode.BadRequest)
                 {
+                    // The worker's 400 body is already {"error":"..."}. Reading it whole and
+                    // re-wrapping in the filter produced {"error":"{\"error\":\"...\"}"} —
+                    // unwrap to the message so the client sees a single, flat envelope.
                     var detail = await resp.Content.ReadAsStringAsync(cancellationToken);
-                    throw new WorkerRequestRejectedException(detail);
+                    throw new WorkerRequestRejectedException(ExtractErrorMessage(detail));
                 }
 
                 // 5xx from the worker means the worker itself is faulted — still unavailable
@@ -77,6 +80,28 @@ namespace Dorc.Api.Services
                 return body ?? throw new InvalidOperationException(
                     $"Windows worker returned a success status with an empty body for {endpoint}.");
             }
+        }
+
+        // Pulls the "error" property out of the worker's {"error":"..."} body. Falls back to
+        // the raw body when it is not that shape, so an unexpected payload is not swallowed.
+        private static string ExtractErrorMessage(string? body)
+        {
+            if (string.IsNullOrWhiteSpace(body)) return string.Empty;
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(body);
+                if (doc.RootElement.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && doc.RootElement.TryGetProperty("error", out var err)
+                    && err.ValueKind == System.Text.Json.JsonValueKind.String)
+                {
+                    return err.GetString() ?? body;
+                }
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // Not JSON — fall through and surface the raw body.
+            }
+            return body;
         }
     }
 }

--- a/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
+++ b/src/Dorc.Api/Services/HttpWindowsWorkerClient.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using System.Net.Http.Json;
+using System.Net.Sockets;
 using Dorc.Api.Exceptions;
 using Dorc.Api.Interfaces;
 using Dorc.ApiModel;
@@ -20,12 +22,61 @@ namespace Dorc.Api.Services
 
         public async Task<ServerOperatingSystemApiModel> GetServerOperatingSystemAsync(string serverName, CancellationToken cancellationToken = default)
         {
-            using var resp = await _http.GetAsync(
-                $"/remote-server/operating-system?serverName={Uri.EscapeDataString(serverName)}",
-                cancellationToken);
-            resp.EnsureSuccessStatusCode();
-            var body = await resp.Content.ReadFromJsonAsync<ServerOperatingSystemApiModel>(cancellationToken: cancellationToken);
-            return body ?? throw new WorkerUnavailableException("remote-server/operating-system");
+            const string endpoint = "remote-server/operating-system";
+
+            HttpResponseMessage resp;
+            try
+            {
+                resp = await _http.GetAsync(
+                    $"{endpoint}?serverName={Uri.EscapeDataString(serverName)}",
+                    cancellationToken);
+            }
+            // A worker that is configured but not running (connection refused, process
+            // crashed, host unreachable, request timed out) is "unavailable" — the same
+            // condition WorkerUnavailableClient represents. Without this it surfaced as an
+            // unhandled HttpRequestException → 500, so the documented 503 only ever fired
+            // for the config-disabled case, never for real runtime unavailability.
+            catch (HttpRequestException ex)
+            {
+                throw new WorkerUnavailableException(endpoint, ex);
+            }
+            catch (SocketException ex)
+            {
+                throw new WorkerUnavailableException(endpoint, ex);
+            }
+            catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                // HttpClient timeout, not a caller-initiated cancellation.
+                throw new WorkerUnavailableException(endpoint, ex);
+            }
+
+            using (resp)
+            {
+                // The worker answers 400 for genuine user-facing failures ("cannot open the
+                // target machine"). Surface that as a 400 rather than collapsing it into a
+                // 500, which is what EnsureSuccessStatusCode did.
+                if (resp.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    var detail = await resp.Content.ReadAsStringAsync(cancellationToken);
+                    throw new WorkerRequestRejectedException(detail);
+                }
+
+                // 5xx from the worker means the worker itself is faulted — still unavailable
+                // from the caller's point of view.
+                if ((int)resp.StatusCode >= 500)
+                {
+                    throw new WorkerUnavailableException(endpoint);
+                }
+
+                resp.EnsureSuccessStatusCode();
+
+                var body = await resp.Content.ReadFromJsonAsync<ServerOperatingSystemApiModel>(cancellationToken: cancellationToken);
+
+                // A 200 with an empty body is a worker bug, NOT unavailability. Reporting it
+                // as 503 sends operators hunting for a dead process that is running fine.
+                return body ?? throw new InvalidOperationException(
+                    $"Windows worker returned a success status with an empty body for {endpoint}.");
+            }
         }
     }
 }

--- a/src/Dorc.Api/Services/WorkerUnavailableClient.cs
+++ b/src/Dorc.Api/Services/WorkerUnavailableClient.cs
@@ -1,16 +1,17 @@
+using Dorc.Api.Exceptions;
 using Dorc.Api.Interfaces;
+using Dorc.ApiModel;
 
 namespace Dorc.Api.Services
 {
     // Null implementation of IWindowsWorkerClient used on Linux installs (or any
-    // host with WindowsWorker:Enabled=false). Every method on the interface (none
-    // yet, see SPEC-S-003 §2.1) throws WorkerUnavailableException, which the
-    // WorkerUnavailableExceptionFilter translates to the documented 503 body.
-    //
-    // Later S-steps that add methods to IWindowsWorkerClient must add matching
-    // throwing overrides here. Keep the throw site name (the endpoint argument)
-    // identical to the route segment so the 503 body's `endpoint` field is useful.
+    // host with WindowsWorker:Enabled=false). Every method throws
+    // WorkerUnavailableException with an endpoint name matching the route segment
+    // exposed on the worker, so WorkerUnavailableExceptionFilter renders the
+    // documented 503 body { "error": "windows_worker_unavailable", "endpoint": "..." }.
     public class WorkerUnavailableClient : IWindowsWorkerClient
     {
+        public Task<ServerOperatingSystemApiModel> GetServerOperatingSystemAsync(string serverName, CancellationToken cancellationToken = default)
+            => throw new WorkerUnavailableException("remote-server/operating-system");
     }
 }

--- a/src/Dorc.Api/Services/WorkerUnavailableExceptionFilter.cs
+++ b/src/Dorc.Api/Services/WorkerUnavailableExceptionFilter.cs
@@ -1,6 +1,7 @@
 using Dorc.Api.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
 
 namespace Dorc.Api.Services
 {
@@ -8,9 +9,27 @@ namespace Dorc.Api.Services
     // documented 503 body. Registered globally in Program.cs.
     public class WorkerUnavailableExceptionFilter : IExceptionFilter
     {
+        private readonly ILogger<WorkerUnavailableExceptionFilter> _log;
+
+        public WorkerUnavailableExceptionFilter(ILogger<WorkerUnavailableExceptionFilter> log)
+        {
+            _log = log;
+        }
+
         public void OnException(ExceptionContext context)
         {
+            if (context.Exception is WorkerRequestRejectedException rejected)
+            {
+                context.Result = new BadRequestObjectResult(new { error = rejected.Message });
+                context.ExceptionHandled = true;
+                return;
+            }
+
             if (context.Exception is not WorkerUnavailableException ex) return;
+
+            // Without this, every worker-dependent call on a host with no worker becomes a
+            // silent 503 with no server-side trace of why.
+            _log.LogWarning(ex, "Windows worker unavailable for endpoint {Endpoint}", ex.Endpoint);
 
             context.Result = new ObjectResult(new
             {


### PR DESCRIPTION
## Summary

- IS step S-004 from the [API split work](https://github.com/sefe/dorc/pull/706). Moves `/RefDataServers/GetServerOperatingFromTarget`'s Windows-registry read to the worker. Proof-of-pattern for S-005 / S-006.
- Adds `GetServerOperatingSystemAsync` to `IWindowsWorkerClient`. `HttpWindowsWorkerClient` calls the worker over HTTP; `WorkerUnavailableClient` throws → global filter returns the documented 503 body.
- New worker controller `Dorc.Api.WindowsWorker/Controllers/RemoteServerController.cs` carries the `RegistryKey.OpenRemoteBaseKey` logic.
- Primary's controller becomes a thin pass-through.
- `using Microsoft.Win32` removed from the primary controller.

## Stacking

This PR contains the S-002 + S-003 + S-004 diffs (since the worker project from S-002 and the contract from S-003 must exist for S-004's code to compile). When #711 (S-002) and #712 (S-003) merge to main, rebase this PR; the diff will collapse to just S-004's own change.

## Test plan

- [x] `Dorc.Api`, `Dorc.Api.WindowsWorker` build clean
- [x] `Dorc.Api.Tests`: 194 / 194 pass
- [x] `Dorc.Api.WindowsWorker.Tests`: 7 / 7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)