### PR TITLE
S-014: withhold DOrc's own operating credentials from script scope

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -41,7 +41,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-011 | Validate source URLs at the write path | SD-9, W-11, W-16, W-5a | **DONE** — unenforced until configured, see the step |
 | S-012 | Bind source credentials to validated hosts | SD-9, W-11, W-16, SC-05b | **DONE** — partly inert until S-011 is configured |
 | ⚙ S-013 | Migrate the three `DORC_NonProdDeployPassword` consumers | SD-3a precondition | **U-12 CLOSED** |
-| S-014 | Denylist the operator-only secret keys | SD-3a, W-4, SC-03 | S-006, S-013 |
+| S-014 | Classify config values: reserved-key denylist | SD-3a, W-4, SC-03 | **DONE for the three zero-consumer keys**; the rest still gated on S-013 |
 | S-014a | Restrict `CanReadSecrets` to service principals | W-19 | Usage decision (see step) |
 | ⚙ S-015 | Rotate the deployment credentials | SD-3, W-4 | **S-004 and S-014** |
 | ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | S-010 |
@@ -300,6 +300,16 @@ One of the three sits in the production script folder and consumes the *non-prod
 **Dependencies.** S-006 (or same release), S-013, U-12.
 
 **Verification intent.** No denylisted key appears in the serialized script group for any environment, asserted as an invariant over the classified set rather than a fixed list. Username keys remain present. The scripts migrated in S-013 continue to deploy. Coverage sits at script-group serialization and at variable assignment in the runner, not only at dispatch.
+
+**Delivered against the evidence, which does not permit the step as originally written.** "Password and secret keys are denylisted unconditionally, the list derived by enumerating secure configuration values" would withhold `DeploymentServiceAccountPassword` — roughly eighty call sites, and the mechanism by which scripts reach target servers at all — along with `ProgetAccountPassword` and `DorcCliSecret`. That is not a denylist, it is an outage. U-12's scan is what makes the difference, and it reversed this half of the design.
+
+So the withheld set is the three keys the scan showed have **zero** consumers: `DORC_ProdDeployPassword`, `DORC_WebDeployPassword`, `DorcApiAccessPassword`. Those are a drop-in, and they include the credential behind the live incident. The remaining secure keys stay published until S-013 migrates their consumers; the list is configurable so that migration extends it without a code change.
+
+**The derivation survives as reporting rather than as enforcement.** Enumerating secure values and subtracting the withheld set gives the set still reaching script scope, which the Monitor logs on every deployment. That keeps S-013's backlog measured against the estate rather than against a list in code, and surfaces a secure value added after this was written — without that derivation being able to break a deployment.
+
+**Two gates, as required.** Configuration values are excluded where they become properties, and the script group is filtered again as it is assembled. The second is not redundant: a property reaching the set by another route — an environment property, or a request-supplied value bearing the same name — would otherwise carry an operating credential across the process boundary into a Runner.
+
+**Not closed by this step:** W-4 remains open for the four secure keys that are still published, and S-015's rotation still depends on S-013 completing first.
 
 ### S-014a — Restrict `CanReadSecrets` to service principals
 

--- a/src/Dorc.Monitor.Tests/PendingRequestProcessorStopOnFailureTests.cs
+++ b/src/Dorc.Monitor.Tests/PendingRequestProcessorStopOnFailureTests.cs
@@ -1,10 +1,11 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core;
 using Dorc.Core.Events;
 using Dorc.Core.Interfaces;
 using Dorc.Core.VariableResolution;
 using Dorc.Monitor.RequestProcessors;
+using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -84,7 +85,8 @@ namespace Dorc.Monitor.Tests
                 mockConfigValuesPersistentSource,
                 mockPropertyEvaluator,
                 mockEventsPublisher,
-                mockGitHubArtifactDownloader);
+                mockGitHubArtifactDownloader,
+                Substitute.For<IScriptScopeConfigValues>());
         }
 
         private static RequestToProcessDto CreateRequest(List<ComponentApiModel> components)

--- a/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
@@ -1,8 +1,9 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core.Configuration;
 using Dorc.Monitor;
 using Dorc.Monitor.Pipes;
+using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -33,6 +34,7 @@ namespace Dorc.Monitor.Tests
         private IScriptGroupPipeServer _pipeServer = null!;
         private IConfigValuesPersistentSource _configValues = null!;
         private IConfigurationSettings _configurationSettings = null!;
+        private IScriptScopeConfigValues _scriptScopeConfigValues = null!;
 
         [TestInitialize]
         public void Setup()
@@ -46,6 +48,7 @@ namespace Dorc.Monitor.Tests
             _configValues.GetConfigValue("DORC_NonProdDeployPassword").Returns("nonprod-password");
 
             _configurationSettings = Substitute.For<IConfigurationSettings>();
+            _scriptScopeConfigValues = Substitute.For<IScriptScopeConfigValues>();
             _configurationSettings.GetConfigurationDomainNameIntra().Returns(Domain);
         }
 
@@ -56,7 +59,8 @@ namespace Dorc.Monitor.Tests
                 Substitute.For<ILogger<ScriptDispatcher>>(),
                 _pipeServer,
                 _configurationSettings,
-                Substitute.For<IRequestsPersistentSource>());
+                Substitute.For<IRequestsPersistentSource>(),
+                _scriptScopeConfigValues);
 
         /// <summary>
         /// Dispatch is driven to the point where the Runner's security context is built and no
@@ -195,6 +199,71 @@ namespace Dorc.Monitor.Tests
         public void RefusesToNameNoAccountAtAll(string? userName)
         {
             Assert.ThrowsExactly<ArgumentException>(() => new ScriptGroupReaderIdentity("CORP", userName!));
+        }
+    }
+    /// <summary>
+    /// The withheld keys are already excluded where configuration values become properties.
+    /// This is the second gate: the script group is the artefact that crosses the process
+    /// boundary into a Runner, so the invariant has to hold there rather than be assumed to
+    /// have held upstream. A property reaching the set by another route - an environment
+    /// property, or a request-supplied value bearing the same name - would otherwise carry
+    /// DOrc's own operating credential into script scope after all.
+    /// </summary>
+    [TestClass]
+    public class WithheldKeysAreNotDispatchedTests
+    {
+        private const string Withheld = "DORC_ProdDeployPassword";
+
+        [TestMethod]
+        public void TheDispatchedScriptGroupCarriesNoWithheldKey()
+        {
+            var pipeServer = Substitute.For<IScriptGroupPipeServer>();
+
+            var configValues = Substitute.For<IConfigValuesPersistentSource>();
+            configValues.GetConfigValue("DORC_ProdDeployUsername").Returns("svc-dorc");
+            configValues.GetConfigValue("DORC_ProdDeployPassword").Returns("password");
+
+            var settings = Substitute.For<IConfigurationSettings>();
+            settings.GetConfigurationDomainNameIntra().Returns(string.Empty);
+
+            var scopeValues = Substitute.For<IScriptScopeConfigValues>();
+            scopeValues.IsWithheld(Withheld).Returns(true);
+
+            var dispatcher = new ScriptDispatcher(
+                Substitute.For<IDeploymentRequestProcessesPersistentSource>(),
+                configValues,
+                Substitute.For<ILogger<ScriptDispatcher>>(),
+                pipeServer,
+                settings,
+                Substitute.For<IRequestsPersistentSource>(),
+                scopeValues);
+
+            var properties = new Dictionary<string, VariableValue>
+            {
+                [Withheld] = new() { Value = "the-credential", Type = typeof(string) },
+                ["EnvironmentName"] = new() { Value = "SOME-ENV", Type = typeof(string) }
+            };
+
+            // Fails once it reaches the security context, which a test host cannot build. The
+            // script group has been published by then, which is what is under test.
+            Assert.ThrowsExactly<Exception>(() => dispatcher.Dispatch(
+                @"\\host\share\Scripts",
+                new ScriptApiModel { Path = "Deploy.ps1", PowerShellVersionNumber = "7.4" },
+                properties,
+                requestId: 42,
+                deploymentRequestId: 42,
+                isProduction: true,
+                environmentName: "SOME-ENV",
+                new StringBuilder(),
+                CancellationToken.None));
+
+            pipeServer.Received(1).Start(
+                Arg.Any<string>(),
+                Arg.Is<ScriptGroup>(group =>
+                    !group.CommonProperties.ContainsKey(Withheld)
+                    && group.CommonProperties.ContainsKey("EnvironmentName")),
+                Arg.Any<ScriptGroupReaderIdentity>(),
+                Arg.Any<CancellationToken>());
         }
     }
 }

--- a/src/Dorc.Monitor.Tests/ScriptScopeConfigValuesTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptScopeConfigValuesTests.cs
@@ -1,0 +1,139 @@
+using Dorc.ApiModel;
+using Dorc.PersistentData.Security;
+using Microsoft.Extensions.Configuration;
+
+namespace Dorc.Monitor.Tests
+{
+    /// <summary>
+    /// Every secure configuration value is decrypted and injected into every deployment whose
+    /// production flag matches, with no exclusion for the credentials DOrc itself needs to
+    /// operate. An estate inventory found the production deployment password reaching all 1,083
+    /// non-production environments — the lowest-trust population, and the easiest place to land
+    /// a component that reads it.
+    ///
+    /// The estate's secure keys are two classes, and that is the whole difficulty. A completed
+    /// production share scan found three with zero consumers and three that scripts genuinely
+    /// depend on — one of which is how scripts reach target servers at all, in roughly eighty
+    /// call sites. Withholding "every secure value" would close the weakness and break the
+    /// estate, so the withheld set is the evidenced three, and what remains published is
+    /// reported rather than assumed.
+    /// </summary>
+    [TestClass]
+    public class ScriptScopeConfigValuesTests
+    {
+        private static ScriptScopeConfigValues Default() =>
+            Build(new Dictionary<string, string?>());
+
+        private static ScriptScopeConfigValues Build(Dictionary<string, string?> settings) =>
+            new(new ConfigurationBuilder().AddInMemoryCollection(settings).Build());
+
+        /// <summary>
+        /// The three the scan showed no script consumes. Withholding them breaks nothing, which
+        /// is why they are the default rather than a setting someone has to discover.
+        /// </summary>
+        [TestMethod]
+        [DataRow("DORC_ProdDeployPassword")]
+        [DataRow("DORC_WebDeployPassword")]
+        [DataRow("DorcApiAccessPassword")]
+        public void WithholdsTheOperatorOnlyKeysByDefault(string key)
+        {
+            Assert.IsTrue(Default().IsWithheld(key));
+        }
+
+        /// <summary>
+        /// The three scripts genuinely depend on. Withholding these would break roughly ninety
+        /// call sites, so they are published until their consumers are migrated.
+        /// </summary>
+        [TestMethod]
+        [DataRow("DeploymentServiceAccountPassword")]
+        [DataRow("ProgetAccountPassword")]
+        [DataRow("DorcCliSecret")]
+        public void DoesNotWithholdTheKeysScriptsDependOn(string key)
+        {
+            Assert.IsFalse(Default().IsWithheld(key),
+                $"'{key}' has confirmed consumers; withholding it breaks deployments.");
+        }
+
+        /// <summary>
+        /// Usernames are identities rather than credentials — already visible in target-server
+        /// access control lists, process listings and event logs — and scripts legitimately
+        /// consume them to grant logon rights.
+        /// </summary>
+        [TestMethod]
+        [DataRow("DORC_ProdDeployUsername")]
+        [DataRow("DORC_NonProdDeployUsername")]
+        public void DoesNotWithholdUsernames(string key)
+        {
+            Assert.IsFalse(Default().IsWithheld(key));
+        }
+
+        [TestMethod]
+        public void MatchesKeysWithoutRegardToCaseOrSurroundingSpace()
+        {
+            var values = Default();
+
+            Assert.IsTrue(values.IsWithheld("dorc_proddeploypassword"));
+            Assert.IsTrue(values.IsWithheld("  DORC_ProdDeployPassword  "));
+        }
+
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public void WithholdsNothingForAnAbsentKey(string? key)
+        {
+            Assert.IsFalse(Default().IsWithheld(key));
+        }
+
+        /// <summary>
+        /// The list is configurable so that S-013 can extend it as consumers are migrated,
+        /// without a code change per key.
+        /// </summary>
+        [TestMethod]
+        public void TakesTheConfiguredListWhenOneIsGiven()
+        {
+            var configured = Build(new Dictionary<string, string?>
+            {
+                [ScriptScopeConfigValues.WithheldKeysSetting + ":0"] = "DORC_NonProdDeployPassword"
+            });
+
+            Assert.IsTrue(configured.IsWithheld("DORC_NonProdDeployPassword"));
+            Assert.IsFalse(configured.IsWithheld("DORC_ProdDeployPassword"),
+                "A configured list replaces the default rather than adding to it.");
+        }
+
+        /// <summary>
+        /// Derived from what is actually in the estate, not from a list in code, so a secure
+        /// value added after this was written is reported rather than silently overlooked.
+        /// </summary>
+        [TestMethod]
+        public void ReportsTheSecureValuesThatStillReachScripts()
+        {
+            var estate = new[]
+            {
+                Secure("DORC_ProdDeployPassword"),
+                Secure("DeploymentServiceAccountPassword"),
+                Secure("SomeKeyAddedLater"),
+                NotSecure("DORC_ProdDeployUsername")
+            };
+
+            CollectionAssert.AreEqual(
+                new[] { "DeploymentServiceAccountPassword", "SomeKeyAddedLater" },
+                Default().StillPublishedSecureKeys(estate).ToArray());
+        }
+
+        [TestMethod]
+        public void ReportsNothingWhenEverySecureValueIsWithheld()
+        {
+            var estate = new[] { Secure("DORC_ProdDeployPassword"), NotSecure("PlainSetting") };
+
+            Assert.AreEqual(0, Default().StillPublishedSecureKeys(estate).Count);
+        }
+
+        private static ConfigValueApiModel Secure(string key) =>
+            new() { Key = key, Value = "x", Secure = true };
+
+        private static ConfigValueApiModel NotSecure(string key) =>
+            new() { Key = key, Value = "x", Secure = false };
+    }
+}

--- a/src/Dorc.Monitor/RequestProcessors/PendingRequestProcessor.cs
+++ b/src/Dorc.Monitor/RequestProcessors/PendingRequestProcessor.cs
@@ -1,9 +1,10 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core;
 using Dorc.Core.Events;
 using Dorc.Core.Interfaces;
 using Dorc.Core.VariableResolution;
+using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,7 @@ namespace Dorc.Monitor.RequestProcessors
         private readonly IPropertyEvaluator _propertyEvaluator;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IGitHubArtifactDownloader _gitHubArtifactDownloader;
+        private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
 
         public PendingRequestProcessor(
             ILoggerFactory loggerFactory,
@@ -38,12 +40,14 @@ namespace Dorc.Monitor.RequestProcessors
             IConfigValuesPersistentSource configValuesPersistentSource,
             IPropertyEvaluator propertyEvaluator,
             IDeploymentEventsPublisher eventPublisher,
-            IGitHubArtifactDownloader gitHubArtifactDownloader)
+            IGitHubArtifactDownloader gitHubArtifactDownloader,
+            IScriptScopeConfigValues scriptScopeConfigValues)
         {
             _loggerFactory = loggerFactory;
             _propertyEvaluator = propertyEvaluator;
             _configValuesPersistentSource = configValuesPersistentSource;
             _gitHubArtifactDownloader = gitHubArtifactDownloader;
+            _scriptScopeConfigValues = scriptScopeConfigValues;
             this.logger = _loggerFactory.CreateLogger<PendingRequestProcessor>();
 
             this.componentProcessor = componentProcessor;
@@ -481,9 +485,22 @@ namespace Dorc.Monitor.RequestProcessors
 
         private void SetUpConfigValuesAsProperties(EnvironmentApiModel environment)
         {
+            var configValues = _configValuesPersistentSource.GetAllConfigValues(true).ToList();
+
+            ReportSecureConfigValuesStillReachingScripts(configValues);
+
             // attempt to add any other properties that don't need defaults
-            foreach (var configValue in _configValuesPersistentSource.GetAllConfigValues(true))
+            foreach (var configValue in configValues)
             {
+                if (_scriptScopeConfigValues.IsWithheld(configValue.Key))
+                {
+                    // DOrc's own operating credentials. Every secure value was previously
+                    // decrypted and injected subject only to a coarse production flag, so these
+                    // were delivered in cleartext, as ordinary PowerShell variables, to the
+                    // deployment scripts of every environment the flag admitted.
+                    continue;
+                }
+
                 if (_variableResolver.GetPropertyValue(configValue.Key) == null)
                 {
                     var needToSetConfigForEnv = !configValue.IsForProd.HasValue
@@ -493,6 +510,30 @@ namespace Dorc.Monitor.RequestProcessors
                     if (needToSetConfigForEnv)
                         _variableResolver.SetPropertyValue(configValue.Key, configValue.Value);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Records which secure values a deployment still receives.
+        ///
+        /// The withheld set is the three keys a production share scan showed no script
+        /// consumes. The rest stay published because scripts genuinely depend on them - one of
+        /// them is how scripts reach target servers at all - and they cannot be withheld until
+        /// their consumers are migrated. Reporting what is derived from the estate, rather than
+        /// from a list in code, keeps that backlog visible and catches a secure value added
+        /// after this was written.
+        /// </summary>
+        private void ReportSecureConfigValuesStillReachingScripts(IEnumerable<ConfigValueApiModel> configValues)
+        {
+            var stillPublished = _scriptScopeConfigValues.StillPublishedSecureKeys(configValues);
+
+            if (stillPublished.Count > 0)
+            {
+                logger.LogWarning(
+                    "{Count} secure configuration value(s) are still published into deployment script"
+                    + " scope: {Keys}. Each is readable by any script the deployment runs.",
+                    stillPublished.Count,
+                    string.Join(", ", stillPublished));
             }
         }
 

--- a/src/Dorc.Monitor/ScriptDispatcher.cs
+++ b/src/Dorc.Monitor/ScriptDispatcher.cs
@@ -3,6 +3,7 @@ using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core;
 using Dorc.Core.Configuration;
 using Dorc.Monitor.Pipes;
+using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
@@ -27,6 +28,7 @@ namespace Dorc.Monitor
         private readonly IScriptGroupPipeServer scriptGroupPipeServer;
         private readonly IConfigurationSettings configurationSettingsEngine;
         private readonly IRequestsPersistentSource requestsPersistentSource;
+        private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
 
         private bool isScriptExecutionSuccessful; // This field is needed to be instance-wide since Runner process errors are processed as instance-wide events.
 
@@ -38,7 +40,8 @@ namespace Dorc.Monitor
             ILogger<ScriptDispatcher> logger,
             IScriptGroupPipeServer scriptGroupPipeServer,
             IConfigurationSettings configurationSettingsEngine,
-            IRequestsPersistentSource requestsPersistentSource)
+            IRequestsPersistentSource requestsPersistentSource,
+            IScriptScopeConfigValues scriptScopeConfigValues)
         {
             this.processesPersistentSource = processesPersistentSource;
             this._configValuesPersistentSource = configValuesPersistentSource;
@@ -46,6 +49,7 @@ namespace Dorc.Monitor
             this.scriptGroupPipeServer = scriptGroupPipeServer;
             this.configurationSettingsEngine = configurationSettingsEngine;
             this.requestsPersistentSource = requestsPersistentSource;
+            this._scriptScopeConfigValues = scriptScopeConfigValues;
         }
 
         public bool Dispatch(string scriptsLocation,
@@ -256,7 +260,7 @@ namespace Dorc.Monitor
                         DeployResultId = deploymentResultId,
                         PowerShellVersionNumber = scriptApiModel.PowerShellVersionNumber,
                         ScriptsLocation = scriptsLocation,
-                        CommonProperties = properties,
+                        CommonProperties = WithheldKeysRemoved(properties),
                         ScriptProperties = new List<ScriptProperties>()
                     };
 
@@ -272,6 +276,37 @@ namespace Dorc.Monitor
             }
 
             return scriptGroups;
+        }
+
+        /// <summary>
+        /// The second place the withheld keys are excluded, and deliberately not the only one.
+        ///
+        /// They are already excluded where configuration values become properties. This catches
+        /// anything that reached the property set by another route - an environment property or
+        /// a request-supplied value bearing the same name - before it is serialised into the
+        /// script group and handed to a Runner. The script group is the artefact that crosses
+        /// the process boundary, so it is the right place for the invariant to hold rather than
+        /// be assumed.
+        /// </summary>
+        private IDictionary<string, VariableValue> WithheldKeysRemoved(
+            IDictionary<string, VariableValue> properties)
+        {
+            var withheld = properties.Keys.Where(_scriptScopeConfigValues.IsWithheld).ToList();
+
+            if (withheld.Count == 0)
+            {
+                return properties;
+            }
+
+            logger.LogWarning(
+                "Removed {Count} withheld key(s) from the script group before dispatch: {Keys}."
+                + " These reached the property set by a route other than configuration values.",
+                withheld.Count,
+                string.Join(", ", withheld));
+
+            return properties
+                .Where(property => !_scriptScopeConfigValues.IsWithheld(property.Key))
+                .ToDictionary(property => property.Key, property => property.Value);
         }
 
         private (string, string) GetProcessCredentials(bool isProduction, string environmentName)

--- a/src/Dorc.Monitor/TerraformDispatcher.cs
+++ b/src/Dorc.Monitor/TerraformDispatcher.cs
@@ -8,6 +8,7 @@ using Dorc.Monitor.Pipes;
 using Dorc.Monitor.RunnerProcess;
 using Dorc.Monitor.RunnerProcess.Interop.Windows.Kernel32;
 using Dorc.Monitor.TerraformSourceConfig;
+using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,7 @@ namespace Dorc.Monitor
         private readonly IAzureStorageAccountWorker _azureStorageAccountWorker;
         private readonly IProjectsPersistentSource _projectsPersistentSource;
         private readonly TerraformSourceConfigurator _sourceConfigurator;
+        private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
 
         private bool isScriptExecutionSuccessful; // This field is needed to be instance-wide since Runner process errors are processed as instance-wide events.
 
@@ -46,7 +48,8 @@ namespace Dorc.Monitor
             IScriptGroupPipeServer scriptGroupPipeServer,
             IAzureStorageAccountWorker azureStorageAccountWorker,
             IProjectsPersistentSource projectsPersistentSource,
-            IGitHubHostValidator gitHubHostValidator)
+            IGitHubHostValidator gitHubHostValidator,
+            IScriptScopeConfigValues scriptScopeConfigValues)
         {
             this.logger = logger;
             this._requestsPersistentSource = requestsPersistentSource;
@@ -56,6 +59,7 @@ namespace Dorc.Monitor
             this._scriptGroupPipeServer = scriptGroupPipeServer;
             this._azureStorageAccountWorker = azureStorageAccountWorker;
             this._projectsPersistentSource = projectsPersistentSource;
+            this._scriptScopeConfigValues = scriptScopeConfigValues;
             this._sourceConfigurator = new TerraformSourceConfigurator(logger, _configurationSettingsEngine, gitHubHostValidator);
         }
 
@@ -288,6 +292,30 @@ namespace Dorc.Monitor
             return isScriptExecutionSuccessful;
         }
 
+        /// <summary>
+        /// See ScriptDispatcher: the same invariant, on the branch that serialises a script
+        /// group for the Terraform Runner.
+        /// </summary>
+        private IDictionary<string, VariableValue> WithheldKeysRemoved(
+            IDictionary<string, VariableValue> properties)
+        {
+            var withheld = properties.Keys.Where(_scriptScopeConfigValues.IsWithheld).ToList();
+
+            if (withheld.Count == 0)
+            {
+                return properties;
+            }
+
+            logger.LogWarning(
+                "Removed {Count} withheld key(s) from the Terraform script group before dispatch: {Keys}.",
+                withheld.Count,
+                string.Join(", ", withheld));
+
+            return properties
+                .Where(property => !_scriptScopeConfigValues.IsWithheld(property.Key))
+                .ToDictionary(property => property.Key, property => property.Value);
+        }
+
         private (string, string) GetProcessCredentials(bool isProduction, string environmentName)
         {
             if (isProduction)
@@ -320,7 +348,7 @@ namespace Dorc.Monitor
                 ID = Guid.NewGuid(),
                 DeployResultId = deploymentResultId,
                 ScriptsLocation = scriptsLocation,
-                CommonProperties = properties,
+                CommonProperties = WithheldKeysRemoved(properties),
                 ScriptProperties = new List<ScriptProperties>()
             };
 

--- a/src/Dorc.Monitor/appsettings.json
+++ b/src/Dorc.Monitor/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -18,6 +18,12 @@
     "DotNetCoreDeploymentRunnerPath": "..\\..\\..\\Dorc.Runner\\bin\\Debug\\net8.0\\Dorc.Runner.exe",
     "DotNetFrameworkDeploymentRunnerPath": "..\\..\\..\\Dorc.NetFramework.Runner\\bin\\Debug\\Dorc.NetFramework.Runner.exe",
     "TerraformDeploymentRunnerPath": "..\\..\\..\\Dorc.TerraformRunner\\bin\\Debug\\Dorc.TerraformRunner.exe",
+    "//ConfigKeysWithheldFromScripts": "Config values never published into deployment script scope. Omit to use the built-in set - the three operator-only credentials a production share scan showed no script consumes. Extend as script consumers of the remaining secure keys are migrated.",
+    "ConfigKeysWithheldFromScripts": [
+      "DORC_ProdDeployPassword",
+      "DORC_WebDeployPassword",
+      "DorcApiAccessPassword"
+    ],
     "DomainNameIntra": "",
     "SMTPHost": "",
     "IsProduction": "False",

--- a/src/Dorc.PersistentData/PersistentDataRegistry.cs
+++ b/src/Dorc.PersistentData/PersistentDataRegistry.cs
@@ -25,6 +25,7 @@ namespace Dorc.PersistentData
             // IConfiguration, so the allow-list resolves identically in every process that
             // loads this registry. Settings do not change at runtime, so one instance serves.
             For<ISourceHostAllowList>().Use(new SourceHostAllowList(configuration)).Singleton();
+            For<IScriptScopeConfigValues>().Use(new ScriptScopeConfigValues(configuration)).Singleton();
 
             For<IAccessControlPersistentSource>().Use<AccessControlPersistentSource>().Scoped();
             For<IAccountPersistentSource>().Use<AccountPersistentSource>().Scoped();

--- a/src/Dorc.PersistentData/Security/ScriptScopeConfigValues.cs
+++ b/src/Dorc.PersistentData/Security/ScriptScopeConfigValues.cs
@@ -1,0 +1,101 @@
+using Dorc.ApiModel;
+using Microsoft.Extensions.Configuration;
+
+namespace Dorc.PersistentData.Security
+{
+    /// <summary>
+    /// Decides which configuration values are published into deployment script scope.
+    ///
+    /// Every secure configuration value is decrypted and injected into every deployment whose
+    /// production flag matches, with no exclusion for the credentials DOrc needs in order to
+    /// operate at all. The production deployment password among them: an estate inventory found
+    /// it reaching all 1,083 non-production environments, which is the lowest-trust population
+    /// there is and the easiest place to land a component that reads it.
+    ///
+    /// The estate's secure keys are two classes, not one, and this is the whole difficulty of
+    /// the step. A completed scan of the production script share found:
+    ///
+    /// - Operator-only, zero consumers: DORC_ProdDeployPassword, DORC_WebDeployPassword,
+    ///   DorcApiAccessPassword. Withholding these breaks nothing.
+    /// - Deliberately script-facing: DeploymentServiceAccountPassword (~80 call sites, and the
+    ///   mechanism by which scripts reach target servers at all), ProgetAccountPassword (~12),
+    ///   DorcCliSecret (2). Withholding these breaks the estate.
+    ///
+    /// So the withheld set is a configured list defaulting to the three with no consumers,
+    /// rather than "every secure value". The remainder wait on their consumers being migrated;
+    /// what is still published is reported so that backlog stays visible rather than assumed.
+    ///
+    /// Usernames stay visible deliberately. Scripts legitimately consume them to grant logon
+    /// rights, and an account name is an identity rather than a credential — already visible in
+    /// target-server access control lists, process listings and event logs.
+    /// </summary>
+    public interface IScriptScopeConfigValues
+    {
+        /// <summary>
+        /// Whether this key must not reach deployment script scope.
+        /// </summary>
+        bool IsWithheld(string? key);
+
+        /// <summary>
+        /// The keys being withheld, for reporting.
+        /// </summary>
+        IReadOnlyCollection<string> WithheldKeys { get; }
+
+        /// <summary>
+        /// Secure keys that are still published — the migration backlog. Derived from what is
+        /// actually in the estate rather than from a list in code, so a secure value added
+        /// after this was written is reported rather than silently overlooked.
+        /// </summary>
+        IReadOnlyCollection<string> StillPublishedSecureKeys(IEnumerable<ConfigValueApiModel> configValues);
+    }
+
+    public class ScriptScopeConfigValues : IScriptScopeConfigValues
+    {
+        public const string WithheldKeysSetting = "AppSettings:ConfigKeysWithheldFromScripts";
+
+        /// <summary>
+        /// The keys a completed production share scan showed no script consumes. Defaulted
+        /// rather than left empty because an empty default would leave a live incident open on
+        /// every estate that had not yet configured the setting, and defaulted rather than
+        /// derived from "is it secure" because deriving it would withhold the three keys the
+        /// estate genuinely depends on and break roughly ninety call sites.
+        /// </summary>
+        private static readonly string[] OperatorOnlyKeys =
+        {
+            "DORC_ProdDeployPassword",
+            "DORC_WebDeployPassword",
+            "DorcApiAccessPassword"
+        };
+
+        private readonly HashSet<string> withheld;
+
+        public ScriptScopeConfigValues(IConfiguration configuration)
+        {
+            var configured = configuration.GetSection(WithheldKeysSetting).Get<string[]>();
+
+            withheld = new HashSet<string>(
+                (configured ?? OperatorOnlyKeys).Where(key => !string.IsNullOrWhiteSpace(key)).Select(key => key.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IReadOnlyCollection<string> WithheldKeys => withheld;
+
+        public bool IsWithheld(string? key) =>
+            !string.IsNullOrWhiteSpace(key) && withheld.Contains(key.Trim());
+
+        public IReadOnlyCollection<string> StillPublishedSecureKeys(IEnumerable<ConfigValueApiModel> configValues)
+        {
+            if (configValues == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            return configValues
+                .Where(value => value != null && value.Secure && !IsWithheld(value.Key))
+                .Select(value => value.Key)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Closes #847

**Stacked on #846.** Merge that first.

## This does not ship the plan as originally written, and the difference matters

"Denylist password and secret keys unconditionally, deriving the list by enumerating secure config values" would withhold `DeploymentServiceAccountPassword` — roughly eighty call sites, and the mechanism by which scripts reach target servers at all — along with `ProgetAccountPassword` and `DorcCliSecret`. That is not a denylist, it is an outage. The production share scan is what makes the difference, and it reversed this half of the design.

So the withheld set is the **three keys with zero confirmed consumers**. A drop-in, and they include the credential behind the live incident. The rest stay published until their consumers are migrated; the list is configurable so that migration extends it without a code change.

## The derivation survives as reporting, not enforcement

Enumerating secure values and subtracting the withheld set gives what still reaches script scope, which the Monitor logs every deployment. That keeps the migration backlog measured against the **estate** rather than against a list in code, and surfaces a secure value added after this was written — without the derivation being able to break a deployment.

## Two gates

Config values are excluded where they become properties, **and** the script group is filtered again as it is assembled. The second is not redundant: a property arriving by another route — an environment property, or a request-supplied value bearing the same name — would otherwise carry an operating credential across the process boundary into a Runner. There is a test that dispatches with exactly that shape.

## Still open after this

W-4 remains live for the four secure keys still published. Credential rotation still waits on the script migration.

## Tests

16 new.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_