### PR TITLE
S-014a: restrict ReadSecrets to service principals, and redact uniformly

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -42,7 +42,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-012 | Bind source credentials to validated hosts | SD-9, W-11, W-16, SC-05b | **DONE** — partly inert until S-011 is configured |
 | ⚙ S-013 | Migrate the three `DORC_NonProdDeployPassword` consumers | SD-3a precondition | **U-12 CLOSED** |
 | S-014 | Classify config values: reserved-key denylist | SD-3a, W-4, SC-03 | **DONE for the three zero-consumer keys**; the rest still gated on S-013 |
-| S-014a | Restrict `CanReadSecrets` to service principals | W-19 | Usage decision (see step) |
+| S-014a | Restrict `CanReadSecrets` to service principals | W-19 | **DONE** — has a blast radius, see the step |
 | ⚙ S-015 | Rotate the deployment credentials | SD-3, W-4 | **S-004 and S-014** |
 | ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | S-010 |
 | S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | S-010, S-016 |
@@ -333,6 +333,10 @@ Whether `AccessControlController`'s use of the same predicate for ACL visibility
 Neither is introduced by this step; both are made prominent by it, which makes this the right moment to correct them.
 
 **Blast radius, stated plainly.** Every environment owner who today sees decrypted secret property values in the web UI will stop seeing them. If anyone relies on that to operate — debugging a deployment, confirming a credential rotation landed — this breaks their workflow. That is the same shape of risk as S-013's script migration, and deserves the same treatment: find out who relies on it before shipping, not after.
+
+**The predicate-separation decision, made.** `AccessControlController`'s second use of the predicate is not ACL visibility — it is the guard that stops a caller granting `ReadSecrets` when they do not hold it. Left on the restricted predicate, **no human could ever grant the privilege to anyone** and it would become unadministrable the moment this step shipped. So the two questions are now two predicates: `CanReadSecrets` for exercising it (service principal + explicit grant) and `CanGrantReadSecrets` for administering it (the original privilege-or-ownership test, unchanged). Administration behaves exactly as before. The `UserCanReadSecrets` flag on the access model keeps the restricted predicate, because it tells a client whether values will actually be readable, which is now false for people.
+
+**One consequence worth stating before this is deployed.** Windows authentication carries no machine-versus-person discriminator, so `IsServicePrincipal` is false for every Windows-authenticated caller and the privilege cannot be exercised over that scheme at all. That is the intended shape — service accounts of live running systems authenticate as OAuth machine clients, which is where the `m2m` claim exists — but a consumer that reads secrets over Windows authentication would stop working. The Monitor is unaffected: it uses the direct-tool reader, which reports itself a machine.
 
 **Verification intent.** A service principal with the privilege still retrieves decrypted values — the path that must not break. A human principal does not, whether they hold an explicit grant or own the environment; the owner case specifically confirms the implicit grant is closed. A result set consisting entirely of secure values returns redacted entries rather than raising an exception. An unscoped query redacts rather than returning ciphertext. Existing clients degrade to blank values rather than failing. ACL visibility is verified independently of the secret-retrieval path, per the predicate-separation decision above.
 

--- a/src/Dorc.Api.Tests/PropertyValuesServiceTests.cs
+++ b/src/Dorc.Api.Tests/PropertyValuesServiceTests.cs
@@ -161,7 +161,19 @@ namespace Dorc.Api.Tests
                     }
                 });
 
-            Assert.Throws<NonEnoughRightsException>(() => testService.GetPropertyValues(propertyName, environmentName, new GenericPrincipal(new GenericIdentity("test-user"), null)));
+            // A result set consisting entirely of secure values used to raise a rights
+            // exception while a partially-secure one redacted, so the same caller saw masked
+            // data or an error depending on what happened to be in the set. Redaction is now
+            // uniform - which matters far more once restricting the privilege to service
+            // principals makes this the path every human takes.
+            var redacted = testService
+                .GetPropertyValues(propertyName, environmentName,
+                    new GenericPrincipal(new GenericIdentity("test-user"), null))
+                .ToList();
+
+            Assert.AreEqual(1, redacted.Count);
+            Assert.AreEqual(string.Empty, redacted[0].Value);
+            Assert.AreEqual(propertyName, redacted[0].Property.Name);
         }
 
         [TestMethod]

--- a/src/Dorc.Api.Tests/ReadSecretsRestrictionTests.cs
+++ b/src/Dorc.Api.Tests/ReadSecretsRestrictionTests.cs
@@ -1,0 +1,130 @@
+﻿using Dorc.Core;
+using Dorc.Core.Interfaces;
+using Dorc.PersistentData;
+using Dorc.PersistentData.Model;
+using Dorc.PersistentData.Repositories;
+using Dorc.PersistentData.Sources.Interfaces;
+using NSubstitute;
+using System.Security.Claims;
+using System.Security.Principal;
+
+namespace Dorc.Api.Tests
+{
+    /// <summary>
+    /// The ReadSecrets privilege exists for service accounts belonging to live running systems.
+    /// As implemented it did neither of the two things that requires: it was granted implicitly
+    /// to every environment owner, and it could not be restricted to machines at all — so human
+    /// owners received decrypted secret property values through the API and the web UI, the
+    /// exact outcome it was designed to prevent.
+    /// </summary>
+    [TestClass]
+    public class ReadSecretsRestrictionTests
+    {
+        private const string EnvName = "SOME-ENV";
+
+        private IEnvironmentsPersistentSource _environments = null!;
+        private ISecurityObjectFilter _securityObjectFilter = null!;
+        private IClaimsPrincipalReader _claimsPrincipalReader = null!;
+        private ClaimsPrincipal _user = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _user = new ClaimsPrincipal(new ClaimsIdentity("test"));
+
+            _environments = Substitute.For<IEnvironmentsPersistentSource>();
+            _environments.GetSecurityObject(EnvName).Returns(new PersistentData.Model.Environment());
+
+            _securityObjectFilter = Substitute.For<ISecurityObjectFilter>();
+            _claimsPrincipalReader = Substitute.For<IClaimsPrincipalReader>();
+        }
+
+        private SecurityPrivilegesChecker NewChecker() =>
+            new(Substitute.For<IProjectsPersistentSource>(),
+                _environments,
+                _securityObjectFilter,
+                Substitute.For<IRolePrivilegesChecker>(),
+                _claimsPrincipalReader);
+
+        private void GrantsOnEnvironment(AccessLevel granted) =>
+            _securityObjectFilter
+                .HasPrivilege(Arg.Any<PersistentData.Model.Environment>(), Arg.Any<ClaimsPrincipal>(), Arg.Any<AccessLevel>())
+                .Returns(call => (call.ArgAt<AccessLevel>(2) & granted) != 0);
+
+        [TestMethod]
+        public void AServicePrincipalWithAnExplicitGrantStillReadsSecrets()
+        {
+            _claimsPrincipalReader.IsServicePrincipal(_user).Returns(true);
+            GrantsOnEnvironment(AccessLevel.ReadSecrets);
+
+            Assert.IsTrue(NewChecker().CanReadSecrets(_user, EnvName),
+                "This is the path that must not break.");
+        }
+
+        /// <summary>
+        /// The weakness, directly: a person holding the privilege was reading secrets.
+        /// </summary>
+        [TestMethod]
+        public void APersonWithAnExplicitGrantDoesNotReadSecrets()
+        {
+            _claimsPrincipalReader.IsServicePrincipal(_user).Returns(false);
+            GrantsOnEnvironment(AccessLevel.ReadSecrets);
+
+            Assert.IsFalse(NewChecker().CanReadSecrets(_user, EnvName));
+        }
+
+        /// <summary>
+        /// The implicit half of the weakness. Ownership conferred the privilege on every
+        /// environment owner without anyone granting it, which also made an audit of holders
+        /// meaningless.
+        /// </summary>
+        [TestMethod]
+        public void OwnershipNoLongerImpliesThePrivilege()
+        {
+            _claimsPrincipalReader.IsServicePrincipal(_user).Returns(true);
+            GrantsOnEnvironment(AccessLevel.Owner);
+
+            Assert.IsFalse(NewChecker().CanReadSecrets(_user, EnvName),
+                "Owner must no longer imply ReadSecrets, even for a machine.");
+        }
+
+        [TestMethod]
+        public void AServicePrincipalWithoutAGrantDoesNotReadSecrets()
+        {
+            _claimsPrincipalReader.IsServicePrincipal(_user).Returns(true);
+            GrantsOnEnvironment(AccessLevel.Write);
+
+            Assert.IsFalse(NewChecker().CanReadSecrets(_user, EnvName));
+        }
+
+        /// <summary>
+        /// Administering the privilege is a human activity; exercising it is a machine one. Had
+        /// the grant guard kept using the retrieval predicate, no person could ever have granted
+        /// ReadSecrets to anyone and it would have become unadministrable.
+        /// </summary>
+        [TestMethod]
+        public void APersonMayStillGrantThePrivilegeTheyCannotExercise()
+        {
+            _claimsPrincipalReader.IsServicePrincipal(_user).Returns(false);
+            GrantsOnEnvironment(AccessLevel.Owner);
+
+            var checker = NewChecker();
+
+            Assert.IsTrue(checker.CanGrantReadSecrets(_user, EnvName));
+            Assert.IsFalse(checker.CanReadSecrets(_user, EnvName));
+        }
+
+        [TestMethod]
+        public void NeitherPredicateAdmitsAnUnknownEnvironment()
+        {
+            _claimsPrincipalReader.IsServicePrincipal(_user).Returns(true);
+            GrantsOnEnvironment(AccessLevel.ReadSecrets | AccessLevel.Owner);
+            _environments.GetSecurityObject("GHOST").Returns((PersistentData.Model.Environment)null!);
+
+            var checker = NewChecker();
+
+            Assert.IsFalse(checker.CanReadSecrets(_user, "GHOST"));
+            Assert.IsFalse(checker.CanGrantReadSecrets(_user, "GHOST"));
+        }
+    }
+}

--- a/src/Dorc.Api/Controllers/AccessControlController.cs
+++ b/src/Dorc.Api/Controllers/AccessControlController.cs
@@ -129,9 +129,13 @@ namespace Dorc.Api.Controllers
                 }
                 accessControl.ObjectId = authorizedObject.ObjectId;
 
-                // Prevent users without read-secrets privilege from granting it
+                // Prevent users without the read-secrets privilege from granting it. This asks
+                // whether the caller may ADMINISTER the privilege, which is not the same
+                // question as whether they may exercise it - exercising it is restricted to
+                // service principals, and using that predicate here would leave no-one able to
+                // grant it.
                 var requestingUserCanReadSecrets = accessControl.Type == AccessControlType.Environment
-                    ? _securityPrivilegesChecker.CanReadSecrets(User, accessControl.Name)
+                    ? _securityPrivilegesChecker.CanGrantReadSecrets(User, accessControl.Name)
                     : _securityPrivilegesChecker.IsProjectOwnerOrAdmin(User, accessControl.Name);
 
                 if (!requestingUserCanReadSecrets)

--- a/src/Dorc.Api/Security/ClaimsPrincipalReaderFactory.cs
+++ b/src/Dorc.Api/Security/ClaimsPrincipalReaderFactory.cs
@@ -30,6 +30,11 @@ namespace Dorc.Api.Security
             _winAuthReader = new WinAuthClaimsPrincipalReader(_adUserGroupsReader);
         }
 
+        public bool IsServicePrincipal(IPrincipal user)
+        {
+            return ResolveReader().IsServicePrincipal(user);
+        }
+
         public string GetUserName(IPrincipal user)
         {
             var reader = ResolveReader();

--- a/src/Dorc.Api/Security/OAuthClaimsPrincipalReader.cs
+++ b/src/Dorc.Api/Security/OAuthClaimsPrincipalReader.cs
@@ -29,6 +29,11 @@ namespace Dorc.Api.Security
             return user?.FindFirst(M2MClaimType)?.Value?.ToLower() == "true";
         }
 
+        public bool IsServicePrincipal(IPrincipal user)
+        {
+            return IsM2MAuthentication(GetClaimsPrincipal(user));
+        }
+
         private string GetClientId(ClaimsPrincipal user)
         {
             return user?.FindFirst(ClientIdClaimType)?.Value ?? string.Empty;

--- a/src/Dorc.Api/Security/WinAuthClaimsPrincipalReader.cs
+++ b/src/Dorc.Api/Security/WinAuthClaimsPrincipalReader.cs
@@ -14,6 +14,20 @@ namespace Dorc.Api.Security
             _userGroupReader = userGroupReader;
         }
 
+        /// <summary>
+        /// Windows authentication carries no machine-versus-person discriminator: a service
+        /// account and a person present the same kind of identity. Answering "no" is the only
+        /// safe answer, and it means the ReadSecrets privilege cannot be exercised over Windows
+        /// authentication at all. That is the intended shape - service accounts of live running
+        /// systems authenticate as OAuth machine clients, which is where the discriminator
+        /// exists - but it is a real restriction and worth knowing about before enabling
+        /// Windows-only authentication for a consumer that reads secrets.
+        /// </summary>
+        public bool IsServicePrincipal(IPrincipal user)
+        {
+            return false;
+        }
+
         public string GetUserName(IPrincipal user)
         {
             return GetUserFullDomainName(user).Split('\\')[1];

--- a/src/Dorc.Api/Services/PropertyValuesService.cs
+++ b/src/Dorc.Api/Services/PropertyValuesService.cs
@@ -55,11 +55,22 @@ namespace Dorc.Api.Services
             result.AddRange(propValues);
             var canReadSecrets = _securityPrivilegesChecker.CanReadSecrets(user, environmentName);
 
-            if (!canReadSecrets && !String.IsNullOrEmpty(environmentName))
+            if (!canReadSecrets)
             {
-                if (result.Any() && result.All(propertyValueDto => propertyValueDto.Property.Secure))
-                    throw new NonEnoughRightsException($"User {username} doesn't have \"ReadSecrets\" permission to read secured properties");
-
+                // Redaction is uniform, and both corrections here matter more than they did
+                // before: restricting the privilege to service principals turns this from the
+                // path a few callers take into the path every human takes.
+                //
+                // It previously raised a rights exception when EVERY value in the result was
+                // secure, so a partial result redacted while a wholly-secure one failed. For
+                // someone opening a property set that happens to contain only secure values,
+                // that surfaced as an error rather than as masked data.
+                //
+                // And it was conditioned on an environment being named, so an unscoped query
+                // redacted nothing - and because the decrypt branch is skipped too, the caller
+                // received the stored CIPHERTEXT rather than either the plaintext or a blank.
+                // Not a plaintext disclosure, but it hands encrypted material and value
+                // presence to a caller not entitled to the value at all.
                 result.Where(propertyValueDto => propertyValueDto.Property.Secure).ForEach(propertyValueDto =>
                 {
                     propertyValueDto.Value = String.Empty;

--- a/src/Dorc.Core/Interfaces/ISecurityPrivilegesChecker.cs
+++ b/src/Dorc.Core/Interfaces/ISecurityPrivilegesChecker.cs
@@ -11,6 +11,12 @@ namespace Dorc.Core.Interfaces
         bool CanModifyProject(ClaimsPrincipal user, string projectName);
         bool CanModifyEnvironment(ClaimsPrincipal user, string envName);
         bool CanReadSecrets(ClaimsPrincipal user, string environmentName);
+
+        /// <summary>
+        /// Whether the caller may grant the read-secrets privilege. Separate from exercising
+        /// it: administration is a human activity, retrieval is a machine one.
+        /// </summary>
+        bool CanGrantReadSecrets(ClaimsPrincipal user, string environmentName);
         bool CanModifyProject(ClaimsPrincipal user, int projectId);
     }
 }

--- a/src/Dorc.Core/Security/DirectToolClaimsPrincipalReader.cs
+++ b/src/Dorc.Core/Security/DirectToolClaimsPrincipalReader.cs
@@ -24,6 +24,16 @@ namespace Dorc.Core.Security
             _clientName = clientName;
         }
 
+        /// <summary>
+        /// This reader stands in for a tool running as itself - the Monitor among them - so the
+        /// caller is a machine by construction. It is not a bypass: the ReadSecrets privilege
+        /// still has to be granted explicitly on the environment.
+        /// </summary>
+        public bool IsServicePrincipal(IPrincipal user)
+        {
+            return true;
+        }
+
         public string GetUserName(IPrincipal user)
         {
             return _clientName;

--- a/src/Dorc.Core/SecurityPrivilegesChecker.cs
+++ b/src/Dorc.Core/SecurityPrivilegesChecker.cs
@@ -51,7 +51,46 @@ namespace Dorc.Core
                 : _rolePrivilegesChecker.IsAdmin(user) || _securityObjectFilter.HasPrivilege(project, user, AccessLevel.Owner);
         }
 
+        /// <summary>
+        /// Whether decrypted secret values may be retrieved for this environment.
+        ///
+        /// The privilege exists for service accounts belonging to live running systems. As
+        /// implemented it did neither of the two things that requires: it was granted
+        /// implicitly to every environment OWNER, and it could not be restricted to machines at
+        /// all, so human owners received decrypted secret property values through the API and
+        /// the web UI - the exact outcome it was designed to prevent.
+        ///
+        /// Both are closed here. A person fails regardless of what they have been granted or
+        /// what they own, and ownership no longer implies the privilege, so holding it now
+        /// requires an explicit grant and an audit of holders means something.
+        ///
+        /// Humans are not refused, they are redacted: the secure value is replaced with an
+        /// empty string on the path that serves it. See PropertyValuesService.
+        /// </summary>
         public bool CanReadSecrets(ClaimsPrincipal user, string environmentName)
+        {
+            if (!_claimsPrincipalReader.IsServicePrincipal(user))
+            {
+                return false;
+            }
+
+            var env = _environmentsPersistentSource.GetSecurityObject(environmentName);
+            return env != null && _securityObjectFilter.HasPrivilege(env, user, AccessLevel.ReadSecrets);
+        }
+
+        /// <summary>
+        /// Whether this caller may GRANT the read-secrets privilege to someone else.
+        ///
+        /// Deliberately a different question from whether they may exercise it, and the reason
+        /// the two cannot share a predicate. Administering the privilege is something people
+        /// do; exercising it is something machines do. Had the grant guard kept using
+        /// CanReadSecrets after the restriction above, no human could ever have granted
+        /// ReadSecrets to anyone, and the privilege would have become unadministrable.
+        ///
+        /// This therefore keeps the original semantics - the privilege or ownership of the
+        /// environment - so that administration is unchanged by this step.
+        /// </summary>
+        public bool CanGrantReadSecrets(ClaimsPrincipal user, string environmentName)
         {
             var env = _environmentsPersistentSource.GetSecurityObject(environmentName);
             return env != null && _securityObjectFilter.HasPrivilege(env, user, AccessLevel.ReadSecrets | AccessLevel.Owner);

--- a/src/Dorc.PersistentData/IClaimsPrincipalReader.cs
+++ b/src/Dorc.PersistentData/IClaimsPrincipalReader.cs
@@ -12,5 +12,16 @@ namespace Dorc.PersistentData
         string GetUserSafeIdentifier(IPrincipal user);
         string GetUserEmail(ClaimsPrincipal user);
         List<string> GetSidsForUser(IPrincipal user);
+
+        /// <summary>
+        /// Whether the caller is a machine rather than a person.
+        ///
+        /// The determination already existed, as a private test of an OAuth "m2m" claim used to
+        /// decide what to call the caller in logs. It is surfaced here because the authorization
+        /// layer needs it: the ReadSecrets privilege exists for service accounts belonging to
+        /// live running systems, and could not be restricted to them while the only code that
+        /// could tell the difference was one layer away and private.
+        /// </summary>
+        bool IsServicePrincipal(IPrincipal user);
     }
 }


### PR DESCRIPTION
Closes #849

**Stacked on #848.** Merge that first. This is the last PR in the stack.

## ⚠️ Blast radius — worth a heads-up before this merges

**Every environment owner who today sees decrypted secret values in the web UI will stop seeing them.** Anyone relying on that to debug a deployment or confirm a credential rotation landed loses that view. Worth finding out who relies on it before shipping, not after.

**Windows authentication carries no machine-versus-person discriminator**, so `IsServicePrincipal` is false for every Windows-authenticated caller and the privilege cannot be exercised over that scheme at all. That is the intended shape — service accounts authenticate as OAuth machine clients, which is where the `m2m` claim exists — but a Windows-auth consumer that reads secrets would stop working. The Monitor is unaffected: it uses the direct-tool reader, which reports itself a machine.

## What changes

`CanReadSecrets` requires a service principal **and** an explicit grant. Ownership no longer implies the privilege, so an audit of holders means something. The `m2m` determination moves from a private method in the OAuth claims reader onto `IClaimsPrincipalReader`, so the authorization layer can ask the question.

## The predicate separation, which the plan required a decision on

The controller's second use of the predicate is **not** ACL visibility — it is the guard that stops a caller granting `ReadSecrets` when they do not hold it. Left on the restricted predicate, **no human could ever have granted the privilege to anyone**, and it would have become unadministrable the moment this shipped.

So there are now two predicates: `CanReadSecrets` for exercising it, and `CanGrantReadSecrets` for administering it, keeping the original privilege-or-ownership semantics. Administration behaves exactly as before.

## Redaction corrections

Humans are redacted rather than refused, per the agreed usage decision. Both edge cases in the issue are fixed, because this step turns them from what a few callers hit into what every human hits.

## Tests

6 new; one existing test updated from asserting the throw to asserting uniform redaction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_