### PR TITLE
Restore visual separation of grid icon buttons

### DIFF
--- a/src/dorc-web/src/components/grid-button-groups/access-control-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/access-control-controls.ts
@@ -19,6 +19,7 @@ export class AccessControlControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/bundle-request-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/bundle-request-controls.ts
@@ -13,6 +13,7 @@ export class BundleRequestControls extends LitElement {
       display: inline-flex;
       align-items: center;
       flex-wrap: nowrap;
+      gap: var(--lumo-space-xs);
     }
     vaadin-button {
       padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/config-value-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/config-value-controls.ts
@@ -31,6 +31,7 @@ export class ConfigValueControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/daemon-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/daemon-controls.ts
@@ -24,6 +24,7 @@ export class DaemonControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/database-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/database-controls.ts
@@ -26,6 +26,7 @@ export class DatabaseControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/database-env-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/database-env-controls.ts
@@ -26,6 +26,7 @@ export class DatabaseEnvControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/edit-comments-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/edit-comments-controls.ts
@@ -28,6 +28,7 @@ export class EditCommentsControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/env-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/env-controls.ts
@@ -28,6 +28,7 @@ export class EnvControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/project-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/project-controls.ts
@@ -173,10 +173,12 @@ export class ProjectControls extends ResponsiveMixin(LitElement) {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         --lumo-button-size: 28px;
-        --lumo-icon-size-m: 26px;
+        --lumo-icon-size-m: 20px;
+        padding: 0;
       }
     `;
   }

--- a/src/dorc-web/src/components/grid-button-groups/request-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/request-controls.ts
@@ -34,6 +34,7 @@ export class RequestControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/server-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/server-controls.ts
@@ -33,6 +33,7 @@ export class ServerControls extends LitElement {
         display: inline-flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
       }
       vaadin-button {
         padding: 0px;

--- a/src/dorc-web/src/components/grid-button-groups/variable-value-controls.ts
+++ b/src/dorc-web/src/components/grid-button-groups/variable-value-controls.ts
@@ -30,6 +30,7 @@ export class VariableValueControls extends LitElement {
         display: flex;
         align-items: center;
         flex-wrap: nowrap;
+        gap: var(--lumo-space-xs);
         width: 100%;
       }
       vaadin-text-field,


### PR DESCRIPTION
Fixes #784

## What

The icon-button rows in grids across DORC render as one continuous grey strip with no visible boundary between buttons, and the projects-page buttons are oblong (40×28) with icons filling them edge-to-edge.

## Why

- The switch of the `grid-button-groups` components to `display: inline-flex` hosts (needed to stop buttons stacking vertically and stretching grid rows) discarded the inter-element whitespace that previously rendered as a ~4px gap between buttons. Lumo buttons have no horizontal margin of their own, so the adjacent identical secondary backgrounds merged into one strip.
- In `project-controls`, the 26px icon inside a 28px button combined with Lumo's icon-theme horizontal padding (7px per side) stretched the buttons to 40×28. It is the only group that didn't zero the padding.

Full analysis in #784.

## Changes

- Add `gap: var(--lumo-space-xs)` to the `:host` flex rule in all 12 components under `src/dorc-web/src/components/grid-button-groups/`.
- `project-controls`: zero the button padding like the other groups and drop `--lumo-icon-size-m` from 26px to 20px so the buttons render square at 28×28.

## Verification

- Rendered `project-controls`, `env-controls`, and `server-controls` in the Vite dev server before/after: buttons are again distinct square pills with 4px gaps, matching the pre-regression look (compared against a checkout of `bd9e7df`).
- `eslint` and `tsc --noEmit` clean.
- `vitest run` (chromium): 12 files, 118 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rUjZZX9frb8JnHhh5WCg1

---
_Generated by [Claude Code](https://claude.ai/code/session_012rUjZZX9frb8JnHhh5WCg1)_