### PR TITLE
fix(ci): unbreak main, restore the NuGet cache, run the full web matrix everywhere

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -97,23 +97,26 @@ critical path.
 
 ### Web Tests (`web-tests` job)
 
-The suite runs under Playwright. Which engines it runs against depends on the
-branch, via the `VITEST_BROWSERS` environment variable read by
-`src/dorc-web/vitest.config.ts`:
+The suite runs under Playwright against **chromium, firefox and webkit, on every
+build, on every branch**. The job runs in parallel with `build`, which takes
+roughly five times as long, so the full matrix costs nothing in wall-clock.
 
-| Ref | Engines |
-| --- | --- |
-| `main`, `develop`, `release/**` | chromium, firefox, webkit |
-| Pull requests and everything else | chromium |
+This was briefly narrowed to chromium on PRs and topic branches. Don't do that
+again without a specific reason: it meant pull requests exercised a different
+configuration from `main`, and the first bug that hit — an `actions/cache` key
+containing a comma, which only the three-engine list produced — passed every PR
+check and broke `main` on merge. A CI configuration that varies by branch cannot
+tell you whether merging is safe.
 
-Running all three engines on every PR meant three browser downloads on any cache
-miss for little extra signal. Locally, `npm test` with `VITEST_BROWSERS` unset
-still runs all three; set it to reproduce a CI run — `VITEST_BROWSERS=chromium
-npm test`.
+`src/dorc-web/vitest.config.ts` still honours a `VITEST_BROWSERS` environment
+variable, for local iteration when you don't want to wait on all three:
 
-The Playwright browser cache is keyed on both the Playwright version and the
-engine list, so a chromium-only cache entry is never reused for a run that needs
-all three.
+```bash
+VITEST_BROWSERS=chromium npm test
+```
+
+CI does not set it. Setting it empty fails loudly rather than silently running
+no tests.
 
 ### NuGet packages are cached
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -115,13 +115,26 @@ The Playwright browser cache is keyed on both the Playwright version and the
 engine list, so a chromium-only cache entry is never reused for a run that needs
 all three.
 
-### NuGet packages are not cached
+### NuGet packages are cached
 
-There is intentionally no `actions/cache` step for `~/.nuget/packages`. Caching it
-on Windows means moving tens of thousands of small files: measured over run
-`30527995114` it cost 1m04s to restore and 10s to save, in order to speed up a
-restore that takes 27s warm. The key also hashed `**/*.csproj`, so any project
-file edit paid the full cost for no hit.
+`~/.nuget/packages` is cached via `actions/cache`. This was removed in #797 on
+the grounds that it cost more than it saved — 1m04s to restore plus 10s to save,
+against a 27s warm restore — and restored immediately afterwards, because the
+measurement that mattered had not been taken: how long an *uncached* restore
+takes on this solution.
+
+| Restore | Wall-clock |
+| --- | --- |
+| Cached (27s restore + 1m04s cache restore + 10s save) | ~1m41s |
+| Uncached (run `30751703601`) | 2m04s |
+| Uncached (run `30794820988`) | 2m41s |
+
+Caching a Windows NuGet folder is genuinely slow, but a cold restore of 124
+packages is slower. Keep the cache.
+
+If this is revisited, the durable improvement is lock files
+(`RestorePackagesWithLockFile`) so the key stops hashing `**/*.csproj` and
+surviving a project-file edit.
 
 ### Profiling the build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,11 +229,20 @@ jobs:
           Write-Host "UpdateVersion.ps1 not found, skipping cmdlet versioning"
         }
       
-    # There is deliberately no actions/cache step for ~/.nuget/packages here.
-    # Caching it on Windows means shuffling tens of thousands of small files:
-    # measured over run 30527995114 it cost 1m04s to restore plus 10s to save,
-    # to speed up a restore that takes 27s warm. The key also hashed **/*.csproj,
-    # so any project-file edit paid that cost for nothing.
+    # #797 removed this cache on the argument that it cost more than it saved:
+    # 1m04s to restore plus 10s to save, against a 27s warm restore. The
+    # measurement that mattered was the one not taken — how long an uncached
+    # restore takes. It is 2m04s (run 30751703601) to 2m41s (run 30794820988),
+    # so removing the cache cost 25-100s per build rather than saving 40s.
+    # Restored on that evidence.
+    - name: Cache NuGet packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
     # Every project in the solution is SDK-style (csproj / wixproj / sqlproj)
     # and there is no packages.config anywhere in the tree, so the `nuget
     # restore` pass that used to run first was pure duplication of the work

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
         Write-Host "Browser matrix: $browsers"
         echo "list=$browsers" >> $env:GITHUB_OUTPUT
         echo "install=$($browsers -replace ',',' ')" >> $env:GITHUB_OUTPUT
+        # actions/cache rejects a key containing a comma, so the cache key gets
+        # its own dash-separated form. Using $browsers directly worked on PRs
+        # (single 'chromium', no comma) and failed the moment main built the
+        # full 'chromium,firefox,webkit' matrix.
+        echo "cachekey=$($browsers -replace ',','-')" >> $env:GITHUB_OUTPUT
 
     # The next three steps assume Windows (pwsh + the Windows cache path).
     # The whole job is windows-latest today; the `if: runner.os == 'Windows'`
@@ -110,7 +115,7 @@ jobs:
       uses: actions/cache@v6
       with:
         path: ~\AppData\Local\ms-playwright
-        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ steps.browsers.outputs.list }}
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ steps.browsers.outputs.cachekey }}
 
     - name: Install Playwright browsers
       if: runner.os == 'Windows' && steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,32 +57,6 @@ jobs:
       working-directory: src/dorc-web
       run: npm ci --loglevel=error
 
-    - name: Select browser matrix
-      id: browsers
-      shell: pwsh
-      run: |
-        # Branches that ship get all three engines; everything else gets
-        # chromium, which keeps PR feedback short and avoids downloading two
-        # extra browser engines on a cache miss.
-        #
-        # Read the ref from the environment rather than interpolating
-        # ${{ github.ref }} into the script body: ref names may contain quotes
-        # and backticks, so the interpolated form is a script-injection sink.
-        $ref = $env:GITHUB_REF
-        if ($ref -eq "refs/heads/main" -or $ref -eq "refs/heads/develop" -or $ref -like "refs/heads/release/*") {
-          $browsers = "chromium,firefox,webkit"
-        } else {
-          $browsers = "chromium"
-        }
-        Write-Host "Browser matrix: $browsers"
-        echo "list=$browsers" >> $env:GITHUB_OUTPUT
-        echo "install=$($browsers -replace ',',' ')" >> $env:GITHUB_OUTPUT
-        # actions/cache rejects a key containing a comma, so the cache key gets
-        # its own dash-separated form. Using $browsers directly worked on PRs
-        # (single 'chromium', no comma) and failed the moment main built the
-        # full 'chromium,firefox,webkit' matrix.
-        echo "cachekey=$($browsers -replace ',','-')" >> $env:GITHUB_OUTPUT
-
     # The next three steps assume Windows (pwsh + the Windows cache path).
     # The whole job is windows-latest today; the `if: runner.os == 'Windows'`
     # guards align them so adding a Linux/macOS matrix entry later is a
@@ -107,26 +81,30 @@ jobs:
         }
         echo "version=$version" >> $env:GITHUB_OUTPUT
 
-    # The browser list is part of the key: a cache populated by a chromium-only
-    # run must not satisfy a run that needs all three engines.
+    # Every engine is installed on every run, so the Playwright version alone
+    # identifies the cache contents. Do not reintroduce a per-branch browser
+    # subset without putting that subset back into the key — a chromium-only
+    # cache entry must never satisfy a run that needs all three.
     - name: Cache Playwright browsers
       id: playwright-cache
       if: runner.os == 'Windows'
       uses: actions/cache@v6
       with:
         path: ~\AppData\Local\ms-playwright
-        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ steps.browsers.outputs.cachekey }}
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
     - name: Install Playwright browsers
       if: runner.os == 'Windows' && steps.playwright-cache.outputs.cache-hit != 'true'
       working-directory: src/dorc-web
-      run: npx playwright install ${{ steps.browsers.outputs.install }}
+      run: npx playwright install chromium firefox webkit
 
+    # VITEST_BROWSERS is deliberately not set: the suite runs its full default
+    # matrix on every build, on every branch. Varying it per branch meant PRs
+    # exercised a different configuration from main, which is precisely how the
+    # comma-in-cache-key bug reached main green.
     - name: Run web tests
       if: runner.os == 'Windows'
       working-directory: src/dorc-web
-      env:
-        VITEST_BROWSERS: ${{ steps.browsers.outputs.list }}
       run: npm test
 
   build:

--- a/src/dorc-web/vitest.config.ts
+++ b/src/dorc-web/vitest.config.ts
@@ -1,11 +1,10 @@
 import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
-// Which engines the suite runs against. All three by default, so a bare
-// `npm test` locally keeps the behaviour it has always had. CI narrows this to
-// chromium on PRs and topic branches — three engines plus their Playwright
-// download is a poor trade for the feedback loop there — and restores the full
-// matrix on develop, main and release/**, which are the branches that ship.
+// Which engines the suite runs against. All three by default — CI does not set
+// VITEST_BROWSERS, so every build on every branch runs the full matrix. The
+// override exists for local iteration (`VITEST_BROWSERS=chromium npm test`)
+// when you do not want to wait on firefox and webkit.
 const BROWSERS = (process.env.VITEST_BROWSERS ?? 'chromium,firefox,webkit')
   .split(',')
   .map(name => name.trim())


### PR DESCRIPTION
Follow-up to #797. **`main` is currently red** — the first commit here fixes that.

## 1. `60c6fb6` — unbreak `main`

The `web-tests` job has failed on every `main` build since #797 merged:

```
##[error]Key Validation Error: playwright-Windows-1.62.0-chromium,firefox,webkit
cannot contain commas.
```

`actions/cache` rejects keys containing commas. #797 keyed the Playwright cache on the browser list so a chromium-only entry couldn't satisfy a three-engine run — but that list is comma-separated.

It passed every PR check and broke on merge because PRs resolved to a single `chromium` (no comma) while `main` built the full `chromium,firefox,webkit` matrix. **The `build` job was unaffected and green throughout** — only `web-tests` failed, at the cache step, skipping everything after it.

## 2. `5c55a3e` — restore the NuGet package cache

#797 removed it, arguing 1m04s to restore plus 10s to save was a bad trade against a 27s warm restore. That compared against the wrong baseline — the cost of an *uncached* restore was never measured. It has been now:

| Restore | Wall-clock |
| --- | --- |
| Cached (27s + 1m04s restore + 10s save) | ~1m41s |
| Uncached — run `30751703601` | 2m04s |
| Uncached — run `30794820988` | 2m41s |

Removing it **cost** 25–100s per build rather than saving 40s, wiping out about half the gain from building in parallel.

## 3. `460cbd6` — run the full browser matrix on every build

#797 narrowed the web suite to chromium on PRs and topic branches. That saved nothing worth having and is the direct cause of item 1: the bug was reachable only from the three-engine list, so no pre-merge run could ever have caught it.

CI that varies by branch can't answer the question CI exists to answer. All three engines now run on every build, on every branch. This costs no wall-clock — `web-tests` runs in parallel with `build`, which takes roughly five times as long — and it's the pre-#797 behaviour, green on `main` for months.

The cache key drops the browser component and returns to keying on the Playwright version alone, removing the comma hazard at its source rather than sanitising it. A comment warns against reintroducing a per-branch subset without putting it back in the key.

## Where the numbers actually landed

#797 was estimated at ~11m40s → ~6m. Measured on `main` (run `30794820988`): **11m42s → 10m11s**. The parallel build delivered — `Build solution` 6m08s → 4m05s, consistent across runs — but the NuGet cache removal ate most of it. With item 2 restored this should land near **8m30s**, a real ~27% rather than the 49% claimed.

## Verification

- `build` job green on `main` at `249663e` — 10m11s, all five artifact groups copied, MSIs uploaded, artifact byte-equivalent to baseline (123,305,980 vs 123,216,915).
- Web suite green locally on chromium: 12 files / 118 tests.
- firefox and webkit could not be exercised locally — this Linux container lacks their system libraries and firefox times out under contention. The three-engine run rests on pre-#797 CI evidence (run `30527995114`, all three engines, 33s), not a local pass.

## Needs a maintainer

**`web-tests` is not a required check in branch protection.** It has been failing on `main` since 07:45 today without blocking anything. Worth adding alongside `build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY39MK8CWjmqWNcBjKzSD6)_