### PR TITLE
fix(kafka): acceptance-review gap fill — poll default, user-action wake, coverage

### DIFF
--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -11,6 +11,11 @@ on:
     paths:
       - 'src/Dorc.Kafka.*/**'
       - 'src/Dorc.Kafka.*.Tests/**'
+      # Monitor-side substrate wiring (poll signal, lock consumers, fallback
+      # registration) lives outside src/Dorc.Kafka.* — changes there must also
+      # trigger the live-broker suite.
+      - 'src/Dorc.Monitor/**'
+      - 'src/Dorc.Core/**'
       - 'compose.kafka.yml'
       - '.github/workflows/kafka-integration.yml'
   push:
@@ -19,6 +24,8 @@ on:
       - feat/kafka-migration
     paths:
       - 'src/Dorc.Kafka.*/**'
+      - 'src/Dorc.Monitor/**'
+      - 'src/Dorc.Core/**'
       - 'compose.kafka.yml'
       - '.github/workflows/kafka-integration.yml'
 

--- a/src/Dorc.Kafka.Events.Tests/Publisher/PollSignalRequestEventHandlerTests.cs
+++ b/src/Dorc.Kafka.Events.Tests/Publisher/PollSignalRequestEventHandlerTests.cs
@@ -7,10 +7,12 @@ namespace Dorc.Kafka.Events.Tests.Publisher;
 
 /// <summary>
 /// The handler raises the wake-up signal exactly once per requests.new
-/// record — and ONLY for requests.new. requests.status records include the
-/// Monitor's own status publishes, so signalling on them made every processed
-/// request wake the poll loop again (self-wake; each wake costs a forced full
-/// GC + 4 DB sweeps in DeploymentEngine).
+/// record, and for requests.status records ONLY when the status is a
+/// user-action state the Monitor's sweeps act on (Cancelling/Restarting/
+/// Pending). The high-frequency Monitor-published result states (Running/
+/// Completed/Failed/Errored/...) stay filtered: signalling on them made every
+/// processed request wake the poll loop again (self-wake; each wake costs a
+/// forced full GC + 4 DB sweeps in DeploymentEngine).
 /// </summary>
 [TestClass]
 public class PollSignalRequestEventHandlerTests
@@ -33,20 +35,59 @@ public class PollSignalRequestEventHandlerTests
         Assert.AreEqual(1, signal.SignalCount);
     }
 
-    [TestMethod]
-    public async Task Handle_RequestsStatusRecord_DoesNotSignal()
+    [DataTestMethod]
+    [DataRow("Running")]
+    [DataRow("Completed")]
+    [DataRow("Failed")]
+    [DataRow("Errored")]
+    [DataRow("Cancelled")]
+    public async Task Handle_RequestsStatusRecord_MonitorResultState_DoesNotSignal(string status)
     {
-        // requests.status events include the Monitor's own publishes —
-        // signalling here would self-wake the poll loop on every processed
-        // request.
+        // These are the Monitor's own high-frequency publishes — signalling
+        // here would self-wake the poll loop on every processed request.
         var signal = new CountingSignal();
         var sut = NewHandler(signal);
 
         await sut.HandleAsync(Topics.RequestsStatus,
-            new DeploymentRequestEventData(1, "Running", null, null, DateTimeOffset.UtcNow),
+            new DeploymentRequestEventData(1, status, null, null, DateTimeOffset.UtcNow),
             CancellationToken.None);
 
         Assert.AreEqual(0, signal.SignalCount);
+    }
+
+    [DataTestMethod]
+    [DataRow("Cancelling")]
+    [DataRow("Restarting")]
+    [DataRow("Pending")]
+    public async Task Handle_RequestsStatusRecord_UserActionState_Signals(string status)
+    {
+        // User cancel (Cancelling), restart (Restarting) and resume (Pending)
+        // must wake the sweeps within one signal, not one poll interval.
+        var signal = new CountingSignal();
+        var sut = NewHandler(signal);
+
+        await sut.HandleAsync(Topics.RequestsStatus,
+            new DeploymentRequestEventData(1, status, null, null, DateTimeOffset.UtcNow),
+            CancellationToken.None);
+
+        Assert.AreEqual(1, signal.SignalCount);
+    }
+
+    [TestMethod]
+    public async Task Handle_RequestsStatusRecord_StatusMatchIsCaseInsensitive_AndNullStatusDoesNotSignal()
+    {
+        var signal = new CountingSignal();
+        var sut = NewHandler(signal);
+
+        await sut.HandleAsync(Topics.RequestsStatus,
+            new DeploymentRequestEventData(1, "CANCELLING", null, null, DateTimeOffset.UtcNow),
+            CancellationToken.None);
+        Assert.AreEqual(1, signal.SignalCount);
+
+        await sut.HandleAsync(Topics.RequestsStatus,
+            new DeploymentRequestEventData(2, null, null, null, DateTimeOffset.UtcNow),
+            CancellationToken.None);
+        Assert.AreEqual(1, signal.SignalCount, "A null status must never signal.");
     }
 
     [TestMethod]

--- a/src/Dorc.Kafka.Events/Publisher/IRequestEventHandler.cs
+++ b/src/Dorc.Kafka.Events/Publisher/IRequestEventHandler.cs
@@ -1,3 +1,4 @@
+using Dorc.ApiModel;
 using Dorc.Core.Events;
 using Dorc.Kafka.Events.Configuration;
 using Microsoft.Extensions.Options;
@@ -28,24 +29,50 @@ public interface IRequestEventHandler
 
 public sealed class PollSignalRequestEventHandler : IRequestEventHandler
 {
+    /// <summary>
+    /// requests.status states that wake the poll loop. These are the
+    /// USER-ACTION states the Monitor's sweeps act on: the API publishes
+    /// Cancelling/Restarting (user cancel/restart of an in-flight request)
+    /// and Pending (resume of a paused request). The Monitor never publishes
+    /// Cancelling/Restarting itself, so those can't self-wake. It DOES
+    /// publish Pending (startup resume in CancelStaleRequests, and
+    /// RestartRequests processing) — accepted: those are low-frequency (one
+    /// extra sweep per startup/restart, not per-deployment-burst) and Pending
+    /// is genuinely actionable (runnable work exists). The high-frequency
+    /// Monitor-published result states (Running/Completed/Failed/Errored/
+    /// Cancelled/Abandoned) stay filtered — signalling on them made every
+    /// processed request wake the loop again (self-wake), and each wake costs
+    /// a forced full GC plus four DB sweeps in DeploymentEngine.
+    /// </summary>
+    private static readonly HashSet<string> WakeStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        nameof(DeploymentRequestStatus.Cancelling),
+        nameof(DeploymentRequestStatus.Restarting),
+        nameof(DeploymentRequestStatus.Pending),
+    };
+
     private readonly IRequestPollSignal _signal;
     private readonly string _requestsNewTopic;
+    private readonly string _requestsStatusTopic;
 
     public PollSignalRequestEventHandler(IRequestPollSignal signal, IOptions<KafkaTopicsOptions> topics)
     {
         _signal = signal;
         _requestsNewTopic = topics.Value.RequestsNew;
+        _requestsStatusTopic = topics.Value.RequestsStatus;
     }
 
     public Task HandleAsync(string topic, DeploymentRequestEventData eventData, CancellationToken cancellationToken)
     {
-        // Only requests.new events wake the poll loop: they are the "a new
+        // requests.new events always wake the poll loop: they are the "a new
         // request needs picking up" signal the acceleration path exists for.
-        // requests.status events include the Monitor's OWN status publishes,
-        // so signalling on them made every processed request wake the loop
-        // again (self-wake) — and each wake costs a forced full GC plus four
-        // DB sweeps in DeploymentEngine.
+        // requests.status events wake it only for user-action states (see
+        // WakeStatuses) so cancel/restart/resume are picked up within one
+        // signal rather than one poll interval.
         if (string.Equals(topic, _requestsNewTopic, StringComparison.Ordinal))
+            _signal.Signal();
+        else if (string.Equals(topic, _requestsStatusTopic, StringComparison.Ordinal)
+                 && eventData.Status is { } status && WakeStatuses.Contains(status))
             _signal.Signal();
         return Task.CompletedTask;
     }

--- a/src/Dorc.Kafka.Lock.Tests/KafkaLockCoordinatorTests.cs
+++ b/src/Dorc.Kafka.Lock.Tests/KafkaLockCoordinatorTests.cs
@@ -22,7 +22,9 @@ public class KafkaLockCoordinatorTests
         int? livenessTimeoutMs = null,
         TimeProvider? timeProvider = null,
         int? sessionTimeoutMs = null,
-        int? lockSessionTimeoutMs = null)
+        int? lockSessionTimeoutMs = null,
+        bool useStaticGroupMembership = true,
+        string? replicaId = null)
     {
         var opts = Options.Create(new KafkaLocksOptions
         {
@@ -30,7 +32,8 @@ public class KafkaLockCoordinatorTests
             PartitionCount = partitionCount,
             ConsumerGroupId = "test",
             LivenessTimeoutMs = livenessTimeoutMs,
-            SessionTimeoutMs = lockSessionTimeoutMs
+            SessionTimeoutMs = lockSessionTimeoutMs,
+            UseStaticGroupMembership = useStaticGroupMembership
         });
         var topics = Options.Create(new KafkaTopicsOptions());
         return new KafkaLockCoordinator(
@@ -38,7 +41,10 @@ public class KafkaLockCoordinatorTests
             opts,
             topics,
             NullLogger<KafkaLockCoordinator>.Instance,
-            timeProvider);
+            timeProvider,
+            replicaId is null
+                ? null
+                : Options.Create(new Dorc.Kafka.Client.Configuration.KafkaClientOptions { ReplicaId = replicaId }));
     }
 
     private static void InvokePrivate(object target, string name, params object[] args)
@@ -372,6 +378,75 @@ public class KafkaLockCoordinatorTests
         Assert.IsTrue((bool)GetPrivateField(c, "_connectivitySuspect"),
             "A 'lost' revoke (local timeout, no broker round-trip) must NOT clear " +
             "_connectivitySuspect.");
+    }
+
+    // ---- BuildConsumerConfig seam: lock-consumer config invariants ----
+
+    [TestMethod]
+    public async Task BuildConsumerConfig_PinsAutoCommitAndOffsetReset()
+    {
+        await using var c = NewCoordinator();
+        var config = c.BuildConsumerConfig();
+
+        // Lock semantics don't use committed offsets: auto-commit on, join at Latest.
+        Assert.IsTrue(config.EnableAutoCommit);
+        Assert.AreEqual(AutoOffsetReset.Latest, config.AutoOffsetReset);
+    }
+
+    [TestMethod]
+    public async Task BuildConsumerConfig_LockSessionTimeoutOverride_WinsOverSharedClientValue()
+    {
+        await using var c = NewCoordinator(sessionTimeoutMs: 30_000, lockSessionTimeoutMs: 150_000);
+        Assert.AreEqual(150_000, c.BuildConsumerConfig().SessionTimeoutMs);
+    }
+
+    [TestMethod]
+    public async Task BuildConsumerConfig_NoLockSessionTimeout_InheritsSharedClientValue()
+    {
+        await using var c = NewCoordinator(sessionTimeoutMs: 30_000, lockSessionTimeoutMs: null);
+        Assert.AreEqual(30_000, c.BuildConsumerConfig().SessionTimeoutMs);
+    }
+
+    [TestMethod]
+    public async Task BuildConsumerConfig_StaticMembership_SetsGroupScopedHostInstanceId()
+    {
+        // group.instance.id = "{group}.{HostInstanceId.For(replicaId)}". The
+        // expectation is computed through HostInstanceId.For itself — the
+        // honest pin, since DORC_REPLICA_ID in the test environment outranks
+        // any configured replica id and would change the raw string.
+        await using var c = NewCoordinator(useStaticGroupMembership: true);
+        Assert.AreEqual(
+            $"test.{Dorc.Kafka.Events.Publisher.HostInstanceId.For(null)}",
+            c.BuildConsumerConfig().GroupInstanceId);
+    }
+
+    [TestMethod]
+    public async Task BuildConsumerConfig_StaticMembershipDisabled_LeavesGroupInstanceIdNull()
+    {
+        await using var c = NewCoordinator(useStaticGroupMembership: false);
+        Assert.IsNull(c.BuildConsumerConfig().GroupInstanceId);
+    }
+
+    [TestMethod]
+    public async Task BuildConsumerConfig_ConfiguredReplicaId_FlowsIntoGroupInstanceId()
+    {
+        // Kafka:ReplicaId (constructor-injected KafkaClientOptions) must reach
+        // the static-membership id via the same HostInstanceId channel the
+        // event consumers use.
+        await using var c = NewCoordinator(replicaId: "tier1");
+        var groupInstanceId = c.BuildConsumerConfig().GroupInstanceId;
+
+        Assert.AreEqual(
+            $"test.{Dorc.Kafka.Events.Publisher.HostInstanceId.For("tier1")}",
+            groupInstanceId);
+
+        // When the env var is not set, the config channel combines with the
+        // machine name — pin the exact "{MachineName}-{ReplicaId}" suffix.
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(
+                Dorc.Kafka.Events.Publisher.HostInstanceId.EnvironmentVariable)))
+        {
+            Assert.AreEqual($"test.{Environment.MachineName}-tier1", groupInstanceId);
+        }
     }
 
     private sealed class FakeConnectionProvider : Dorc.Kafka.Client.Connection.IKafkaConnectionProvider

--- a/src/Dorc.Kafka.Lock/KafkaLockCoordinator.cs
+++ b/src/Dorc.Kafka.Lock/KafkaLockCoordinator.cs
@@ -149,7 +149,13 @@ public sealed class KafkaLockCoordinator : IHostedService, IAsyncDisposable
     private IConsumer<byte[], byte[]> CreateConsumer() =>
         ConsumerFactoryOverride?.Invoke() ?? BuildConsumer();
 
-    private IConsumer<byte[], byte[]> BuildConsumer()
+    /// <summary>
+    /// Lock-consumer configuration, split from <see cref="BuildConsumer"/> as
+    /// an internal seam so the unit tests can pin the config invariants
+    /// (static membership id, session-timeout override, auto-commit,
+    /// offset-reset) without constructing a librdkafka consumer.
+    /// </summary>
+    internal ConsumerConfig BuildConsumerConfig()
     {
         var config = _connectionProvider.GetConsumerConfig(_options.ConsumerGroupId);
         // Lock semantics don't use committed offsets — auto-commit is harmless
@@ -158,7 +164,7 @@ public sealed class KafkaLockCoordinator : IHostedService, IAsyncDisposable
         config.AutoOffsetReset = AutoOffsetReset.Latest;
         // Lock-specific session timeout: the outage-grace budget for held
         // locks (see KafkaLocksOptions.SessionTimeoutMs). The liveness
-        // watchdog derives from the same effective value below.
+        // watchdog derives from the same effective value.
         if (_options.SessionTimeoutMs is { } sessionMs)
             config.SessionTimeoutMs = sessionMs;
         // Static membership: a restart that rejoins within session.timeout.ms
@@ -172,6 +178,12 @@ public sealed class KafkaLockCoordinator : IHostedService, IAsyncDisposable
         // fan-out consumer warning covers the same topology.
         if (_options.UseStaticGroupMembership)
             config.GroupInstanceId = $"{_options.ConsumerGroupId}.{Events.Publisher.HostInstanceId.For(_configuredReplicaId)}";
+        return config;
+    }
+
+    private IConsumer<byte[], byte[]> BuildConsumer()
+    {
+        var config = BuildConsumerConfig();
 
         var handlers = new KafkaRebalanceHandlers<byte[], byte[]>(_logger, "dorc-lock-coordinator");
 

--- a/src/Dorc.Monitor.Tests/DeploymentEngineBackpressureTests.cs
+++ b/src/Dorc.Monitor.Tests/DeploymentEngineBackpressureTests.cs
@@ -1,0 +1,205 @@
+using Dorc.Core.Events;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.Collections.Concurrent;
+
+namespace Dorc.Monitor.Tests
+{
+    /// <summary>
+    /// Pins the DeploymentEngine backpressure loop (UC3):
+    /// <list type="bullet">
+    ///   <item>Completed tasks are pruned each iteration, then — when
+    ///   MaxConcurrentDeployments &gt; 0 and the in-flight count is at or over
+    ///   the cap — the loop awaits <c>Task.WhenAny</c> before pulling new work,
+    ///   so <c>ExecuteRequests</c> is NOT called again while at the cap.</item>
+    ///   <item>Once one in-flight deployment completes, the loop resumes and
+    ///   <c>ExecuteRequests</c> is called again (even if the post-prune count
+    ///   still equals the cap — the guard is a single <c>if</c>, not a loop).</item>
+    ///   <item>MaxConcurrentDeployments = 0 means unlimited: the loop never
+    ///   blocks on in-flight tasks.</item>
+    /// </list>
+    /// Iteration timing is driven deterministically through a controllable
+    /// IRequestPollSignal (the engine ends each iteration in
+    /// <c>pollSignal.WaitAsync</c>) — no Thread.Sleep racing.
+    /// </summary>
+    [TestClass]
+    public class DeploymentEngineBackpressureTests
+    {
+        private static readonly TimeSpan AssertTimeout = TimeSpan.FromSeconds(10);
+        /// <summary>Bounded window for "did NOT happen" checks.</summary>
+        private static readonly TimeSpan NegativeCheckWindow = TimeSpan.FromMilliseconds(250);
+
+        private IDeploymentRequestStateProcessor mockProcessor = null!;
+        private IMonitorConfiguration mockConfiguration = null!;
+        private ControllablePollSignal pollSignal = null!;
+        private DeploymentEngine sut = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            mockProcessor = Substitute.For<IDeploymentRequestStateProcessor>();
+            mockConfiguration = Substitute.For<IMonitorConfiguration>();
+            pollSignal = new ControllablePollSignal();
+            sut = new DeploymentEngine(
+                Substitute.For<ILogger<DeploymentEngine>>(),
+                mockProcessor,
+                mockConfiguration,
+                pollSignal);
+        }
+
+        [TestMethod]
+        public async Task ProcessDeploymentRequests_AtMaxConcurrent_DoesNotPullNewWorkUntilOneCompletes()
+        {
+            // Arrange: cap of 2, first ExecuteRequests hands back 3 long-running
+            // tasks (the engine adds everything a single call returns; the cap
+            // gates the NEXT pull, not the batch size).
+            mockConfiguration.MaxConcurrentDeployments.Returns(2);
+
+            var tcs1 = NewTcs();
+            var tcs2 = NewTcs();
+            var tcs3 = NewTcs();
+            var firstExecuteCall = NewTcs();
+            var secondExecuteCall = NewTcs();
+            var executeCalls = 0;
+
+            mockProcessor
+                .ExecuteRequests(false, Arg.Any<ConcurrentDictionary<int, CancellationTokenSource>>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    var call = Interlocked.Increment(ref executeCalls);
+                    if (call == 1)
+                    {
+                        firstExecuteCall.TrySetResult(true);
+                        return new[] { tcs1.Task, tcs2.Task, tcs3.Task };
+                    }
+                    secondExecuteCall.TrySetResult(true);
+                    return Array.Empty<Task>();
+                });
+
+            var secondIterationSweep = NewTcs();
+            var sweepCalls = 0;
+            mockProcessor
+                .When(p => p.AbandonRequests(false, Arg.Any<ConcurrentDictionary<int, CancellationTokenSource>>(), Arg.Any<CancellationToken>()))
+                .Do(_ =>
+                {
+                    if (Interlocked.Increment(ref sweepCalls) == 2)
+                        secondIterationSweep.TrySetResult(true);
+                });
+
+            using var monitorCts = new CancellationTokenSource();
+            var cancellationSources = new ConcurrentDictionary<int, CancellationTokenSource>();
+
+            // Act: iteration 1 pulls the 3 tasks, then parks on the poll signal.
+            var engineTask = sut.ProcessDeploymentRequestsAsync(false, cancellationSources, monitorCts.Token, iterationDelayMs: 60_000);
+            await firstExecuteCall.Task.WaitAsync(AssertTimeout);
+
+            // Release iteration 2: its sweeps run, then — at 3 in-flight >= cap 2 —
+            // the loop must block in Task.WhenAny BEFORE calling ExecuteRequests.
+            pollSignal.ReleaseIteration();
+            await secondIterationSweep.Task.WaitAsync(AssertTimeout);
+
+            var pulledWhileAtCap = await Task.WhenAny(secondExecuteCall.Task, Task.Delay(NegativeCheckWindow)) == secondExecuteCall.Task;
+            Assert.IsFalse(pulledWhileAtCap,
+                "ExecuteRequests must not be called again while the in-flight count is at MaxConcurrentDeployments.");
+            Assert.AreEqual(1, Volatile.Read(ref executeCalls));
+
+            // Complete one deployment: WhenAny returns, the completed task is
+            // pruned, and the loop pulls new work again.
+            tcs1.SetResult(true);
+            await secondExecuteCall.Task.WaitAsync(AssertTimeout);
+            Assert.AreEqual(2, Volatile.Read(ref executeCalls));
+
+            await ShutDownAsync(engineTask, monitorCts, tcs2, tcs3);
+        }
+
+        [TestMethod]
+        public async Task ProcessDeploymentRequests_MaxConcurrentZero_IsUnlimited_NeverBlocksOnInFlightTasks()
+        {
+            // Arrange: cap disabled; 3 in-flight tasks must not stop the next pull.
+            mockConfiguration.MaxConcurrentDeployments.Returns(0);
+
+            var tcs1 = NewTcs();
+            var tcs2 = NewTcs();
+            var tcs3 = NewTcs();
+            var firstExecuteCall = NewTcs();
+            var secondExecuteCall = NewTcs();
+            var executeCalls = 0;
+
+            mockProcessor
+                .ExecuteRequests(false, Arg.Any<ConcurrentDictionary<int, CancellationTokenSource>>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    var call = Interlocked.Increment(ref executeCalls);
+                    if (call == 1)
+                    {
+                        firstExecuteCall.TrySetResult(true);
+                        return new[] { tcs1.Task, tcs2.Task, tcs3.Task };
+                    }
+                    secondExecuteCall.TrySetResult(true);
+                    return Array.Empty<Task>();
+                });
+
+            using var monitorCts = new CancellationTokenSource();
+            var cancellationSources = new ConcurrentDictionary<int, CancellationTokenSource>();
+
+            // Act
+            var engineTask = sut.ProcessDeploymentRequestsAsync(false, cancellationSources, monitorCts.Token, iterationDelayMs: 60_000);
+            await firstExecuteCall.Task.WaitAsync(AssertTimeout);
+
+            // Iteration 2 with all 3 tasks still running must reach
+            // ExecuteRequests without waiting for any completion.
+            pollSignal.ReleaseIteration();
+            await secondExecuteCall.Task.WaitAsync(AssertTimeout);
+            Assert.AreEqual(2, Volatile.Read(ref executeCalls));
+
+            await ShutDownAsync(engineTask, monitorCts, tcs1, tcs2, tcs3);
+        }
+
+        private static TaskCompletionSource<bool> NewTcs()
+            => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Graceful-shutdown teardown: the engine's exit path awaits every
+        /// in-flight task, so complete the remaining TCSs before cancelling.
+        /// </summary>
+        private async Task ShutDownAsync(
+            Task engineTask,
+            CancellationTokenSource monitorCts,
+            params TaskCompletionSource<bool>[] remaining)
+        {
+            foreach (var tcs in remaining)
+                tcs.TrySetResult(true);
+            monitorCts.Cancel();
+            pollSignal.ReleaseIteration(); // wake the loop if parked on the signal
+            await engineTask.WaitAsync(AssertTimeout);
+        }
+
+        /// <summary>
+        /// Poll signal whose WaitAsync completes only when the test releases an
+        /// iteration (the configured timeout is deliberately ignored), making
+        /// loop progress fully test-driven. Cancellation still unparks the loop
+        /// for shutdown, mirroring the production RequestPollSignal contract.
+        /// </summary>
+        private sealed class ControllablePollSignal : IRequestPollSignal
+        {
+            private readonly SemaphoreSlim _iterations = new(initialCount: 0);
+
+            public void Signal()
+            {
+                // The engine never signals itself; consumers do. Not used here.
+            }
+
+            public async Task WaitAsync(TimeSpan timeout, CancellationToken cancellationToken)
+            {
+                try { await _iterations.WaitAsync(cancellationToken); }
+                catch (OperationCanceledException)
+                {
+                    // Engine swallows cancellation here and re-checks the loop
+                    // condition; match RequestPollSignal by rethrowing nothing.
+                }
+            }
+
+            public void ReleaseIteration() => _iterations.Release();
+        }
+    }
+}

--- a/src/Dorc.Monitor.Tests/DeploymentRequestStateProcessorTests.cs
+++ b/src/Dorc.Monitor.Tests/DeploymentRequestStateProcessorTests.cs
@@ -528,6 +528,15 @@ namespace Dorc.Monitor.Tests
                     Arg.Any<DateTimeOffset>());
         }
 
+        [TestMethod]
+        public void LockBackoffDuration_Is30Seconds()
+        {
+            // The backoff window after a failed distributed-lock acquisition is
+            // an operational contract: an environment held by a peer Monitor is
+            // retried after 30s, not busy-retried every sweep.
+            Assert.AreEqual(TimeSpan.FromSeconds(30), DeploymentRequestStateProcessor.LockBackoffDuration);
+        }
+
         // =====================================================================
         // TryAdd race condition fix: environmentRequestIdRunning.TryAdd before Task.Run
         // =====================================================================
@@ -1001,6 +1010,52 @@ namespace Dorc.Monitor.Tests
             mockRequestsPersistentSource.DidNotReceive()
                 .UpdateNonProcessedRequest(
                     Arg.Any<DeploymentRequestApiModel>(),
+                    Arg.Any<DeploymentRequestStatus>(),
+                    Arg.Any<DateTimeOffset>());
+        }
+
+        [TestMethod]
+        public async Task ExecuteRequests_WhenPausedRequestIsBehindPendingHead_ExecutesTheHead()
+        {
+            // Converse of the paused-head case: a Paused request LATER in the
+            // queue (higher ID) must not block the environment — only a Paused
+            // HEAD does. Request 95 (Pending, lowest ID) executes; 96 is Paused.
+            var requests = new List<DeploymentRequestApiModel>
+            {
+                new() { Id = 95, EnvironmentName = "EnvPauseBehind", Status = DeploymentRequestStatus.Pending.ToString(),
+                        IsProd = false, UserName = "testuser",
+                        RequestDetails = "<DeploymentRequestDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><Components /><ComponentsToSkip /><Properties /></DeploymentRequestDetail>" },
+                new() { Id = 96, EnvironmentName = "EnvPauseBehind", Status = DeploymentRequestStatus.Paused.ToString(),
+                        IsProd = false, UserName = "testuser",
+                        RequestDetails = "<DeploymentRequestDetail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><Components /><ComponentsToSkip /><Properties /></DeploymentRequestDetail>" }
+            };
+            mockRequestsPersistentSource
+                .GetRequestsWithStatus(
+                    DeploymentRequestStatus.Pending,
+                    DeploymentRequestStatus.Running,
+                    DeploymentRequestStatus.Confirmed,
+                    DeploymentRequestStatus.Paused,
+                    false)
+                .Returns(requests);
+
+            mockDistributedLockService.IsEnabled.Returns(false);
+            mockRequestsPersistentSource
+                .UpdateNonProcessedRequest(
+                    Arg.Any<DeploymentRequestApiModel>(),
+                    Arg.Any<DeploymentRequestStatus>(),
+                    Arg.Any<DateTimeOffset>())
+                .Returns(0); // Return 0 to avoid going deeper into execution
+
+            var cancellationSources = new ConcurrentDictionary<int, CancellationTokenSource>();
+
+            // Act
+            var tasks = sut.ExecuteRequests(false, cancellationSources, CancellationToken.None);
+            await Task.WhenAll(tasks);
+
+            // Assert - the Pending head is processed (environment NOT skipped)
+            mockRequestsPersistentSource.Received(1)
+                .UpdateNonProcessedRequest(
+                    Arg.Is<DeploymentRequestApiModel>(r => r.Id == 95),
                     Arg.Any<DeploymentRequestStatus>(),
                     Arg.Any<DateTimeOffset>());
         }

--- a/src/Dorc.Monitor.Tests/KafkaStartupFallbackTests.cs
+++ b/src/Dorc.Monitor.Tests/KafkaStartupFallbackTests.cs
@@ -20,13 +20,12 @@ namespace Dorc.Monitor.Tests;
 ///   <item>No Kafka background (IHostedService) registered in fallback mode.</item>
 /// </list>
 ///
-/// <b>Known limitation:</b> <see cref="BuildFallbackRegistrations"/> is a
-/// hand-copy of Program.cs's fallback-branch DI wiring rather than an
-/// invocation of the production code itself; it must be kept in sync with
-/// Program.cs manually, so the FallbackPath_* assertions verify the copy, not
-/// the production path. The gate decision itself, however, IS production code:
-/// <see cref="EvaluateKafkaEnabled"/> calls the shared
-/// <c>KafkaStartupGate.IsKafkaEnabled</c> that both Program.cs files invoke.
+/// Both halves exercise production code: <see cref="EvaluateKafkaEnabled"/>
+/// calls the shared <c>KafkaStartupGate.IsKafkaEnabled</c> that both
+/// Program.cs files invoke, and <see cref="BuildFallbackRegistrations"/> calls
+/// <see cref="DbPollFallbackRegistration.Register"/> — the extracted
+/// else-branch wiring Program.cs itself uses (the previous known limitation,
+/// a hand-copied mirror of the fallback DI wiring, is retired).
 /// </summary>
 [TestClass]
 public class KafkaStartupFallbackTests
@@ -190,24 +189,28 @@ public class KafkaStartupFallbackTests
 
     // ── fallback service registrations ─────────────────────────────────────
 
-    // Builds a ServiceCollection that mirrors Program.cs's fallback branch.
-    // We inspect registrations rather than resolve instances so this test has
-    // no dependency on SignalRDeploymentEventPublisher's full constructor
+    // Builds a ServiceCollection carrying the fallback-mode registrations.
+    // The else-branch wiring comes from the PRODUCTION method
+    // (DbPollFallbackRegistration.Register); only the SignalR publisher
+    // registrations are mirrored here, because in Program.cs they are
+    // unconditional and live OUTSIDE the kafkaEnabled gate. We inspect
+    // registrations rather than resolve instances so this test has no
+    // dependency on SignalRDeploymentEventPublisher's full constructor
     // (which requires IMonitorConfiguration / a live hub URL).
-    private static ServiceCollection BuildFallbackRegistrations()
+    private static ServiceCollection BuildFallbackRegistrations(List<string>? warnings = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
-        // Mirror Program.cs lines 146–177 (fallback branch).
+        // Mirror Program.cs's unconditional SignalR publisher registrations.
         services.AddSingleton<SignalRDeploymentEventPublisher>();
         services.AddSingleton<IDeploymentEventsPublisher>(sp =>
             sp.GetRequiredService<SignalRDeploymentEventPublisher>());
         services.AddSingleton<IFallbackDeploymentEventPublisher>(sp =>
             sp.GetRequiredService<SignalRDeploymentEventPublisher>());
 
-        services.AddSingleton<IDistributedLockService, NoOpDistributedLockService>();
-        services.AddSingleton<IRequestPollSignal, RequestPollSignal>();
+        // Production fallback wiring (Program.cs else-branch).
+        DbPollFallbackRegistration.Register(services, message => warnings?.Add(message));
         return services;
     }
 
@@ -243,6 +246,19 @@ public class KafkaStartupFallbackTests
                 sd.ServiceType == typeof(IRequestPollSignal) &&
                 sd.ImplementationType == typeof(RequestPollSignal)),
             "IRequestPollSignal must be registered in fallback mode (DB poll still runs).");
+    }
+
+    [TestMethod]
+    public void FallbackPath_EmitsSingleReplicaWarning()
+    {
+        // The warning is the only split-brain guard in fallback mode (the NoOp
+        // lock service cannot detect peer replicas), so its emission is a
+        // load-bearing part of the registration path.
+        var warnings = new List<string>();
+        BuildFallbackRegistrations(warnings);
+
+        Assert.HasCount(1, warnings, "Register must emit exactly one warning.");
+        StringAssert.Contains(warnings[0], "EXACTLY ONE Monitor replica");
     }
 
     [TestMethod]

--- a/src/Dorc.Monitor.Tests/MonitorConfigurationTests.cs
+++ b/src/Dorc.Monitor.Tests/MonitorConfigurationTests.cs
@@ -25,13 +25,19 @@ namespace Dorc.Monitor.Tests
         }
 
         [TestMethod]
-        public void RequestProcessingIterationDelay_ParsesValue_AndDefaultsToZeroOnGarbage()
+        public void RequestProcessingIterationDelay_ParsesValue_AndDefaultsTo1000OnGarbageOrAbsent()
         {
-            Assert.AreEqual(2500, Sut(new() { ["AppSettings:requestProcessingIterationDelayMs"] = "2500" })
+            Assert.AreEqual(2500, Sut(new() { ["AppSettings:RequestProcessingIterationDelayMs"] = "2500" })
                 .RequestProcessingIterationDelayMs);
-            // int.TryParse zeroes the out param on failure — the documented-by-
-            // behaviour fallback is 0, not the field initialiser's 1000.
-            Assert.AreEqual(0, Sut(new() { ["AppSettings:requestProcessingIterationDelayMs"] = "not-a-number" })
+            // Absent or unparseable must fall back to 1000ms — the previous
+            // int.TryParse zeroed the out param on failure, yielding a 0ms
+            // busy-spin (with a forced full GC per iteration) whenever the key
+            // was missing or garbage.
+            Assert.AreEqual(1000, Sut().RequestProcessingIterationDelayMs);
+            Assert.AreEqual(1000, Sut(new() { ["AppSettings:RequestProcessingIterationDelayMs"] = "not-a-number" })
+                .RequestProcessingIterationDelayMs);
+            // An explicit 0 is a deliberate operator opt-in and must be honoured.
+            Assert.AreEqual(0, Sut(new() { ["AppSettings:RequestProcessingIterationDelayMs"] = "0" })
                 .RequestProcessingIterationDelayMs);
         }
 

--- a/src/Dorc.Monitor/DbPollFallbackRegistration.cs
+++ b/src/Dorc.Monitor/DbPollFallbackRegistration.cs
@@ -1,0 +1,41 @@
+using Dorc.Core.Events;
+using Dorc.Core.HighAvailability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dorc.Monitor
+{
+    /// <summary>
+    /// DI wiring for the Monitor's Kafka-off (DB-poll) fallback mode — the
+    /// else-branch of Program.cs's <c>kafkaEnabled</c> gate, extracted so the
+    /// unit tests exercise the production registrations instead of a hand-copy
+    /// (UC22). Registers the no-op distributed lock and the in-process poll
+    /// signal; the SignalR publisher registrations are unconditional and stay
+    /// in Program.cs.
+    /// </summary>
+    internal static class DbPollFallbackRegistration
+    {
+        /// <summary>
+        /// Single-replica constraint: with the NoOp lock service every
+        /// environment-lock acquisition short-circuits to success, so a second
+        /// Monitor replica in this mode would deploy concurrently to the same
+        /// environments (split brain). Nothing can detect peer replicas from
+        /// here — the warning is the guard, the runbook is the control.
+        /// </summary>
+        internal const string SingleReplicaWarning =
+            "Kafka disabled - distributed locking is OFF. " +
+            "Run EXACTLY ONE Monitor replica in this mode; a second replica causes concurrent deployments to the same environment.";
+
+        /// <summary>
+        /// Registers the fallback services and emits the single-replica warning
+        /// through <paramref name="warn"/>. Program.cs routes the warning to
+        /// Serilog at Error level so it survives Windows-service hosting
+        /// (Console.WriteLine is discarded without an attached console).
+        /// </summary>
+        internal static void Register(IServiceCollection services, Action<string> warn)
+        {
+            warn(SingleReplicaWarning);
+            services.AddSingleton<IDistributedLockService, NoOpDistributedLockService>();
+            services.AddSingleton<IRequestPollSignal, RequestPollSignal>();
+        }
+    }
+}

--- a/src/Dorc.Monitor/DeploymentRequestStateProcessor.cs
+++ b/src/Dorc.Monitor/DeploymentRequestStateProcessor.cs
@@ -24,7 +24,8 @@ namespace Dorc.Monitor
         private bool disposedValue;
         private ConcurrentDictionary<string, int> environmentRequestIdRunning = new ConcurrentDictionary<string, int>();
         private readonly ConcurrentDictionary<string, DateTime> environmentLockBackoff = new ConcurrentDictionary<string, DateTime>();
-        private static readonly TimeSpan LockBackoffDuration = TimeSpan.FromSeconds(30);
+        // Internal (not private) so the unit tests can pin the backoff window.
+        internal static readonly TimeSpan LockBackoffDuration = TimeSpan.FromSeconds(30);
         private const int EnvironmentLockAcquireTimeoutMs = 300000;
 
         // Test hook: invoked when a fire-and-forget publish task is created.

--- a/src/Dorc.Monitor/MonitorConfiguration.cs
+++ b/src/Dorc.Monitor/MonitorConfiguration.cs
@@ -25,9 +25,12 @@ namespace Dorc.Monitor
         {
             get
             {
-                int delay = 1000;
-                int.TryParse(configurationRoot.GetSection(appSettings)["requestProcessingIterationDelayMs"], out delay);
-                return delay;
+                var delayStr = configurationRoot.GetSection(appSettings)["RequestProcessingIterationDelayMs"];
+                if (int.TryParse(delayStr, out int delay))
+                {
+                    return delay; // explicit values win, including 0 (busy-poll opt-in)
+                }
+                return 1000; // absent or unparseable: default 1s poll cadence
             }
         }
 

--- a/src/Dorc.Monitor/Program.cs
+++ b/src/Dorc.Monitor/Program.cs
@@ -159,18 +159,12 @@ if (kafkaEnabled)
 }
 else
 {
-    // Single-replica constraint: with the NoOp lock service every
-    // environment-lock acquisition short-circuits to success, so a second
-    // Monitor replica in this mode would deploy concurrently to the same
-    // environments (split brain). Nothing can detect peer replicas from
-    // here — the warning is the guard, the runbook is the control. Logged
-    // at Error through Serilog so it survives Windows-service hosting
+    // DB-poll fallback wiring (NoOp lock + in-process poll signal) plus the
+    // single-replica split-brain warning — see DbPollFallbackRegistration.
+    // Logged at Error through Serilog so it survives Windows-service hosting
     // (Console.WriteLine is discarded without an attached console).
-    Log.Error(
-        "Kafka disabled - distributed locking is OFF. " +
-        "Run EXACTLY ONE Monitor replica in this mode; a second replica causes concurrent deployments to the same environment.");
-    builder.Services.AddSingleton<IDistributedLockService, NoOpDistributedLockService>();
-    builder.Services.AddSingleton<Dorc.Core.Events.IRequestPollSignal, Dorc.Core.Events.RequestPollSignal>();
+    DbPollFallbackRegistration.Register(builder.Services,
+        message => Log.Error("{KafkaFallbackWarning}", message));
 }
 
 PersistentSourcesRegistry.Register(builder.Services);

--- a/src/Dorc.Monitor/appsettings.json
+++ b/src/Dorc.Monitor/appsettings.json
@@ -22,6 +22,7 @@
     "SMTPHost": "",
     "IsProduction": "False",
     "Environment": "local",
+    "RequestProcessingIterationDelayMs": "1000",
     "RunnerLogPath": "c:\\Log\\DOrc\\Deploy\\Services\\Requests",
     "ServiceName": "DeploymentActionServiceNonProd",
     "ScriptRoot": "",


### PR DESCRIPTION
Mechanical merge landing the acceptance-review gap-fill commit on the PR #611 branch (same pattern as #723/#761/#762).

- Poll-interval default fixed (0ms busy-spin → 1000ms; explicit values win) and shipped in appsettings.
- User cancel/restart/resume events now wake the Monitor poll loop (event-speed pickup) without reintroducing self-wake.
- Coverage gaps from the requirements review closed: DeploymentEngine backpressure (UC3), single-replica fallback warning via extracted production wiring (UC22), lock-consumer config pins (static membership / session override), 30s backoff constant, paused-mid-queue converse.
- kafka-integration CI path filter now covers Monitor/Core wiring changes.

Suites: 56/150/66/17/77 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDRFc8HVe1mXvdPhxsxKVU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDRFc8HVe1mXvdPhxsxKVU)_