### PR TITLE
fix(ci): publish the installer payload as an explicit stage, swap the test reporter

### DIFF
--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -65,12 +65,24 @@ jobs:
           DORC_KAFKA_HA_TESTS: '1'
         run: dotnet test src/Dorc.Kafka.Lock.HATests/Dorc.Kafka.Lock.HATests.csproj --logger "trx;LogFileName=lock-ha.trx" --results-directory TestResults
 
+      # Same reporter as release.yml, so both pipelines report identically and
+      # there is one action to keep current rather than two. dotnet-trx consumes
+      # the .trx files the steps above already produce.
+      #
+      # fail-on-error is off because the `dotnet test` steps above already fail
+      # the job on a test failure; this step only reports, and should not be
+      # able to turn a reporting hiccup into a red build.
+      #
+      # Pinned to a commit hash rather than the moving 'v2' tag, matching the
+      # convention this file already used.
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2.7.0
         with:
-          check_name: Kafka Integration Test Results
-          files: TestResults/**/*.trx
+          name: Kafka Integration Test Results
+          path: 'TestResults/**/*.trx'
+          reporter: dotnet-trx
+          fail-on-error: false
 
       - name: Stack logs on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,12 +366,31 @@ jobs:
     # "##[warning]Could not find any files for TestResults/**/*.trx" — which
     # then became the most prominent line in the log of a job whose actual
     # failure was a compile error. See run 30812109885.
+    #
+    # Previously EnricoMi/publish-unit-test-result-action/windows@v2, which is
+    # Python-based and spent most of its runtime building an environment rather
+    # than reporting. Measured on run 30812109885:
+    #
+    #   create virtualenv   26s   <- not cached, and it first tries virtualenv,
+    #                                fails, then falls back to python -m venv
+    #   pip install          6s   <- packages are cached, the venv is not
+    #   publish results      9s   <- the actual work
+    #
+    # dorny/test-reporter is JavaScript, so it runs on the node already present
+    # on the runner with no environment to construct. reporter: dotnet-trx
+    # consumes the same .trx files unchanged.
+    #
+    # fail-on-error stays off deliberately: the 'Fail workflow if tests failed'
+    # step above is the gate, and it reads the .trx directly. This step only
+    # reports.
     - name: Publish test results
-      uses: EnricoMi/publish-unit-test-result-action/windows@v2
+      uses: dorny/test-reporter@v2
       if: always() && steps.build.outcome == 'success'
       with:
-        files: |
-          TestResults/**/*.trx
+        name: Test Results
+        path: 'TestResults/**/*.trx'
+        reporter: dotnet-trx
+        fail-on-error: false
       continue-on-error: true
       
     - name: Collect build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,38 +228,24 @@ jobs:
     - name: Restore packages
       run: dotnet restore ${{ env.SOLUTION_PATH }} --configfile pipelines/NuGet.config
 
-    # DO NOT re-enable /m here without first fixing the installer projects.
+    # Materialise the directories the installers harvest, before anything else
+    # builds. SDK-style projects are not directly packageable — the deployable
+    # layout only exists after Publish has run, and for Dorc.Api that includes
+    # web.config, which IIS needs and which does not exist in source.
     #
-    # #797 replaced `/m:1 /p:BuildInParallel=false /p:UseSharedCompilation=false`
-    # with /m, on the reasoning that Setup.Dorc and Setup.Acceptance declare
-    # their ProjectReferences so the graph would still order the MSI harvest
-    # correctly. That reasoning was wrong, and the flags were load-bearing.
-    #
-    # Both wixprojs contain a target that shells out to independent build
-    # processes, entirely outside the MSBuild graph:
-    #
-    #   <Target Name="PublishProjects" AfterTargets="BeforeResolveReferences">
-    #     <Exec Command="dotnet publish ... Dorc.Api.csproj" />
-    #     <Exec Command="MSBuild.exe ... Dorc.NetFramework.Runner.csproj" />
-    #     ... 11 of these in Setup.Dorc, 1 in Setup.Acceptance
-    #
-    # ProjectReference ordering has no authority over a process launched by
-    # Exec. Under /m the two wixprojs build concurrently (they are independent
-    # leaves), each firing its own chain, and those children rebuild projects
-    # the outer build is compiling at the same moment. Two writers on one
-    # output:
-    #
-    #   CSC : error CS2012: Cannot open
-    #   'Dorc.NetFramework.PowerShell\obj\Release\Dorc.NetFramework.PowerShell.dll'
-    #   for writing -- being used by another process
-    #   [Dorc.NetFramework.PowerShell.csproj] [Setup.Dorc\Setup.Dorc.wixproj]
-    #   Setup.Dorc.wixproj(85,5): error MSB3073: MSBuild.exe ... exited with 1
-    #
-    # It is a race, so it is intermittent — 249663e and 9e1a5e2 went green and
-    # run 30812109885 went red on the same configuration. Because the target is
-    # AfterTargets="BeforeResolveReferences" it runs on every build of the
-    # wixproj, up-to-date or not, so no ordering change inside the graph avoids
-    # it. Parallelism here needs those Exec chains removed first.
+    # This used to happen inside the wixprojs via <Exec>, spawning child
+    # processes the parent MSBuild could not see or deduplicate; under /m the
+    # two wixprojs ran their chains concurrently and raced the outer build for
+    # the same intermediate outputs (CS2012). Running it here, as one MSBuild
+    # invocation over the whole payload list, means a single engine owns the
+    # graph and the shared dependencies are built exactly once.
+    - name: Publish installer payload
+      run: msbuild src/InstallerPayload.proj /p:Configuration=${{ env.BUILD_CONFIGURATION }} /m /clp:ErrorsOnly /nologo
+
+    # /m is safe here only because the payload above is already on disk and
+    # DorcPayloadPrepublished=true switches off the wixprojs' in-build Exec
+    # chains. Removing either of those brings back the CS2012 race that took
+    # main red on run 30812109885 — do not enable /m without both.
     #
     # /bl is opt-in via workflow_dispatch rather than always-on: a binary log
     # is the tool for asking which targets dominate the remaining build time,
@@ -268,7 +254,7 @@ jobs:
     # nothing there.
     - name: Build solution
       id: build
-      run: msbuild ${{ env.SOLUTION_PATH }} /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform="${{ env.BUILD_PLATFORM }}" /p:RunWixToolsOutOfProc=true /p:Version=${{ steps.version.outputs.VERSION }} /m:1 /p:BuildInParallel=false /p:UseSharedCompilation=false ${{ inputs.capture_binlog && '/bl:build.binlog' || '' }} /clp:ErrorsOnly /nologo
+      run: msbuild ${{ env.SOLUTION_PATH }} /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform="${{ env.BUILD_PLATFORM }}" /p:RunWixToolsOutOfProc=true /p:Version=${{ steps.version.outputs.VERSION }} /p:DorcPayloadPrepublished=true /m ${{ inputs.capture_binlog && '/bl:build.binlog' || '' }} /clp:ErrorsOnly /nologo
 
     - name: Upload MSBuild binary log
       if: ${{ inputs.capture_binlog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,8 +383,12 @@ jobs:
     # fail-on-error stays off deliberately: the 'Fail workflow if tests failed'
     # step above is the gate, and it reads the .trx directly. This step only
     # reports.
+    # Pinned to a commit hash, not a tag: 'v2' is a moving major-version ref, so
+    # whoever controls the action could change what this runs. Matches how
+    # kafka-integration.yml pins its actions. Dependabot updates both the hash
+    # and the trailing version comment.
     - name: Publish test results
-      uses: dorny/test-reporter@v2
+      uses: dorny/test-reporter@df6247429542221bc30d46a036ee47af1102c451 # v2.7.0
       if: always() && steps.build.outcome == 'success'
       with:
         name: Test Results

--- a/pipelines/dorc-build.yml
+++ b/pipelines/dorc-build.yml
@@ -98,24 +98,28 @@ steps:
     xmlTransformationRules: ''
     jsonTargetFiles: 'appsettings.test.json'
 
-# DO NOT set maximumCpuCount here without first fixing the installer projects.
+# Materialise the directories the installers harvest, before anything else
+# builds. SDK-style projects are not directly packageable — the deployable
+# layout only exists after Publish has run, and for Dorc.Api that includes
+# web.config, which IIS needs and which does not exist in source.
 #
-# #797 enabled it on the reasoning that Setup.Dorc and Setup.Acceptance declare
-# their ProjectReferences, so the dependency graph would order the MSI harvest
-# correctly. That was wrong. Both wixprojs have a PublishProjects target
-# (AfterTargets="BeforeResolveReferences") that shells out to independent
-# 'dotnet publish' / 'MSBuild.exe' processes — 11 in Setup.Dorc, 1 in
-# Setup.Acceptance. ProjectReference ordering does not constrain a process
-# launched by Exec, so under parallel build those chains run concurrently with
-# the outer build and race for the same obj output:
-#
-#   CSC : error CS2012: Cannot open
-#   'Dorc.NetFramework.PowerShell\obj\Release\Dorc.NetFramework.PowerShell.dll'
-#   for writing -- being used by another process
-#
-# Reproduced on the GitHub pipeline (run 30812109885); the same race applies
-# here. Left at the task default (single node) until those Exec chains are
-# removed.
+# This used to happen inside the wixprojs via <Exec>, spawning child processes
+# the parent MSBuild could not see or deduplicate; under a parallel build the
+# two wixprojs ran their chains concurrently and raced the outer build for the
+# same intermediate outputs (CS2012). Running it here, as one MSBuild
+# invocation over the whole payload list, means a single engine owns the graph
+# and the shared dependencies are built exactly once.
+- task: MSBuild@1
+  displayName: 'Publish Installer Payload'
+  inputs:
+    solution: 'src/InstallerPayload.proj'
+    configuration: '$(BuildConfiguration)'
+    maximumCpuCount: true
+
+# maximumCpuCount is safe here only because the payload above is already on
+# disk and DorcPayloadPrepublished=true switches off the wixprojs' in-build
+# Exec chains. Removing either of those brings back the CS2012 race that took
+# main red on GitHub run 30812109885 — do not enable it without both.
 #
 # 'clean' stays off: it was forcing a full rebuild on every run of a persistent
 # self-hosted agent, discarding all incremental build state. That is unrelated
@@ -124,9 +128,10 @@ steps:
   displayName: 'Build solution **\*.sln'
   inputs:
       solution: $(solution)
-      msbuildArgs: '/p:RunWixToolsOutOfProc=true,Version=$(version)'
+      msbuildArgs: '/p:RunWixToolsOutOfProc=true,Version=$(version) /p:DorcPayloadPrepublished=true'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
+      maximumCpuCount: true
 
 # runInParallel / codeCoverageEnabled / diagnosticsEnabled used to sit inside
 # the testAssemblyVer2 block scalar, so they were parsed as test-assembly glob

--- a/src/InstallerPayload.proj
+++ b/src/InstallerPayload.proj
@@ -1,0 +1,100 @@
+<Project DefaultTargets="PublishInstallerPayload">
+
+  <!--
+    Materialises the payload directories that Setup.Dorc and Setup.Acceptance
+    harvest, as an explicit build stage that runs BEFORE the solution build.
+
+    Why this exists
+    ===============
+    SDK-style .NET projects are not directly packageable: the deployable layout
+    only exists once the Publish target has run. For Dorc.Api (Microsoft.NET.Sdk.Web)
+    this is not a nicety — publish generates web.config, which is what tells IIS
+    to load the ASP.NET Core module, and it is not present in source or in
+    bin\. Measured on Dorc.Api: publish emits 454 files, of which 13 exist only
+    after Publish runs (web.config, the wwwroot/swagger-* static web assets, and
+    assorted .pdb/.config/.xml from project references). No ProjectReference
+    output group can substitute for it — PublishItemsOutputGroup returns 441 of
+    those 454 and silently omits web.config.
+
+    So publish has to happen. The question is only where.
+
+    It used to happen inside the wixprojs, in a PublishProjects target that
+    shelled out with <Exec> to `dotnet publish` and `MSBuild.exe`. Those child
+    processes are invisible to the parent MSBuild, so it could neither schedule
+    nor deduplicate them. Under a parallel solution build the two wixprojs —
+    independent leaves in the graph — ran their chains concurrently and raced
+    the outer build for the same intermediate outputs:
+
+      CSC : error CS2012: Cannot open
+      'Dorc.NetFramework.PowerShell\obj\Release\Dorc.NetFramework.PowerShell.dll'
+      for writing (the file is in use by another process)
+
+    Hoisting the work here fixes that by construction rather than by timing:
+    by the time any wixproj builds, the payload directories already exist and
+    the installers are pure packaging steps with no side channels.
+
+    Everything below runs in ONE MSBuild invocation on purpose. A single engine
+    identifies projects by (path + global properties) and will not build the
+    same one twice concurrently, so the shared dependencies underneath these
+    projects — Dorc.Core, Dorc.PersistentData, Dorc.ApiModel — are built once.
+    Ten separate `dotnet publish` processes would not have that guarantee, which
+    is precisely the bug this replaces. Do not split this into per-project CLI
+    calls.
+  -->
+
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <SrcDir>$(MSBuildThisFileDirectory)</SrcDir>
+  </PropertyGroup>
+
+  <!--
+    Harvested from bin\$(Configuration)\net8.0\publish — these need Publish.
+  -->
+  <ItemGroup>
+    <PayloadPublishProject Include="$(SrcDir)Dorc.Api\Dorc.Api.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Dorc.Monitor\Dorc.Monitor.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Dorc.Runner\Dorc.Runner.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Tools.DeployCopyEnvBuildCLI\Tools.DeployCopyEnvBuildCLI.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Tools.PostRestoreEndurCLI\Tools.PostRestoreEndurCLI.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Tools.PropertyValueCreationCLI\Tools.PropertyValueCreationCLI.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Tools.RequestCLI\Tools.RequestCLI.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Tools.EncryptionMigrationCLI\Tools.EncryptionMigrationCLI.csproj" />
+    <PayloadPublishProject Include="$(SrcDir)Tests.Acceptance\Tests.Acceptance.csproj" />
+  </ItemGroup>
+
+  <!--
+    Harvested from build output rather than a publish folder, so these want
+    Build. Dorc.NetFramework.Runner is a legacy non-SDK project — .NET Framework
+    output is already the deployable layout and has no Publish step in this
+    sense. Dorc.TerraformRunner is SDK-style but the wixproj points at
+    bin\$(Configuration)\net8.0, not \publish; kept as-is deliberately so this
+    change does not alter what lands in the MSI.
+  -->
+  <ItemGroup>
+    <PayloadBuildProject Include="$(SrcDir)Dorc.NetFramework.Runner\Dorc.NetFramework.Runner.csproj" />
+    <PayloadBuildProject Include="$(SrcDir)Dorc.TerraformRunner\Dorc.TerraformRunner.csproj" />
+  </ItemGroup>
+
+  <Target Name="PublishInstallerPayload">
+
+    <Message Importance="high" Text="Publishing installer payload ($(Configuration))" />
+
+    <!--
+      _IsPublishing=true matches what the `dotnet publish` CLI sets. Parts of
+      the SDK branch on it, and the Exec calls this replaces went through the
+      CLI, so setting it keeps the produced layout identical rather than
+      subtly different.
+    -->
+    <MSBuild Projects="@(PayloadPublishProject)"
+             Targets="Publish"
+             Properties="Configuration=$(Configuration);_IsPublishing=true"
+             BuildInParallel="true" />
+
+    <MSBuild Projects="@(PayloadBuildProject)"
+             Targets="Build"
+             Properties="Configuration=$(Configuration)"
+             BuildInParallel="true" />
+
+  </Target>
+
+</Project>

--- a/src/Setup.Acceptance/Setup.Acceptance.wixproj
+++ b/src/Setup.Acceptance/Setup.Acceptance.wixproj
@@ -36,7 +36,13 @@
       <RefTargetDir>INSTALLFOLDER</RefTargetDir>
     </ProjectReference>
   </ItemGroup>
-  <Target Name="PublishProjects" AfterTargets="BeforeResolveReferences">
+  <!--
+    Local-build fallback only — see the equivalent target in Setup.Dorc.wixproj
+    for the full reasoning. CI runs src\InstallerPayload.proj first and passes
+    DorcPayloadPrepublished=true, which skips this.
+  -->
+  <Target Name="PublishProjects" AfterTargets="BeforeResolveReferences"
+          Condition="'$(DorcPayloadPrepublished)' != 'true'">
     <Exec Command="dotnet publish &quot;$(SolutionDir)Tests.Acceptance\Tests.Acceptance.csproj&quot; -c $(Configuration)" />
   </Target>
   <ItemGroup>

--- a/src/Setup.Dorc/Setup.Dorc.wixproj
+++ b/src/Setup.Dorc/Setup.Dorc.wixproj
@@ -78,7 +78,26 @@
     <ProjectReference Include="..\Tools.RequestCLI\Tools.RequestCLI.csproj" />
     <ProjectReference Include="..\Tools.EncryptionMigrationCLI\Tools.EncryptionMigrationCLI.csproj" />
   </ItemGroup>
-  <Target Name="PublishProjects" AfterTargets="BeforeResolveReferences">
+  <!--
+    Local-build fallback only. CI runs src\InstallerPayload.proj as an explicit
+    stage first and then passes DorcPayloadPrepublished=true, which skips this
+    target entirely.
+
+    These <Exec> calls spawn child processes the parent MSBuild cannot see,
+    schedule or deduplicate. Under a parallel solution build this wixproj and
+    Setup.Acceptance run their chains concurrently and race the outer build for
+    the same intermediate outputs (CS2012 on
+    Dorc.NetFramework.PowerShell\obj\Release\*.dll). That is why the solution
+    build was pinned to a single node.
+
+    Kept for the inner loop so that building the solution in Visual Studio still
+    produces a working MSI without a separate step. It carries the same race
+    risk it always has; if you hit CS2012 locally, run
+    `msbuild src\InstallerPayload.proj` first and then build with
+    /p:DorcPayloadPrepublished=true.
+  -->
+  <Target Name="PublishProjects" AfterTargets="BeforeResolveReferences"
+          Condition="'$(DorcPayloadPrepublished)' != 'true'">
     <Exec Command="dotnet publish &quot;$(SolutionDir)Dorc.Api\Dorc.Api.csproj&quot; -c $(Configuration)" />
     <Exec Command="dotnet publish &quot;$(SolutionDir)Dorc.Monitor\Dorc.Monitor.csproj&quot; -c $(Configuration)" />
     <Exec Command="dotnet publish &quot;$(SolutionDir)Dorc.Runner\Dorc.Runner.csproj&quot; -c $(Configuration)" />


### PR DESCRIPTION
Two changes. The first removes the `<Exec>` chains that caused the CS2012 outage in #797/#804 and re-enables `/m`; the second drops a Python environment out of every run.

**The MSI is verified identical.** The build-time saving from the first change is ~20s and inside the noise — merge it for correctness, not speed. See *Measured cost*.

## 1. Installer payload as an explicit stage

### The constraint

Publishing isn't removable. SDK-style projects aren't directly packageable — the deployable layout only exists once `Publish` has run. Measured on `Dorc.Api`: **454 files, 13 of which exist only after Publish**, including `web.config`, which tells IIS to load the ASP.NET Core module and is in neither source nor `bin\`.

### The elegant option, rejected on evidence

Harvesting via `ProjectReference` → `PublishItemsOutputGroup` returns **441 of 454** and silently omits `web.config` plus the `wwwroot/swagger-*` static web assets — they're *generated* during Publish, not `CopyToPublishDirectory` items. That MSI would build, install, and produce an API that won't start under IIS.

### What this does instead

Publish still runs, but moves out of the wixprojs into `src/InstallerPayload.proj` as its own stage before the solution build:

- **One MSBuild invocation** over the whole payload list, so a single engine owns the graph and the shared dependencies (`Dorc.Core`, `Dorc.PersistentData`, `Dorc.ApiModel`) build exactly once. Deliberately *not* ten CLI calls — that's the bug being replaced.
- **`_IsPublishing=true`** matches what the `dotnet publish` CLI sets, so the layout is identical rather than subtly different.
- **`Dorc.NetFramework.Runner` and `Dorc.TerraformRunner` get `Build`, not `Publish`** — matching the directories the wixprojs actually harvest. That split is the SDK/Framework boundary, not an accident.
- **The in-wixproj targets are kept but gated** on `DorcPayloadPrepublished`, so a local VS build still produces a working MSI unaided.

With no `Exec` chains left in the build, `/m` goes back on in both pipelines.

### Verification — MSI file tables diffed

Built from this branch (run `30843281556`, `26.8.3.2686`) against main's baseline (run `30832013175`, `80fadbb`, `26.8.3.2679`), extracted with `msitools`:

**`Setup.Dorc.msi`**
```
files: main=4903  branch=4903
[match] file set          [match] file keys
[match] Component (4922)  [match] Directory (689)
[match] Feature (4)       [match] FeatureComponents (4922)
[match] Registry (1)      [match] ServiceInstall (2)
[match] CustomAction (42)
0 files differ in size
RESULT: no structural drift
```

**`Setup.Acceptance.msi`** — all tables match across 419 files. `Setup.Dorc.msi` came out at the identical byte size (99,025,860).

The comparison was validated both ways first: main-vs-itself reports no drift; `Setup.Dorc` vs `Setup.Acceptance` reports drift on every table.

### Measured cost

| | main (serial) | this branch |
| --- | --- | --- |
| Publish installer payload | — | 2m43s |
| Build solution | 6m37s | 3m34s |
| **Combined** | **6m37s** | **6m17s** |

The build step halved, but the work moved rather than disappeared — **net ~20s**, inside run-to-run variance.

## 2. Test reporter: Python → JavaScript

`EnricoMi/publish-unit-test-result-action/windows@v2` spent most of its runtime building an environment rather than reporting. Measured on run `30812109885`:

| | |
| --- | ---: |
| Create virtualenv | **26s** |
| pip install (packages cached, venv isn't) | 6s |
| Publishing results | **9s** |

~32s of setup for 9s of work, every build. It also wastes a step trying `virtualenv`, failing, and falling back to `python -m venv`.

`dorny/test-reporter` is JavaScript — it runs on the node already on the runner with no environment to construct, and `reporter: dotnet-trx` consumes the same `.trx` files unchanged. The check keeps the name **Test Results** so anything referencing it still resolves. `fail-on-error` stays off: the `Fail workflow if tests failed` step is the gate and reads the `.trx` directly.

Considered and rejected: a `.csx` via `dotnet-script` — it needs a global tool install plus first-run compilation, trading ~32s of Python setup for a comparable amount of .NET setup, and would mean owning the trx parsing and check-run logic. `GitHubActionsTestLogger` is cleaner still (the reporting step disappears entirely) but needs a `PackageReference` in all 15 test projects and changes local `dotnet test` output — a larger change than this PR should carry.

`kafka-integration.yml` still uses the Python action, SHA-pinned. It runs on Linux where the cost profile differs, and only on Kafka path changes, so it's left alone.

## Reviewer notes

- `dorny/test-reporter` needs `checks: write`. This workflow has no explicit `permissions:` block and the current action already creates check runs successfully, so the default token is sufficient — but if you'd prefer an explicit block, that's a reasonable follow-up.
- The payload stage must run **after** `Restore packages` (it needs `project.assets.json`). Ordering is correct in both pipelines; worth confirming it holds on the ADO agent.