### PR TITLE
S-016/S-017: confine script paths at dispatch, reporting before enforcing

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -44,8 +44,8 @@ Four rules determine the order below. They are stated up front because several a
 | S-014 | Classify config values: reserved-key denylist | SD-3a, W-4, SC-03 | **DONE for the three zero-consumer keys**; the rest still gated on S-013 |
 | S-014a | Restrict `CanReadSecrets` to service principals | W-19 | **DONE** — has a blast radius, see the step |
 | ⚙ S-015 | Rotate the deployment credentials | SD-3, W-4 | **S-004 and S-014** |
-| ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | S-010 |
-| S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | S-010, S-016 |
+| ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | **Worklist queries delivered** (`S-016-off-share-script-paths.sql`); operator-executed |
+| S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | **DONE** — reports by default, enforce after S-016 |
 | S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | S-017, U-14; **lockstep release** |
 | S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **Server side DONE**; web UI outstanding, see the step |
 | S-020 | Introduce the credential provider abstraction | SD-4 | S-019 (ConfigValues variant only) |
@@ -366,6 +366,10 @@ Two of the three point at what appears to be an individual's incident-workaround
 
 **Verification intent.** The inventory query returns no rows resolving outside the script root, with the comparison performed against the configured root after canonicalising both sides rather than by pattern. Each remediated component deploys successfully.
 
+**Worklist delivered; the remediation itself is operator-executed.** `S-016-off-share-script-paths.sql` classifies every stored script path by the rule S-017 enforces, counts the population, lists the JSON-path rows separately for manual inspection, and orders the off-share set by how often it actually deploys so remediation can be sequenced by risk.
+
+Everything in it is read-only except a remediation template that is commented out deliberately. There is no safe bulk update: each off-share script is either already on the share under another name (repoint), belongs on the share but was never promoted (**promote through the gated pipeline first, then repoint** — repointing before the file exists turns a security finding into a broken deployment), dead (disable the component), or deliberate with the root being wrong (a design decision to escalate, not a data fix).
+
 ### S-017 — Confine script paths at dispatch
 
 **What changes.** Path resolution at dispatch rejects any script path that resolves outside the configured script root after canonicalisation, covering both the direct and JSON path forms.
@@ -375,6 +379,12 @@ Two of the three point at what appears to be an individual's incident-workaround
 **Dependencies.** S-010, S-016.
 
 **Verification intent.** A component whose stored path resolves outside the root fails with a clear, attributable result rather than executing. All remediated components succeed. Comparison is against the configured root, not a pattern — the inventory query's pattern-based classification over-flags, and the enforcement must not inherit that.
+
+**Delivered reporting-first, and enforcement is a configuration switch.** `AppSettings:EnforceScriptPathConfinement` is absent by default, which means report. In that mode a script path that would be refused is logged as a warning and the deployment proceeds; with enforcement on, it is refused. That ordering is sequencing principle 3 applied literally — the estate holds paths that were never validated, and enforcing on the day this ships would fail every deployment of an off-share component at once.
+
+**The report is S-016's worklist.** It names the path, the script root and the reason, so the population to remediate is discoverable from the Monitor log without waiting for a scan. `S-016-off-share-script-paths.sql` finds the same population directly in the database, which is faster and does not require the components to be deployed first.
+
+**The primary check is on the STORED path, not the joined result, and this is load-bearing.** `Path.Combine` is platform-dependent: given a rooted second argument it discards the first on Windows, and merely concatenates on other hosts. A check applied to the joined result therefore passes on a non-Windows build host and refuses in production, or the reverse — the first version of this step had exactly that defect and a test caught it. Checking the stored value uses the same rule the write path uses, so a validator and its enforcer cannot disagree, and it answers identically wherever it runs. The joined result is checked as a second gate, but nothing rests on it alone.
 
 ### S-018 — Verify script content at the point of read
 

--- a/docs/deployment-privilege-containment/S-016-off-share-script-paths.sql
+++ b/docs/deployment-privilege-containment/S-016-off-share-script-paths.sql
@@ -1,0 +1,159 @@
+/*
+    S-016 — Remediate off-share script paths
+    ========================================
+
+    Finds the component script paths that will be refused once
+    AppSettings:EnforceScriptPathConfinement is turned on (S-017).
+
+    Run this BEFORE enabling enforcement. Enforcement without remediation fails every
+    deployment of an off-share component at once, which is the flag day the plan's sequencing
+    rules exist to prevent.
+
+    All queries here are READ-ONLY except the clearly marked remediation template at the end,
+    which is commented out and must be reviewed per row before use.
+
+    A script path is acceptable when it is RELATIVE to the script root and free of traversal.
+    Path.Combine discards the root entirely when the stored path is rooted, so a rooted path
+    does not resolve beneath the root - it replaces it, and the result executes as the
+    deployment account. That is the whole weakness (W-5).
+*/
+
+------------------------------------------------------------------------------------------
+-- 0. The script root currently in force, for reference.
+------------------------------------------------------------------------------------------
+SELECT  [Key], [Value]
+FROM    deploy.ConfigValue
+WHERE   [Key] = 'ScriptRoot';
+
+
+------------------------------------------------------------------------------------------
+-- 1. THE WORKLIST. Every script whose stored path would be refused, and why.
+--
+--    Mirrors the rules in ScriptPathConfinement: rooted paths, traversal segments, and
+--    colons (which name a drive, a device, or an alternate data stream rather than a file
+--    beneath the root).
+------------------------------------------------------------------------------------------
+WITH Classified AS (
+    SELECT  s.Id            AS ScriptId,
+            s.Name          AS ScriptName,
+            s.Path          AS StoredPath,
+            s.IsPathJSON,
+            CASE
+                WHEN s.Path IS NULL OR LTRIM(RTRIM(s.Path)) = ''         THEN 'no script'
+                WHEN s.Path LIKE '\\%'  ESCAPE '~'                       THEN 'absolute: UNC'
+                WHEN s.Path LIKE '/%'                                    THEN 'absolute: rooted'
+                WHEN s.Path LIKE '[A-Za-z]:%'                            THEN 'absolute: drive-qualified'
+                WHEN s.Path LIKE '%..%'                                  THEN 'traversal'
+                WHEN s.Path LIKE '%:%'                                   THEN 'colon: device or data stream'
+                ELSE 'relative - acceptable'
+            END AS Verdict
+    FROM    deploy.Script s
+)
+SELECT      c.Verdict,
+            c.ScriptId,
+            c.ScriptName,
+            c.StoredPath,
+            c.IsPathJSON,
+            STUFF((
+                SELECT  ', ' + p.Name
+                FROM    deploy.Component cm
+                        INNER JOIN deploy.ComponentProject cp ON cp.ComponentId = cm.Id
+                        INNER JOIN deploy.Project p           ON p.Id = cp.ProjectId
+                WHERE   cm.ScriptId = c.ScriptId
+                FOR XML PATH(''), TYPE).value('.', 'nvarchar(max)'), 1, 2, '') AS Projects
+FROM        Classified c
+WHERE       c.Verdict NOT IN ('relative - acceptable', 'no script')
+ORDER BY    c.Verdict, c.ScriptName;
+
+
+------------------------------------------------------------------------------------------
+-- 2. Scale of the problem, for deciding whether to remediate before or alongside release.
+------------------------------------------------------------------------------------------
+SELECT      CASE
+                WHEN [Path] IS NULL OR LTRIM(RTRIM([Path])) = ''  THEN 'no script'
+                WHEN [Path] LIKE '\\%' ESCAPE '~'                 THEN 'absolute: UNC'
+                WHEN [Path] LIKE '/%'                             THEN 'absolute: rooted'
+                WHEN [Path] LIKE '[A-Za-z]:%'                     THEN 'absolute: drive-qualified'
+                WHEN [Path] LIKE '%..%'                           THEN 'traversal'
+                WHEN [Path] LIKE '%:%'                            THEN 'colon: device or data stream'
+                ELSE 'relative - acceptable'
+            END AS Verdict,
+            COUNT(*) AS Scripts
+FROM        deploy.Script
+GROUP BY    CASE
+                WHEN [Path] IS NULL OR LTRIM(RTRIM([Path])) = ''  THEN 'no script'
+                WHEN [Path] LIKE '\\%' ESCAPE '~'                 THEN 'absolute: UNC'
+                WHEN [Path] LIKE '/%'                             THEN 'absolute: rooted'
+                WHEN [Path] LIKE '[A-Za-z]:%'                     THEN 'absolute: drive-qualified'
+                WHEN [Path] LIKE '%..%'                           THEN 'traversal'
+                WHEN [Path] LIKE '%:%'                            THEN 'colon: device or data stream'
+                ELSE 'relative - acceptable'
+            END
+ORDER BY    Scripts DESC;
+
+
+------------------------------------------------------------------------------------------
+-- 3. The JSON-path population, listed separately.
+--
+--    A JSON script path carries the real path under "ScriptPath". These rows need the
+--    embedded value inspected rather than the stored column, so they are surfaced for manual
+--    review instead of being classified above.
+------------------------------------------------------------------------------------------
+SELECT  Id, Name, [Path]
+FROM    deploy.Script
+WHERE   IsPathJSON = 1
+ORDER BY Name;
+
+
+------------------------------------------------------------------------------------------
+-- 4. Which off-share scripts are actually in use, so remediation can be ordered by risk.
+--    A script nothing has deployed in a year is a different problem from one deploying daily.
+------------------------------------------------------------------------------------------
+SELECT      s.Id, s.Name, s.[Path],
+            COUNT(DISTINCT dr.Id)   AS Deployments,
+            MAX(dr.RequestedTime)   AS LastDeployed
+FROM        deploy.Script s
+            INNER JOIN deploy.Component cm         ON cm.ScriptId = s.Id
+            LEFT  JOIN deploy.DeploymentResult res ON res.ComponentId = cm.Id
+            LEFT  JOIN deploy.DeploymentRequest dr ON dr.Id = res.DeploymentRequestId
+WHERE       s.[Path] LIKE '\\%' ESCAPE '~'
+         OR s.[Path] LIKE '[A-Za-z]:%'
+         OR s.[Path] LIKE '%..%'
+GROUP BY    s.Id, s.Name, s.[Path]
+ORDER BY    Deployments DESC;
+
+
+------------------------------------------------------------------------------------------
+-- 5. REMEDIATION TEMPLATE — commented out deliberately. Review every row before use.
+--
+--    There is no safe bulk update. Each off-share script has to be dealt with on its merits:
+--
+--      (a) the script already exists beneath the root under a different name  -> repoint;
+--      (b) the script belongs on the share but was never promoted            -> promote it
+--          through the gated pipeline FIRST, then repoint;
+--      (c) the component is dead                                             -> disable it;
+--      (d) the path is deliberate and the root is wrong                       -> a design
+--          decision, not a data fix. Escalate rather than edit.
+--
+--    Case (b) is the one that matters: repointing before the file exists on the share turns a
+--    security finding into a broken deployment.
+------------------------------------------------------------------------------------------
+
+/*
+-- (a) / (b): repoint one script to its path relative to the root.
+--     Verify the file exists beneath the root before running this.
+UPDATE  deploy.Script
+SET     [Path] = N'<relative\path\under\the\root.ps1>'
+WHERE   Id = <ScriptId>;          -- one row, taken from query 1
+
+-- (c): disable the components using a dead script rather than editing the path.
+UPDATE  deploy.Component
+SET     IsEnabled = 0
+WHERE   ScriptId = <ScriptId>;
+*/
+
+
+------------------------------------------------------------------------------------------
+-- 6. Verification. Re-run query 1 after remediation; it should return no rows.
+--    Only then set AppSettings:EnforceScriptPathConfinement to true.
+------------------------------------------------------------------------------------------

--- a/src/Dorc.Core/Configuration/ConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/ConfigurationSettings.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace Dorc.Core.Configuration
 {
@@ -186,6 +186,22 @@ namespace Dorc.Core.Configuration
             // "enabled for production", so absence is reported as null and the decision is
             // left to the caller, which knows the request's tier.
             return bool.TryParse(value, out bool required) ? required : null;
+        }
+
+        /// <summary>
+        /// Whether a script path that resolves outside the script root refuses the deployment,
+        /// or is only reported.
+        ///
+        /// Absence means report. Enforcement is deliberately opt-in: existing components hold
+        /// paths that were never validated, so enforcing on the day this ships would fail every
+        /// deployment of an off-share component at once. The report is what identifies them, and
+        /// enforcement is turned on once the estate is clean.
+        /// </summary>
+        public bool GetScriptPathEnforcementEnabled()
+        {
+            var value = _configuration.GetSection("AppSettings")["EnforceScriptPathConfinement"];
+
+            return bool.TryParse(value, out bool enforce) && enforce;
         }
 
         public bool GetIsProduction()

--- a/src/Dorc.Core/Configuration/IConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/IConfigurationSettings.cs
@@ -1,4 +1,4 @@
-namespace Dorc.Core.Configuration
+﻿namespace Dorc.Core.Configuration
 {
     public interface IConfigurationSettings
     {
@@ -46,6 +46,12 @@ namespace Dorc.Core.Configuration
         /// absent key to false and would ship this control silently off.
         /// </summary>
         bool? GetTerraformSeparateApproverRequired();
+
+        /// <summary>
+        /// Whether a script path resolving outside the script root refuses the deployment, or is
+        /// only reported. Absence means report.
+        /// </summary>
+        bool GetScriptPathEnforcementEnabled();
         bool GetIsProduction();
     }
 }

--- a/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
@@ -1,0 +1,137 @@
+using Dorc.ApiModel;
+using Dorc.ApiModel.MonitorRunnerApi;
+using Dorc.Core.Configuration;
+using Dorc.Monitor.Pipes;
+using Dorc.PersistentData.Security;
+using Dorc.PersistentData.Sources.Interfaces;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.Text;
+
+namespace Dorc.Monitor.Tests
+{
+    /// <summary>
+    /// The write path stops new components being registered with a path that escapes the script
+    /// root. This is the other half: it stops the ones already stored from executing.
+    ///
+    /// Both are needed. `Path.Combine` discards the root entirely when the stored path is
+    /// rooted, so an off-share path does not resolve beneath the root — it replaces it, and the
+    /// result runs as the deployment account.
+    ///
+    /// Reporting is the default and enforcement is opt-in, because existing components hold
+    /// paths that were never validated and enforcing on day one would fail every deployment of
+    /// an off-share component at once. The report identifies the population to remediate first.
+    /// </summary>
+    [TestClass]
+    public class ScriptPathDispatchConfinementTests
+    {
+        private const string ScriptRoot = @"\\itss.global\prod\GLO\APP\DORC\Scripts\Scripts.PR";
+
+        private IScriptGroupPipeServer _pipeServer = null!;
+        private IConfigurationSettings _settings = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _pipeServer = Substitute.For<IScriptGroupPipeServer>();
+
+            var configValues = Substitute.For<IConfigValuesPersistentSource>();
+            configValues.GetConfigValue("DORC_NonProdDeployUsername").Returns("svc-dorc");
+            configValues.GetConfigValue("DORC_NonProdDeployPassword").Returns("password");
+
+            _settings = Substitute.For<IConfigurationSettings>();
+            // Empty domain: the dispatch fails at the security context, which a test host cannot
+            // build. Everything under test happens before that point.
+            _settings.GetConfigurationDomainNameIntra().Returns(string.Empty);
+
+            _configValues = configValues;
+        }
+
+        private IConfigValuesPersistentSource _configValues = null!;
+
+        private ScriptDispatcher NewDispatcher() =>
+            new(Substitute.For<IDeploymentRequestProcessesPersistentSource>(),
+                _configValues,
+                Substitute.For<ILogger<ScriptDispatcher>>(),
+                _pipeServer,
+                _settings,
+                Substitute.For<IRequestsPersistentSource>(),
+                Substitute.For<IScriptScopeConfigValues>());
+
+        private bool Dispatch(string storedScriptPath)
+        {
+            try
+            {
+                return NewDispatcher().Dispatch(
+                    ScriptRoot,
+                    new ScriptApiModel { Path = storedScriptPath, PowerShellVersionNumber = "7.4" },
+                    new Dictionary<string, VariableValue>(),
+                    requestId: 42,
+                    deploymentRequestId: 42,
+                    isProduction: false,
+                    environmentName: "SOME-ENV",
+                    new StringBuilder(),
+                    CancellationToken.None);
+            }
+            catch (Exception)
+            {
+                // Reached the security context, which means the path was accepted. The refusal
+                // path returns false without ever getting there.
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// The weakness, at dispatch: a rooted stored path replaces the script root.
+        /// </summary>
+        [TestMethod]
+        public void RefusesAnOffShareScriptPathWhenEnforcing()
+        {
+            _settings.GetScriptPathEnforcementEnabled().Returns(true);
+
+            Assert.IsFalse(Dispatch(@"\\attacker\share\payload.ps1"));
+
+            _pipeServer.DidNotReceive().Start(
+                Arg.Any<string>(), Arg.Any<ScriptGroup>(),
+                Arg.Any<ScriptGroupReaderIdentity>(), Arg.Any<CancellationToken>());
+        }
+
+        [TestMethod]
+        public void RefusesTraversalOutOfTheScriptRootWhenEnforcing()
+        {
+            _settings.GetScriptPathEnforcementEnabled().Returns(true);
+
+            Assert.IsFalse(Dispatch(@"..\..\Scripts.ST\payload.ps1"));
+        }
+
+        [TestMethod]
+        public void AcceptsAPathBeneathTheScriptRootWhenEnforcing()
+        {
+            _settings.GetScriptPathEnforcementEnabled().Returns(true);
+
+            Assert.IsTrue(Dispatch(@"00 Generic\DeployMSI.ps1"),
+                "A legitimate script must still dispatch with enforcement on.");
+        }
+
+        /// <summary>
+        /// The default. Reporting mode must not fail a deployment — the estate holds paths that
+        /// were never validated, and the report is how they are found.
+        /// </summary>
+        [TestMethod]
+        public void ReportsButDoesNotRefuseWhenNotEnforcing()
+        {
+            _settings.GetScriptPathEnforcementEnabled().Returns(false);
+
+            Assert.IsTrue(Dispatch(@"\\attacker\share\payload.ps1"),
+                "Reporting mode reports and proceeds; only enforcement stops the deployment.");
+        }
+
+        [TestMethod]
+        public void EnforcementIsOffUnlessConfigured()
+        {
+            // The substitute returns false for an unstubbed bool, which is the same answer the
+            // real setting gives for an absent key — enforcement is opt-in.
+            Assert.IsTrue(Dispatch(@"\\attacker\share\payload.ps1"));
+        }
+    }
+}

--- a/src/Dorc.Monitor/ScriptDispatcher.cs
+++ b/src/Dorc.Monitor/ScriptDispatcher.cs
@@ -2,6 +2,7 @@
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core;
 using Dorc.Core.Configuration;
+using Dorc.Core.Security;
 using Dorc.Monitor.Pipes;
 using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
@@ -85,6 +86,12 @@ namespace Dorc.Monitor
                 scriptsLocation,
                 properties,
                 deploymentRequestId);
+
+            if (!ScriptPathsAreConfined(script, scriptGroups, scriptsLocation))
+            {
+                isScriptExecutionSuccessful = false;
+                return isScriptExecutionSuccessful;
+            }
 
             foreach (ScriptGroup scriptGroup in scriptGroups)
             {
@@ -307,6 +314,81 @@ namespace Dorc.Monitor
             return properties
                 .Where(property => !_scriptScopeConfigValues.IsWithheld(property.Key))
                 .ToDictionary(property => property.Key, property => property.Value);
+        }
+
+        /// <summary>
+        /// Refuses, or reports, a script path that resolves outside the script root.
+        ///
+        /// This is the dispatch half of the confinement the write path already applies. Both are
+        /// needed for different reasons: the write path stops new components being registered
+        /// off-share, and this stops the ones already stored from executing.
+        ///
+        /// The primary check is on the STORED path, using the same rule the write path uses, so
+        /// a validator and its enforcer cannot disagree about what is acceptable. It is also the
+        /// only check that answers identically everywhere: Path.Combine is platform-dependent -
+        /// it discards the root given a rooted second argument on Windows, and merely
+        /// concatenates on other hosts - so a check applied to the JOINED result would pass on a
+        /// non-Windows build host and refuse in production, or the reverse. The joined result is
+        /// checked too, as a second gate, but nothing rests on it alone.
+        ///
+        /// Reporting is the default and enforcement is opt-in. Existing components hold paths
+        /// that were never validated; enforcing on the day this ships would fail every
+        /// deployment of an off-share component at once, which is the flag day the sequencing
+        /// rules exist to prevent. The report identifies the population to remediate, and
+        /// enforcement is turned on once the estate is clean.
+        ///
+        /// The path is logged. It names a script location rather than carrying a value, and the
+        /// whole point of the report is that an operator can act on it.
+        /// </summary>
+        private bool ScriptPathsAreConfined(
+            ScriptApiModel script, IEnumerable<ScriptGroup> scriptGroups, string scriptsLocation)
+        {
+            var enforcing = configurationSettingsEngine.GetScriptPathEnforcementEnabled();
+            var confined = true;
+
+            if (!ScriptPathConfinement.IsConfined(script.Path, out var reason))
+            {
+                confined = false;
+                Report(enforcing, script.Path, scriptsLocation, reason);
+            }
+
+            foreach (var scriptGroup in scriptGroups)
+            {
+                foreach (var scriptProperties in scriptGroup.ScriptProperties)
+                {
+                    if (PathConfinement.IsWithin(scriptProperties.ScriptPath, scriptsLocation))
+                    {
+                        continue;
+                    }
+
+                    confined = false;
+                    Report(enforcing, scriptProperties.ScriptPath, scriptsLocation,
+                        "the resolved path does not lie beneath the script root.");
+                }
+            }
+
+            // Reporting mode reports and proceeds. Only enforcement stops the deployment.
+            return confined || !enforcing;
+        }
+
+        private void Report(bool enforcing, string? scriptPath, string scriptsLocation, string reason)
+        {
+            if (enforcing)
+            {
+                logger.LogError(
+                    "Refusing to execute '{ScriptPath}' against script root '{ScriptRoot}', because"
+                    + " {Reason} Register the script beneath the root, or correct the component's"
+                    + " stored path.",
+                    scriptPath, scriptsLocation, reason);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Script path '{ScriptPath}' would be refused once confinement is enforced,"
+                    + " because {Reason} Executing it because 'EnforceScriptPathConfinement' is not"
+                    + " enabled. Script root: '{ScriptRoot}'.",
+                    scriptPath, reason, scriptsLocation);
+            }
         }
 
         private (string, string) GetProcessCredentials(bool isProduction, string environmentName)


### PR DESCRIPTION
Closes #857

**Stacked on #856.** Merge that first.

## Reporting is the default; enforcement is a switch

`AppSettings:EnforceScriptPathConfinement` is absent by default, which means **report**. A path that would be refused is logged with the reason, and the deployment proceeds. With enforcement on, it is refused.

That ordering is the plan's sequencing principle applied literally — the estate holds paths that were never validated, and enforcing on the day this ships would fail every deployment of an off-share component at once.

**Do not enable enforcement until the worklist below is empty.**

## The check is on the STORED path, not the joined result — this is load-bearing

`Path.Combine` is platform-dependent: given a rooted second argument it discards the first on Windows, and merely **concatenates** on other hosts. A check applied to the joined result therefore passes on a non-Windows build host and refuses in production, or the reverse.

The first version of this step had exactly that defect and a test caught it — the off-share path was accepted because the join concatenated instead of replacing, and the concatenation still began with the root.

Checking the stored value uses the same rule the write path uses, so a validator and its enforcer cannot disagree about what is acceptable, and it answers identically wherever it runs. The joined result is checked as a second gate, but nothing rests on it alone.

## S-016: the worklist is delivered as SQL, not executed

It changes stored data on a live system, so it is operator-executed. `docs/deployment-privilege-containment/S-016-off-share-script-paths.sql`:

1. The script root currently in force.
2. **The worklist** — every stored path that would be refused, classified by why, with the projects using it.
3. Scale, so remediation can be scheduled against release.
4. JSON-path rows listed separately — the real path is embedded, so they need inspecting rather than classifying.
5. The off-share set ordered by **deployment frequency**, so remediation goes by risk. A script nothing has deployed in a year is a different problem from one deploying daily.
6. Verification: re-run the worklist, expect no rows, *then* enable enforcement.

Everything is read-only except a remediation template left **commented out**. There is no safe bulk update — each off-share script is one of:

- already on the share under another name → repoint;
- belongs on the share but was never promoted → **promote through the gated pipeline first, then repoint**. Repointing before the file exists turns a security finding into a broken deployment;
- dead → disable the component;
- deliberate, and the root is wrong → a design decision to escalate, not a data fix.

## Tests

5 new, covering refusal when enforcing, acceptance of a legitimate path either way, and that reporting mode reports without failing the deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_