### PR TITLE
chore: sync feat/kafka-migration with main (#747, #758)

### DIFF
--- a/src/Dorc.Monitor/DeploymentRequestStateProcessor.cs
+++ b/src/Dorc.Monitor/DeploymentRequestStateProcessor.cs
@@ -253,7 +253,6 @@ namespace Dorc.Monitor
                 {
                     TerminateRequestExecution(id, requestCancellationSources);
                 }
-                ;
 
                 // Uses optimistic concurrency: only updates requests still in 'fromStatus'
                 int updatedRequestCount = this.requestsPersistentSource.SwitchDeploymentRequestStatuses(

--- a/src/Dorc.Monitor/DeploymentRequestStateProcessor.cs
+++ b/src/Dorc.Monitor/DeploymentRequestStateProcessor.cs
@@ -249,16 +249,11 @@ namespace Dorc.Monitor
 
                 this.logger.LogInformation($"Going to {methodName} the requests: [{idsString}]");
 
-                if (requests.Any(r => r.IsProd))
-                {
-                    this.logger.LogError($"Cannot {methodName} the request with id '{requests.First(r => r.IsProd).Id}' because request is running on production environment");
-                    return 0;
-                }
-
                 foreach (var id in ids)
                 {
                     TerminateRequestExecution(id, requestCancellationSources);
-                };
+                }
+                ;
 
                 // Uses optimistic concurrency: only updates requests still in 'fromStatus'
                 int updatedRequestCount = this.requestsPersistentSource.SwitchDeploymentRequestStatuses(
@@ -571,7 +566,7 @@ namespace Dorc.Monitor
                     {
                         this.RemoveCancellationTokenSource(requestToExecute.Request.Id, requestCancellationSources);
                         environmentRequestIdRunning.TryRemove(requestGroup.Key, out _);
-                        
+
                         // Release the distributed lock
                         if (envLock != null)
                         {

--- a/src/dorc-web/src/components/attached-servers.ts
+++ b/src/dorc-web/src/components/attached-servers.ts
@@ -63,8 +63,16 @@ export class AttachedServers extends ResponsiveMixin(LitElement) {
         overflow: auto;
         padding: 10px;
       }
+      :host {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+        height: 100%;
+      }
       vaadin-grid#grid {
-        overflow: auto;
+        flex: 1;
+        min-height: 0;
         width: calc(100% - 4px);
         --divider-color: var(--dorc-border-color);
       }
@@ -131,7 +139,6 @@ export class AttachedServers extends ResponsiveMixin(LitElement) {
         .items=${this.servers}
         theme="compact row-stripes no-row-borders no-border"
         multi-sort
-        all-rows-visible
       >
         <vaadin-grid-column
           path="Name"

--- a/src/dorc-web/src/components/environment-tabs/env-servers.ts
+++ b/src/dorc-web/src/components/environment-tabs/env-servers.ts
@@ -51,11 +51,33 @@ export class EnvServers extends PageEnvBase {
         padding: var(--lumo-space-xs);
       }
       vaadin-details {
-        overflow: auto;
+        overflow: hidden;
         width: calc(100% - 4px);
         flex: 1;
         min-height: 0;
         --divider-color: var(--dorc-border-color);
+        display: flex;
+        flex-direction: column;
+      }
+      vaadin-details::part(content) {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        padding: 2;
+      }
+      .details-content {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+      }
+      .servers-wrapper {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
       }
     `;
   }
@@ -67,7 +89,7 @@ export class EnvServers extends PageEnvBase {
         summary="Application Server Details"
         style="border-top: 6px solid var(--dorc-link-color); background-color: var(--dorc-bg-secondary); padding-left: 4px; margin: 0px;"
       >
-        <div>
+        <div class="details-content">
           <div class="inline">
             <vaadin-button
               title="Attach Server"
@@ -87,6 +109,7 @@ export class EnvServers extends PageEnvBase {
             ${dialogFooterRenderer(this.renderAttachServerFooter, [])}
           ></vaadin-dialog>
           </div>
+          <div class="servers-wrapper">
             <attached-servers
               id="attached-servers"
               .envId="${this.environmentId ?? 0}"


### PR DESCRIPTION
Mechanical merge of `origin/main` into `feat/kafka-migration` to bring PR #611 current (direct pushes from this session are restricted to the session branch — same pattern as #723).

Brings in the 5 commits main gained since the last sync:
- #747 — env-servers page scroll fix (`dorc-web` only)
- #758 — remove the IsProd restriction so prod deployments can be cancelled (`DeploymentRequestStateProcessor.cs`)

The merge was conflict-free. The only overlap with the Kafka branch is `DeploymentRequestStateProcessor.cs`, where main's change simply deletes the prod-cancellation guard clause — no interaction with the HA/locking changes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDRFc8HVe1mXvdPhxsxKVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDRFc8HVe1mXvdPhxsxKVU)_