### PR TITLE
Fix DOrc.Cmdlet PropertyExists always true (GetProperty uses query string instead of path route)

### DIFF
--- a/src/Tools.DOrc.Cmdlet/ManageProperty.psm1
+++ b/src/Tools.DOrc.Cmdlet/ManageProperty.psm1
@@ -15,8 +15,12 @@ Class ManageProperty
     {
         if ($name)
         {
-            $queryString = "id=" + $name
-            $property = [ApiCaller]::InvokeGet($this.Connection.Property, $queryString)
+            # The API exposes single-property lookup as a path segment route
+            # (GET /Properties/id={id}); passing "id=" as a query string instead
+            # hits GET /Properties (get-all), which ignores the filter and returns
+            # every property with HTTP 200 - making PropertyExists always true.
+            $path = $this.Connection.Property + "/id=" + [uri]::EscapeDataString($name)
+            $property = [ApiCaller]::InvokeGet($path, "")
         }
         else
         {


### PR DESCRIPTION
## Problem

`DOrc.Cmdlet`'s `ManageProperty.GetProperty` builds the single-property lookup as a **query string**:

```powershell
 = "id=" + 
 = [ApiCaller]::InvokeGet(.Connection.Property, )   # GET /Properties?id=<name>
```

But the API has no `id` query parameter on the get-all action. `PropertiesController` exposes two routes:

| Route | Action | Behaviour |
|---|---|---|
| `GET /Properties` | `GetProperties()` | returns **all** properties |
| `GET /Properties/id={id}` | `GetProperty(id)` | returns **one** property, or **404** |

So `GET /Properties?id=<name>` hits `GetProperties()` — the `?id=` is ignored — returning **every** property (9,983 rows) with **HTTP 200**.

`PropertyExists` treats any 200 as "exists":

```powershell
if ($property.ReturnCode -eq 200) { $exists = $true }
```

…so it **always returns true**. As a result `Import-DOrcProperties` never runs its "Creating missing properties..." step, the new property is never created, and the follow-up value insert fails server-side with `Sequence contains no elements` (the property lookup `.First()` finds nothing).

### Repro
Import a CSV that references a **brand-new** property name. The property is silently not created and the value row reports `<name> : Sequence contains no elements`.

## Fix

Call the documented path-segment route instead, and URL-encode the name:

```powershell
$path = $this.Connection.Property + "/id=" + [uri]::EscapeDataString($name)
$property = [ApiCaller]::InvokeGet($path, "")
```

## Verification (live API)

| Request | Before (this PR) | After |
|---|---|---|
| existing name | `200` + **all 9,983** props | `200` + the single property |
| missing name | `200` + all props (false positive) | `404` (correct) |

```
GET /Properties/id=ROD_CRS_FR_KAFKA_ACTIVITYSYNC_TOPIC  -> 200 {"Id":14187,"Name":"ROD_CRS_FR_KAFKA_ACTIVITYSYNC_TOPIC",...}
GET /Properties/id=THIS_PROPERTY_DOES_NOT_EXIST_XYZ     -> 404
```

With this fix, `Import-DOrcProperties` correctly creates missing properties and inserts their values.



---
Fixes #757
