### PR TITLE
S-023: replace the expression compiler with a fixed grammar

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -51,7 +51,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-020 | Introduce the credential provider abstraction | SD-4 | S-019 (ConfigValues variant only) |
 | S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07 | S-020; revisits S-007, S-008, S-009 |
 | S-022 | Record attribution reached and not reached | SD-8, W-9 | S-021 |
-| S-023 | Replace the expression compiler with a fixed grammar | SD-1b, W-1 | S-004 |
+| S-023 | Replace the expression compiler with a fixed grammar | SD-1b, W-1 | **DONE** |
 
 **Independently shippable today, in any order:** S-001, S-002, S-003, S-004, S-005, S-006, S-007, S-008, S-009, S-010, S-011. Eleven steps, covering every rank-1 and rank-2 weakness and the write-path half of every rank-3 weakness. Nothing in that set waits on an unknown.
 
@@ -461,6 +461,16 @@ Design notes from the inventory: interpolation must handle adjacent tokens and t
 **Dependencies.** S-004. Distant — the containment has already removed the reachable path, so this is cleanup rather than urgent.
 
 **Verification intent.** A differential test evaluates every inventoried expression under both the old and new implementations and asserts identical results. An unparseable expression fails with a clear error and does not fall back. The scripting-compiler package is absent from the assembly's dependencies.
+
+**One correction to the design notes.** They call for interpolation to be handled by the grammar, including adjacent tokens and tokens abutting literal text. It must not be: interpolation has already happened by the time an expression reaches the evaluator, so what the parser sees is the *substituted* literal. Adjacent tokens and abutting text reduce to ordinary literal content before parsing and need no special handling. The differential corpus therefore uses post-interpolation forms, which is what actually reaches the evaluator.
+
+That ordering is also why parsing is strict rather than forgiving: a substituted value containing a quote makes the literal's extent ambiguous, and an ambiguous expression is refused rather than guessed at.
+
+**The differential is real, not recorded.** The scripting package moves to the test project so both implementations can be evaluated side by side; production no longer carries it. The corpus covers every grammar feature the inventory recorded rather than the verbatim eleven expressions, which the HLPS records by shape rather than in full.
+
+**The dependency's absence is asserted by a test**, against the production assembly's own reference list rather than by reading a project file, so it stays true if the package is reintroduced transitively. Verified absent from the `Dorc.Core`, `Dorc.Monitor` and `Dorc.Api` dependency graphs.
+
+**Failing closed has a real cost, accepted deliberately.** Secure configuration values are encrypted at rest, could not be inventoried, and do reach the evaluator. If one of them carries an `fn:` expression outside this grammar, it evaluated before and will now fail the deployment. That is the trade the HLPS chose; the failure names the shape of the problem and its position, and deliberately does **not** quote the literal, which is a resolved property value and may be a secret.
 
 ---
 

--- a/src/Dorc.Core.Tests/Dorc.Core.Tests.csproj
+++ b/src/Dorc.Core.Tests/Dorc.Core.Tests.csproj
@@ -40,4 +40,11 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Referenced by the TEST project only, so the differential test can evaluate every
+         inventoried expression under the compiler this step removes as well as under the
+         grammar that replaces it. Production code must not carry this dependency: a compiler
+         reachable from deployment data is the weakness being closed. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
+  </ItemGroup>
 </Project>

--- a/src/Dorc.Core.Tests/PropertyExpressionGrammarTests.cs
+++ b/src/Dorc.Core.Tests/PropertyExpressionGrammarTests.cs
@@ -1,0 +1,190 @@
+﻿using Dorc.Core.VariableResolution;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+
+namespace Dorc.Core.Tests
+{
+    /// <summary>
+    /// Property resolution used to end by handing values to Roslyn — a C# compiler, reachable
+    /// from deployment data, inside the process holding both deployment credential pairs.
+    /// Provenance containment removed the path a request could take to it; this removes the
+    /// compiler.
+    ///
+    /// An estate inventory found 11 distinct expressions across 133 property values, every one
+    /// of a single shape: a double-quoted literal followed by a left-to-right chain of
+    /// lower-casing, upper-casing and replacement. One expression is 101 of the 133. No loops,
+    /// reflection, assembly references, type construction or I/O. That is a parser's job.
+    ///
+    /// Token interpolation has already happened by this point, so what is parsed is the
+    /// substituted text — which is why parsing is strict rather than forgiving.
+    /// </summary>
+    [TestClass]
+    public class PropertyExpressionGrammarTests
+    {
+        private static string Evaluate(string expression)
+        {
+            Assert.IsTrue(PropertyExpressionGrammar.TryEvaluate(expression, out var result, out var error),
+                $"Expected '{expression}' to parse, but: {error}");
+            return result;
+        }
+
+        private static string Refuse(string expression)
+        {
+            Assert.IsFalse(PropertyExpressionGrammar.TryEvaluate(expression, out _, out var error),
+                $"Expected '{expression}' to be refused.");
+            return error;
+        }
+
+        /// <summary>
+        /// The differential the plan asks for: every shape the inventory recorded, evaluated
+        /// under both the compiler being removed and the grammar replacing it, asserting
+        /// identical results.
+        ///
+        /// These are the POST-interpolation forms, which is what actually reaches the
+        /// evaluator. The corpus covers every recorded grammar feature — adjacent tokens and
+        /// tokens abutting literal text both reduce to plain literal content once substituted,
+        /// and the space-to-underscore replacement is the expression accounting for 101 of the
+        /// 133 occurrences.
+        /// </summary>
+        [TestMethod]
+        [DataRow("\"MY ENV\".Replace(\" \",\"_\")")]
+        [DataRow("\"MY ENV\".Replace(\" \",\"\")")]
+        [DataRow("\"MixedCase\".ToLower()")]
+        [DataRow("\"MixedCase\".ToUpper()")]
+        [DataRow("\"GLO PRD\".Replace(\" \",\"-\").ToLower()")]
+        [DataRow("\"glo\".ToUpper().Replace(\"G\",\"X\")")]
+        [DataRow("\"sefe1uks\"")]
+        [DataRow("\"prd1uks\".ToLower()")]
+        [DataRow("\"a-b-c\".Replace(\"-\",\"\").ToUpper()")]
+        [DataRow("\"KV-GLO-PRD-1\".ToLower().Replace(\"-\",\"\")")]
+        [DataRow("\"\"")]
+        [DataRow("\"\".ToUpper()")]
+        public void AgreesWithTheCompilerItReplaces(string expression)
+        {
+            var compiled = CSharpScript.EvaluateAsync(expression).Result?.ToString();
+
+            Assert.AreEqual(compiled, Evaluate(expression),
+                $"The grammar and the compiler disagree on '{expression}'.");
+        }
+
+        /// <summary>
+        /// The single most common expression in the estate, in its substituted form.
+        /// </summary>
+        [TestMethod]
+        public void EvaluatesTheEnvironmentNameUnderscoreExpression()
+        {
+            Assert.AreEqual("MY_TEST_ENV", Evaluate("\"MY TEST ENV\".Replace(\" \",\"_\")"));
+        }
+
+        [TestMethod]
+        public void AppliesOperationsLeftToRight()
+        {
+            // Upper first would give "AXC"; replace first gives "abc" then "ABC".
+            Assert.AreEqual("ABC", Evaluate("\"a-c\".Replace(\"-\",\"b\").ToUpper()"));
+            Assert.AreEqual("A-C", Evaluate("\"a-c\".ToUpper().Replace(\"B\",\"x\")"));
+        }
+
+        [TestMethod]
+        public void CasingIsCultureIndependent()
+        {
+            // A deployment must not resolve a property differently depending on the host's
+            // locale. The Turkish dotless i is the standard demonstration.
+            Assert.AreEqual("I", Evaluate("\"i\".ToUpper()"));
+            Assert.AreEqual("i", Evaluate("\"I\".ToLower()"));
+        }
+
+        [TestMethod]
+        public void HandlesEscapesThatCanAppearInALiteral()
+        {
+            Assert.AreEqual("a\"b", Evaluate("\"a\\\"b\""));
+            Assert.AreEqual("a\\b", Evaluate("\"a\\\\b\""));
+            Assert.AreEqual("a\tb", Evaluate("\"a\\tb\""));
+        }
+
+        // --- fails closed --------------------------------------------------------------
+
+        /// <summary>
+        /// The whole point. Anything outside the grammar is refused, never compiled. Secure
+        /// configuration values are encrypted at rest, could not be inventoried, and do reach
+        /// the evaluator — so refusal is what contains that residual.
+        /// </summary>
+        [TestMethod]
+        [DataRow("\"abc\".Trim()", "unsupported operation")]
+        [DataRow("\"abc\".Substring(1)", "unsupported operation")]
+        [DataRow("\"abc\".ToLowerInvariant()", "unsupported operation")]
+        [DataRow("System.IO.File.ReadAllText(\"c:/x\")", "expected a double-quoted string literal")]
+        [DataRow("typeof(string).Assembly.Location", "expected a double-quoted string literal")]
+        [DataRow("1+1", "expected a double-quoted string literal")]
+        [DataRow("@\"abc\"", "expected a double-quoted string literal")]
+        public void RefusesAnythingOutsideTheGrammar(string expression, string expectedReason)
+        {
+            StringAssert.Contains(Refuse(expression), expectedReason);
+        }
+
+        /// <summary>
+        /// An interpolated value containing a quote makes the literal's extent ambiguous. The
+        /// grammar refuses rather than guessing which quote closes the literal.
+        /// </summary>
+        [TestMethod]
+        public void RefusesALiteralWhoseExtentIsAmbiguous()
+        {
+            Refuse("\"MY \"ENV\"\".Replace(\" \",\"_\")");
+        }
+
+        [TestMethod]
+        [DataRow("\"unclosed")]
+        [DataRow("\"abc\".Replace(\" \")")]
+        [DataRow("\"abc\".Replace(\" \",\"_\",\"x\")")]
+        [DataRow("\"abc\".ToUpper")]
+        [DataRow("\"abc\".ToUpper(1)")]
+        [DataRow("\"abc\" \"def\"")]
+        [DataRow("\"abc\"..ToUpper()")]
+        [DataRow("")]
+        public void RefusesMalformedExpressions(string expression)
+        {
+            Refuse(expression);
+        }
+
+        /// <summary>
+        /// .NET throws for it, and the estate does not do it, so it is named rather than
+        /// allowed to surface as an unhandled exception mid-deployment.
+        /// </summary>
+        [TestMethod]
+        public void RefusesReplacingTheEmptyString()
+        {
+            StringAssert.Contains(Refuse("\"abc\".Replace(\"\",\"x\")"), "empty first argument");
+        }
+
+        /// <summary>
+        /// The literal is a resolved property value and may be a secret, so a parse failure
+        /// must not quote it back into a log or an exception message.
+        /// </summary>
+        [TestMethod]
+        public void DoesNotEchoTheLiteralInItsErrors()
+        {
+            var error = Refuse("\"s3cret-p4ssword\".Trim()");
+
+            Assert.IsFalse(error.Contains("s3cret"), $"The error disclosed the literal: {error}");
+        }
+        /// <summary>
+        /// The dependency is gone, not merely unused. Asserted against the production
+        /// assembly's own reference list rather than by inspecting a project file, so it stays
+        /// true if someone reintroduces the package transitively.
+        ///
+        /// This test project does reference the compiler — that is how the differential above
+        /// works — so this has to ask Dorc.Core about itself.
+        /// </summary>
+        [TestMethod]
+        public void TheCompilerIsNoLongerReferencedByTheAssemblyThatResolvesProperties()
+        {
+            var referenced = typeof(PropertyExpressionGrammar).Assembly
+                .GetReferencedAssemblies()
+                .Select(assembly => assembly.Name ?? string.Empty)
+                .ToList();
+
+            Assert.IsFalse(
+                referenced.Any(name => name.Contains("CodeAnalysis", StringComparison.OrdinalIgnoreCase)
+                    || name.Contains("Scripting", StringComparison.OrdinalIgnoreCase)),
+                "Dorc.Core references a compiler again: " + string.Join(", ", referenced));
+        }
+    }
+}

--- a/src/Dorc.Core/Dorc.Core.csproj
+++ b/src/Dorc.Core/Dorc.Core.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.25.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.14.0" />
     <PackageReference Include="Microsoft.Graph" Version="5.95.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.4" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="172.76.0" />

--- a/src/Dorc.Core/VariableResolution/PropertyExpressionEvaluator.cs
+++ b/src/Dorc.Core/VariableResolution/PropertyExpressionEvaluator.cs
@@ -1,12 +1,11 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
-using Microsoft.CodeAnalysis.CSharp.Scripting;
 
 namespace Dorc.Core.VariableResolution
 {
     public class PropertyExpressionEvaluator : IPropertyExpressionEvaluator
     {
-        // Per-instance, not static. A process-wide cache keyed on expression text outlives
+        // Results of successfully parsed expressions. Per-instance, not static. A process-wide cache keyed on expression text outlives
         // every request in the Monitor, so a value first computed while deploying to one
         // environment was returned unchanged when deploying to another - including from a
         // non-production deployment to a subsequent production one. The resolver constructs
@@ -38,7 +37,27 @@ namespace Dorc.Core.VariableResolution
                         return res;
                     }
 
-                    var resolvedValue = CSharpScript.EvaluateAsync(exp).Result;
+                    // Parsed, not compiled. The C# scripting dependency is gone from this
+                    // assembly: an estate inventory found every one of the 11 distinct
+                    // expressions in use to be a string literal followed by a chain of
+                    // lower-casing, upper-casing and replacement, which is a parser's job.
+                    if (!PropertyExpressionGrammar.TryEvaluate(exp, out var resolvedValue, out var error))
+                    {
+                        // Fail closed. Never fall back to compilation - that fallback would be
+                        // the weakness this step removes, and it is the only thing containing
+                        // the part of the inventory that could not be examined, since secure
+                        // configuration values are encrypted at rest and do reach here.
+                        //
+                        // The expression itself is not logged: it is a resolved property value
+                        // and may be a secret. The error names the shape of the failure and
+                        // where in the expression it occurred.
+                        _logger.LogError(
+                            "A property expression could not be parsed and was not evaluated: {Error}", error);
+
+                        throw new InvalidOperationException(
+                            $"A property expression could not be parsed and was not evaluated: {error}");
+                    }
+
                     _compiledResults[exp] = resolvedValue;
                     return resolvedValue;
                 }

--- a/src/Dorc.Core/VariableResolution/PropertyExpressionGrammar.cs
+++ b/src/Dorc.Core/VariableResolution/PropertyExpressionGrammar.cs
@@ -1,0 +1,305 @@
+﻿using System.Text;
+
+namespace Dorc.Core.VariableResolution
+{
+    /// <summary>
+    /// Parses and evaluates the whole of the expression language DOrc's property values
+    /// actually use.
+    ///
+    /// An estate inventory found 11 distinct expressions across 133 property values, every one
+    /// of a single shape: a double-quoted string literal followed by a left-to-right chain of
+    /// lower-casing, upper-casing and replacement. No loops, no reflection, no assembly
+    /// references, no type construction, no input or output. One expression accounts for 101 of
+    /// the 133 occurrences.
+    ///
+    /// That is a parser, not a compiler — so the C# scripting dependency is removed from this
+    /// assembly rather than restricted. A compiler reachable from deployment data is a class of
+    /// weakness; a parser for three operations is not.
+    ///
+    /// Token interpolation is NOT handled here, deliberately. It has already happened by the
+    /// time an expression reaches this point, so the literal being parsed is the substituted
+    /// text. That is also why parsing has to be strict: a substituted value containing a quote
+    /// makes the literal's extent ambiguous, and an ambiguous expression is refused rather than
+    /// guessed at.
+    ///
+    /// The grammar fails closed. Anything it cannot parse is an error and never falls back to
+    /// compilation. That is what contains the one part of the inventory that could not be
+    /// examined — secure configuration values are encrypted at rest, could not be inspected by
+    /// query, and do reach the evaluator.
+    /// </summary>
+    public static class PropertyExpressionGrammar
+    {
+        /// <summary>
+        /// Evaluates an expression, with the <c>fn:</c> marker already stripped.
+        /// </summary>
+        /// <param name="result">The evaluated string, when this returns true.</param>
+        /// <param name="error">
+        /// Why parsing failed, when this returns false. Deliberately describes the *shape* of
+        /// the failure and its position, and never quotes the literal's content — the literal
+        /// is a resolved property value and may be a secret.
+        /// </param>
+        public static bool TryEvaluate(string expression, out string result, out string error)
+        {
+            result = string.Empty;
+            error = string.Empty;
+
+            if (string.IsNullOrEmpty(expression))
+            {
+                error = "the expression is empty.";
+                return false;
+            }
+
+            var position = 0;
+
+            if (!TryReadStringLiteral(expression, ref position, out var value, out error))
+            {
+                return false;
+            }
+
+            while (position < expression.Length)
+            {
+                if (!TryApplyOperation(expression, ref position, ref value, out error))
+                {
+                    return false;
+                }
+            }
+
+            result = value;
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a C# double-quoted literal, honouring the escapes that can legitimately appear
+        /// in one. An unrecognised escape is a refusal rather than a passthrough: the point of
+        /// this type is that nothing it does not understand gets evaluated.
+        /// </summary>
+        private static bool TryReadStringLiteral(string expression, ref int position, out string value, out string error)
+        {
+            value = string.Empty;
+            error = string.Empty;
+
+            SkipWhitespace(expression, ref position);
+
+            if (position >= expression.Length || expression[position] != '"')
+            {
+                error = $"expected a double-quoted string literal at position {position}."
+                    + " Verbatim and interpolated literals are not part of the grammar.";
+                return false;
+            }
+
+            position++;
+
+            var literal = new StringBuilder();
+
+            while (position < expression.Length)
+            {
+                var character = expression[position];
+
+                if (character == '"')
+                {
+                    position++;
+                    value = literal.ToString();
+                    return true;
+                }
+
+                if (character != '\\')
+                {
+                    literal.Append(character);
+                    position++;
+                    continue;
+                }
+
+                position++;
+                if (position >= expression.Length)
+                {
+                    error = "the string literal ends with an incomplete escape sequence.";
+                    return false;
+                }
+
+                switch (expression[position])
+                {
+                    case '\\': literal.Append('\\'); break;
+                    case '"': literal.Append('"'); break;
+                    case 'n': literal.Append('\n'); break;
+                    case 'r': literal.Append('\r'); break;
+                    case 't': literal.Append('\t'); break;
+                    case '0': literal.Append('\0'); break;
+                    default:
+                        error = $"unsupported escape sequence at position {position}.";
+                        return false;
+                }
+
+                position++;
+            }
+
+            error = "the string literal is not closed.";
+            return false;
+        }
+
+        private static bool TryApplyOperation(string expression, ref int position, ref string value, out string error)
+        {
+            error = string.Empty;
+
+            SkipWhitespace(expression, ref position);
+
+            if (position >= expression.Length)
+            {
+                return true;
+            }
+
+            if (expression[position] != '.')
+            {
+                error = $"expected '.' before an operation at position {position}, or the end of the expression.";
+                return false;
+            }
+
+            position++;
+
+            // The operation name is read as a whole identifier before being matched, not
+            // prefix-matched. Prefix-matching "ToLower" against "ToLowerInvariant" would still
+            // refuse the expression - correctly - but blame the argument list rather than the
+            // unsupported operation, which sends whoever is diagnosing it the wrong way.
+            var operation = ReadIdentifier(expression, ref position);
+
+            switch (operation)
+            {
+                case "ToLower":
+                    if (!TryConsumeEmptyArgumentList(expression, ref position, operation, out error))
+                    {
+                        return false;
+                    }
+
+                    // Invariant rather than current-culture. The Turkish dotless i is the
+                    // standard example of why a deployment must not resolve a property
+                    // differently depending on the host's locale.
+                    value = value.ToLowerInvariant();
+                    return true;
+
+                case "ToUpper":
+                    if (!TryConsumeEmptyArgumentList(expression, ref position, operation, out error))
+                    {
+                        return false;
+                    }
+
+                    value = value.ToUpperInvariant();
+                    return true;
+
+                case "Replace":
+                    if (!TryReadReplaceArguments(expression, ref position, out var from, out var to, out error))
+                    {
+                        return false;
+                    }
+
+                    if (from.Length == 0)
+                    {
+                        // Replacing the empty string is not something the estate does, and .NET
+                        // throws for it. Refuse it here so the failure names the reason.
+                        error = "Replace was called with an empty first argument.";
+                        return false;
+                    }
+
+                    value = value.Replace(from, to, StringComparison.Ordinal);
+                    return true;
+
+                default:
+                    error = $"unsupported operation at position {position - operation.Length}."
+                        + " The grammar allows ToLower, ToUpper and Replace only.";
+                    return false;
+            }
+        }
+
+        private static string ReadIdentifier(string expression, ref int position)
+        {
+            SkipWhitespace(expression, ref position);
+
+            var start = position;
+            while (position < expression.Length
+                && (char.IsLetterOrDigit(expression[position]) || expression[position] == '_'))
+            {
+                position++;
+            }
+
+            return expression[start..position];
+        }
+
+        private static bool TryReadReplaceArguments(
+            string expression, ref int position, out string from, out string to, out string error)
+        {
+            from = string.Empty;
+            to = string.Empty;
+
+            SkipWhitespace(expression, ref position);
+
+            if (position >= expression.Length || expression[position] != '(')
+            {
+                error = $"expected '(' after Replace at position {position}.";
+                return false;
+            }
+
+            position++;
+
+            if (!TryReadStringLiteral(expression, ref position, out from, out error))
+            {
+                return false;
+            }
+
+            SkipWhitespace(expression, ref position);
+
+            if (position >= expression.Length || expression[position] != ',')
+            {
+                error = $"expected ',' between Replace arguments at position {position}."
+                    + " Replace takes exactly two string literals.";
+                return false;
+            }
+
+            position++;
+
+            if (!TryReadStringLiteral(expression, ref position, out to, out error))
+            {
+                return false;
+            }
+
+            SkipWhitespace(expression, ref position);
+
+            if (position >= expression.Length || expression[position] != ')')
+            {
+                error = $"expected ')' after the Replace arguments at position {position}.";
+                return false;
+            }
+
+            position++;
+            return true;
+        }
+
+        private static bool TryConsumeEmptyArgumentList(
+            string expression, ref int position, string operation, out string error)
+        {
+            error = string.Empty;
+
+            SkipWhitespace(expression, ref position);
+
+            if (position < expression.Length && expression[position] == '(')
+            {
+                position++;
+                SkipWhitespace(expression, ref position);
+
+                if (position < expression.Length && expression[position] == ')')
+                {
+                    position++;
+                    return true;
+                }
+            }
+
+            error = $"{operation} takes no arguments and must be written as {operation}().";
+            return false;
+        }
+
+        private static void SkipWhitespace(string expression, ref int position)
+        {
+            while (position < expression.Length && char.IsWhiteSpace(expression[position]))
+            {
+                position++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #855

**Stacked on #854.** Merge that first.

536 insertions across 6 files, most of it the parser and its tests.

## What changes

`Microsoft.CodeAnalysis.CSharp.Scripting` is **deleted** from `Dorc.Core` and replaced by a ~250-line parser for the three operations the estate actually uses. Verified absent from the `Dorc.Core`, `Dorc.Monitor` and `Dorc.Api` dependency graphs — and asserted by a test against the production assembly's own reference list, rather than by reading a project file, so it stays true if the package returns transitively.

## One correction to the plan's design notes

They call for the grammar to handle interpolation, including adjacent tokens (`$A$$B$`) and tokens abutting literal text (`$A$1uks`). **It must not.** Interpolation has already happened by the time an expression reaches the evaluator — `EvaluatePropertyValue` runs before `_expressionEvaluator.Evaluate` in the resolver — so what the parser sees is the *substituted* literal, and both cases reduce to ordinary literal content before parsing.

That ordering is also why parsing is strict rather than forgiving: a substituted value containing a quote makes the literal's extent ambiguous, and an ambiguous expression is refused rather than guessed at. There is a test for exactly that.

## The differential is real, not recorded

The scripting package moves to the **test project** so both implementations run side by side on the same corpus. Production no longer carries it.

The corpus uses post-interpolation forms — what actually reaches the evaluator — and covers every grammar feature the inventory recorded, rather than the verbatim eleven expressions, which the HLPS records by shape rather than in full.

## ⚠️ Failing closed has a cost, accepted deliberately

Secure config values are encrypted at rest, could not be inventoried, and **do** reach the evaluator. If one of them carries an `fn:` expression outside this grammar, it evaluated before and will now **fail the deployment**.

That is the trade the HLPS chose, and it is what contains the part of the inventory that could not be examined. The failure names the shape of the problem and its position, and deliberately does **not** quote the literal — the literal is a resolved property value and may be a secret. There is a test asserting the error does not echo it.

If you would rather find out before shipping than after, the check is: decrypt the secure `ConfigValue` set and confirm none of them starts with `fn:`.

## Also

Casing is invariant rather than current-culture, so a deployment cannot resolve a property differently depending on the host's locale.

Found while testing: prefix-matching operation names refused `ToLowerInvariant` correctly but blamed the argument list rather than the unsupported operation, which would send a diagnosis the wrong way. Operations are now read as whole identifiers.

## Tests

35 new — the differential, the grammar's own cases, and the fail-closed set (`Trim`, `Substring`, `ToLowerInvariant`, `File.ReadAllText`, `typeof(...).Assembly.Location`, arithmetic, verbatim literals).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_