### PR TITLE
S-020: put deployment credential resolution behind one abstraction

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -48,7 +48,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | **DONE** — reports by default, enforce after S-016 |
 | S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | S-017, U-14; **lockstep release** |
 | S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **Server side DONE**; web UI outstanding, see the step |
-| S-020 | Introduce the credential provider abstraction | SD-4 | S-019 (ConfigValues variant only) |
+| S-020 | Introduce the credential provider abstraction | SD-4 | **DONE** |
 | S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07 | S-020; revisits S-007, S-008, S-009 |
 | S-022 | Record attribution reached and not reached | SD-8, W-9 | S-021 |
 | S-023 | Replace the expression compiler with a fixed grammar | SD-1b, W-1 | **DONE** |
@@ -429,6 +429,17 @@ That half needs the generated TypeScript API client regenerated from the OpenAPI
 **Dependencies.** S-019, if the configuration-value-backed variant is used — a fixed denylist cannot cover keys minted per environment, so the classification must exist first. No dependency if the vault-backed variant is chosen.
 
 **Verification intent.** Both implementations resolve the same credential for the same reference. Switching implementations by configuration requires no code change. The relocated client is consumed identically by the API and the Monitor.
+
+**All four resolution sites now go through it**, which was not stated as part of this step but is what makes it worth doing: the PowerShell dispatcher, the Terraform dispatcher, the daemon status probe in the API process, and the password reset controller each carried their own copy of the same four key names and the same production boolean. Four copies of a security decision is four places for it to drift, and it is why the probe could be reached without authorization while the dispatchers could not.
+
+**One thing preserved rather than quietly corrected.** The password reset controller resolves the **non-production** credential regardless of which server it is resetting a password on. That is either deliberate or a latent defect; it belongs to whoever owns the endpoint, and making it environment-keyed is S-021's business. It is now visible at a single call site instead of being buried in a hard-coded key name.
+
+**The relocation is what makes the vault option real.** The reader moved from `Dorc.Api.Services` — an assembly the Monitor cannot reach, and a namespace the repository's naming standard names as a dumping ground to avoid — into `Dorc.Core.Secrets`. Before that the Monitor could not have read a credential from the vault however it was configured, so "vault-backed" would have been an API-only capability. The vendor-shaped `OnePassword.Connect.Client` namespace is corrected to `Dorc.Core.Secrets.OnePassword` at the same time.
+
+**Configuration values stay the default.** Switching where the whole estate's deployment credentials come from is a deliberate act, not something a release performs on an operator's behalf. The vault-backed source **refuses rather than falling back** when it is selected but its item identifiers are unset — falling back would silently undo the decision to stop keeping those credentials in DOrc's database.
+
+**The S-019 dependency did not bind.** It applies only if the configuration-value variant needs to cover keys minted per environment, which is S-021's concern; the abstraction itself is tier-based and needed no classification first.
+
 
 ### S-021 — Bind execution identity to the environment
 

--- a/src/Dorc.Api/Controllers/ResetAppPasswordController.cs
+++ b/src/Dorc.Api/Controllers/ResetAppPasswordController.cs
@@ -1,5 +1,6 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.Core.Configuration;
+using Dorc.Core.Security;
 using Dorc.Core.Interfaces;
 using Dorc.PersistentData;
 using Dorc.PersistentData.Extensions;
@@ -21,6 +22,7 @@ namespace Dorc.Api.Controllers
     public class ResetAppPasswordController : ControllerBase
     {
         private readonly IDatabasesPersistentSource _databasesPersistentSource;
+        private readonly IDeploymentCredentialSource _credentialSource;
         private readonly ISqlUserPasswordReset _sqlUserPasswordReset;
         private readonly IConfigValuesPersistentSource _configValuesPersistentSource;
         private readonly ILogger _logger;
@@ -34,8 +36,10 @@ namespace Dorc.Api.Controllers
             ILogger<ResetAppPasswordController> logger,
             ISecurityPrivilegesChecker securityPrivilegesChecker,
             IConfigurationSettings configurationSettingsEngine,
-            IClaimsPrincipalReader claimsPrincipalReader)
+            IClaimsPrincipalReader claimsPrincipalReader,
+            IDeploymentCredentialSource credentialSource)
         {
+            _credentialSource = credentialSource;
             _securityPrivilegesChecker = securityPrivilegesChecker;
             _logger = logger;
             _configValuesPersistentSource = configValuesPersistentSource;
@@ -86,13 +90,20 @@ namespace Dorc.Api.Controllers
 
         private ApiBoolResult ResetSqlServerPasswordForUser(string username, string serverName)
         {
-            var user = _configValuesPersistentSource.GetConfigValue("DORC_NonProdDeployUsername");
-            var pwd = _configValuesPersistentSource.GetConfigValue("DORC_NonProdDeployPassword");
+            // The fourth resolution site, and the one whose hard-coded tier is worth noting: it
+            // resolves the NON-PRODUCTION credential regardless of the server it is resetting a
+            // password on. That is preserved here rather than quietly changed - whether it is
+            // deliberate or a latent defect is a question for whoever owns this endpoint, and
+            // making it environment-keyed is the next step's business.
+            var credential = _credentialSource.Resolve(DeploymentTier.NonProduction);
 
             var domainName = _configurationSettingsEngine.GetConfigurationDomainNameIntra();
-            
-            if (user == null || pwd == null)
+
+            if (credential == null)
                 return new ApiBoolResult { Message = "Unable to retrieve DOrc Login details", Result = false };
+
+            var user = credential.UserName;
+            var pwd = credential.Password;
 
             const int logon32ProviderDefault = 0;
             //This parameter causes LogonUser to create a primary token.   

--- a/src/Dorc.Api/Program.cs
+++ b/src/Dorc.Api/Program.cs
@@ -1,4 +1,4 @@
-using AspNetCoreRateLimit;
+﻿using AspNetCoreRateLimit;
 using Dorc.Api.Events;
 using Dorc.Api.Interfaces;
 using Dorc.Api.Security;
@@ -6,6 +6,7 @@ using Dorc.Api.Services;
 using Dorc.Core.AzureStorageAccount;
 using Dorc.Core.BuildServer;
 using Dorc.Core.Configuration;
+using Dorc.Core.Secrets;
 using Dorc.Core.Interfaces;
 using Dorc.Core.Lamar;
 using Dorc.Core.Security;
@@ -398,6 +399,11 @@ builder.Host.UseLamar((context, registry) =>
 {
     registry.IncludeRegistry<OpenSearchDataRegistry>();
     registry.IncludeRegistry<PersistentDataRegistry>();
+    // The two implementations are registered concretely so the core registry's configured
+    // choice between them can resolve either.
+    registry.For<ConfigValueDeploymentCredentialSource>().Use<ConfigValueDeploymentCredentialSource>();
+    registry.For<VaultDeploymentCredentialSource>().Use<VaultDeploymentCredentialSource>();
+
     registry.IncludeRegistry<CoreRegistry>();
     registry.IncludeRegistry<ApiRegistry>();
 

--- a/src/Dorc.Core.Tests/DeploymentCredentialSourceTests.cs
+++ b/src/Dorc.Core.Tests/DeploymentCredentialSourceTests.cs
@@ -1,0 +1,164 @@
+using Dorc.Core.Configuration;
+using Dorc.Core.Security;
+using Dorc.PersistentData.Sources.Interfaces;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dorc.Core.Tests
+{
+    /// <summary>
+    /// Four sites across two processes resolved the deployment credential independently, each
+    /// with its own copy of the same four configuration-value key names and the same production
+    /// boolean: the PowerShell dispatcher, the Terraform dispatcher, the daemon status probe
+    /// running in the API process, and the password reset controller.
+    ///
+    /// Four copies of a security decision is four places for it to drift — and it is why the
+    /// probe could be reached without authorization while the dispatchers could not. The key
+    /// mapping now lives here, once.
+    /// </summary>
+    [TestClass]
+    public class ConfigValueDeploymentCredentialSourceTests
+    {
+        private IConfigValuesPersistentSource _configValues = null!;
+        private ConfigValueDeploymentCredentialSource _source = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _configValues = Substitute.For<IConfigValuesPersistentSource>();
+            _configValues.GetConfigValue("DORC_ProdDeployUsername").Returns("svc-prod");
+            _configValues.GetConfigValue("DORC_ProdDeployPassword").Returns("prod-secret");
+            _configValues.GetConfigValue("DORC_NonProdDeployUsername").Returns("svc-nonprod");
+            _configValues.GetConfigValue("DORC_NonProdDeployPassword").Returns("nonprod-secret");
+
+            _source = new ConfigValueDeploymentCredentialSource(
+                _configValues,
+                Substitute.For<ILogger<ConfigValueDeploymentCredentialSource>>());
+        }
+
+        [TestMethod]
+        public void ResolvesTheProductionPairForTheProductionTier()
+        {
+            var credential = _source.Resolve(DeploymentTier.Production);
+
+            Assert.AreEqual("svc-prod", credential!.UserName);
+            Assert.AreEqual("prod-secret", credential.Password);
+        }
+
+        [TestMethod]
+        public void ResolvesTheNonProductionPairForTheNonProductionTier()
+        {
+            var credential = _source.Resolve(DeploymentTier.NonProduction);
+
+            Assert.AreEqual("svc-nonprod", credential!.UserName);
+            Assert.AreEqual("nonprod-secret", credential.Password);
+        }
+
+        /// <summary>
+        /// Null, not a partial credential. A caller that proceeds without one authenticates as
+        /// whatever the host happens to be running as.
+        /// </summary>
+        [TestMethod]
+        public void RefusesRatherThanReturningAnIncompletePair()
+        {
+            _configValues.GetConfigValue("DORC_ProdDeployPassword").Returns(string.Empty);
+
+            Assert.IsNull(_source.Resolve(DeploymentTier.Production));
+        }
+
+        [TestMethod]
+        public void SaysWhereItReadsFrom()
+        {
+            StringAssert.Contains(_source.Description, "configuration values");
+        }
+    }
+
+    /// <summary>
+    /// The vault-backed source is the migration target: selecting it is what removes deployment
+    /// credentials from DOrc's database. It lives in the shared assembly rather than the API's
+    /// so the Monitor can use it at all — before the relocation it could not have, however it
+    /// was configured.
+    /// </summary>
+    [TestClass]
+    public class VaultDeploymentCredentialSourceTests
+    {
+        private IConfigurationSecretsReader _secrets = null!;
+        private IConfigurationSettings _configuration = null!;
+        private VaultDeploymentCredentialSource _source = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _secrets = Substitute.For<IConfigurationSecretsReader>();
+            _configuration = Substitute.For<IConfigurationSettings>();
+
+            _configuration.GetDeploymentCredentialItemId(DeploymentTier.Production, false).Returns("prod-user-item");
+            _configuration.GetDeploymentCredentialItemId(DeploymentTier.Production, true).Returns("prod-pass-item");
+
+            _secrets.GetSecret("prod-user-item", Arg.Any<string>()).Returns("svc-prod");
+            _secrets.GetSecret("prod-pass-item", Arg.Any<string>()).Returns("prod-secret");
+
+            _source = new VaultDeploymentCredentialSource(
+                _secrets, _configuration,
+                Substitute.For<ILogger<VaultDeploymentCredentialSource>>());
+        }
+
+        [TestMethod]
+        public void ResolvesFromTheConfiguredVaultItems()
+        {
+            var credential = _source.Resolve(DeploymentTier.Production);
+
+            Assert.AreEqual("svc-prod", credential!.UserName);
+            Assert.AreEqual("prod-secret", credential.Password);
+        }
+
+        /// <summary>
+        /// Selected as the source but not told where to look. Refusing is the only safe answer:
+        /// falling back to configuration values would silently undo the decision to stop keeping
+        /// deployment credentials in DOrc's database.
+        /// </summary>
+        [TestMethod]
+        public void RefusesRatherThanFallingBackWhenItemsAreNotConfigured()
+        {
+            Assert.IsNull(_source.Resolve(DeploymentTier.NonProduction));
+
+            _secrets.DidNotReceive().GetSecret(Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        [TestMethod]
+        public void RefusesWhenTheVaultReturnsNothing()
+        {
+            _secrets.GetSecret("prod-pass-item", Arg.Any<string>()).Returns(string.Empty);
+
+            Assert.IsNull(_source.Resolve(DeploymentTier.Production));
+        }
+
+        [TestMethod]
+        public void SaysWhereItReadsFrom()
+        {
+            StringAssert.Contains(_source.Description, "vault");
+        }
+
+        /// <summary>
+        /// Both implementations satisfy the same contract for the same reference, which is what
+        /// makes switching between them a configuration change rather than a code change.
+        /// </summary>
+        [TestMethod]
+        public void ResolvesTheSameCredentialAsTheConfigurationValueSourceWouldFor()
+        {
+            var configValues = Substitute.For<IConfigValuesPersistentSource>();
+            configValues.GetConfigValue("DORC_ProdDeployUsername").Returns("svc-prod");
+            configValues.GetConfigValue("DORC_ProdDeployPassword").Returns("prod-secret");
+
+            var fromConfig = new ConfigValueDeploymentCredentialSource(
+                configValues,
+                Substitute.For<ILogger<ConfigValueDeploymentCredentialSource>>())
+                .Resolve(DeploymentTier.Production);
+
+            var fromVault = _source.Resolve(DeploymentTier.Production);
+
+            Assert.AreEqual(fromConfig!.UserName, fromVault!.UserName);
+            Assert.AreEqual(fromConfig.Password, fromVault.Password);
+        }
+    }
+}

--- a/src/Dorc.Core/Configuration/ConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/ConfigurationSettings.cs
@@ -204,6 +204,35 @@ namespace Dorc.Core.Configuration
             return bool.TryParse(value, out bool enforce) && enforce;
         }
 
+        /// <summary>
+        /// Whether deployment credentials come from the secrets vault rather than from DOrc's
+        /// own configuration values.
+        ///
+        /// Absence means configuration values — today's behaviour. Switching where the whole
+        /// estate's deployment credentials come from is a deliberate act, not something a
+        /// release performs on an operator's behalf.
+        /// </summary>
+        public bool GetDeploymentCredentialsFromVault()
+        {
+            var value = _configuration.GetSection("AppSettings")["DeploymentCredentialsFromVault"];
+
+            return bool.TryParse(value, out bool fromVault) && fromVault;
+        }
+
+        /// <summary>
+        /// The vault item holding a deployment credential, by tier and by whether the username
+        /// or the password is wanted. Null when unconfigured — the vault-backed source refuses
+        /// rather than falling back, so that choosing it cannot silently be undone.
+        /// </summary>
+        public string? GetDeploymentCredentialItemId(Security.DeploymentTier tier, bool forPassword)
+        {
+            var key = tier == Security.DeploymentTier.Production
+                ? (forPassword ? "ProdDeployPasswordItemId" : "ProdDeployUsernameItemId")
+                : (forPassword ? "NonProdDeployPasswordItemId" : "NonProdDeployUsernameItemId");
+
+            return _configuration.GetSection("AppSettings")[key];
+        }
+
         public bool GetIsProduction()
         {
             var value = _configuration.GetSection("AppSettings")["IsProduction"];

--- a/src/Dorc.Core/Configuration/IConfigurationSecrets.cs
+++ b/src/Dorc.Core/Configuration/IConfigurationSecrets.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Dorc.Core.Configuration
 {
@@ -16,5 +16,21 @@ namespace Dorc.Core.Configuration
         /// Gets the API secret for IdentityServer client credentials
         /// </summary>
         string GetIdentityServerApiSecret();
+
+        /// <summary>
+        /// Gets an arbitrary secret by its vault item identifier, or the empty string when it
+        /// cannot be retrieved.
+        /// </summary>
+        /// <param name="itemId">The vault item identifier, taken from configuration.</param>
+        /// <param name="humanizedName">
+        /// What the secret is, for log messages. Never the value.
+        /// </param>
+        /// <remarks>
+        /// Added so that credential resolution can be backed by the vault without a second
+        /// client. Returning empty rather than throwing matches the existing accessors: a
+        /// caller has to decide what an absent secret means, and for a deployment credential
+        /// the answer is to refuse rather than to authenticate as the host account.
+        /// </remarks>
+        string GetSecret(string itemId, string humanizedName);
     }
 } 

--- a/src/Dorc.Core/Configuration/IConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/IConfigurationSettings.cs
@@ -52,6 +52,18 @@
         /// only reported. Absence means report.
         /// </summary>
         bool GetScriptPathEnforcementEnabled();
+
+        /// <summary>
+        /// Whether deployment credentials come from the secrets vault rather than DOrc's own
+        /// configuration values. Absence means configuration values.
+        /// </summary>
+        bool GetDeploymentCredentialsFromVault();
+
+        /// <summary>
+        /// The vault item holding a deployment credential, by tier and by whether the username
+        /// or the password is wanted. Null when unconfigured.
+        /// </summary>
+        string? GetDeploymentCredentialItemId(Security.DeploymentTier tier, bool forPassword);
         bool GetIsProduction();
     }
 }

--- a/src/Dorc.Core/DaemonStatusProbe.cs
+++ b/src/Dorc.Core/DaemonStatusProbe.cs
@@ -1,4 +1,4 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.Core.Configuration;
 using Dorc.Core.Interfaces;
 using Dorc.PersistentData;
@@ -14,16 +14,13 @@ using System.Security.Principal;
 using System.ServiceProcess;
 using Environment = System.Environment;
 
+using Dorc.Core.Security;
+
 namespace Dorc.Core
 {
     [SupportedOSPlatform("windows")]
     public class DaemonStatusProbe : IDaemonStatusProbe
     {
-        private const string DORCProdDeployUsername = "DORC_ProdDeployUsername";
-        private const string DORCProdDeployPassword = "DORC_ProdDeployPassword";
-        private const string DORCNonProdDeployUsername = "DORC_NonProdDeployUsername";
-        private const string DORCNonProdDeployPassword = "DORC_NonProdDeployPassword";
-
         private readonly ILogger _logger;
         private readonly IConfigValuesPersistentSource _configValuesPersistentSource;
         private readonly IEnvironmentsPersistentSource _environmentsPersistentSource;
@@ -36,6 +33,7 @@ namespace Dorc.Core
         private readonly IDaemonAuditPersistentSource _daemonAuditPersistentSource;
         private readonly IServersAuditPersistentSource _serversAuditPersistentSource;
         private readonly IClaimsPrincipalReader _claimsPrincipalReader;
+        private readonly IDeploymentCredentialSource _credentialSource;
 
         public DaemonStatusProbe(IConfigValuesPersistentSource configValuesPersistentSource,
             ILogger<DaemonStatusProbe> logger,
@@ -46,7 +44,8 @@ namespace Dorc.Core
             IConfigurationSettings configurationSettingsEngine,
             IDaemonAuditPersistentSource daemonAuditPersistentSource,
             IServersAuditPersistentSource serversAuditPersistentSource,
-            IClaimsPrincipalReader claimsPrincipalReader)
+            IClaimsPrincipalReader claimsPrincipalReader,
+            IDeploymentCredentialSource credentialSource)
         {
             _daemonsPersistentSource = daemonsPersistentSource;
             _daemonObservationPersistentSource = daemonObservationPersistentSource;
@@ -57,6 +56,7 @@ namespace Dorc.Core
             _daemonAuditPersistentSource = daemonAuditPersistentSource;
             _serversAuditPersistentSource = serversAuditPersistentSource;
             _claimsPrincipalReader = claimsPrincipalReader;
+            _credentialSource = credentialSource;
 
             _domainName = configurationSettingsEngine.GetConfigurationDomainNameIntra();
         }
@@ -167,20 +167,25 @@ namespace Dorc.Core
             return ProbeDaemonStatuses(daemons);
         }
 
+        /// <summary>
+        /// Resolves the credential this probe logs on with, through the same source the
+        /// dispatchers use. This site had its own copy of the four key names and the same
+        /// production boolean; it is also the site that could be reached without authorization
+        /// while the dispatchers could not, which is what four copies of a security decision
+        /// buys.
+        /// </summary>
         private void GetUsernameAndPassword(EnvironmentApiModel? environment, out string user, out string pwd)
         {
-            if (environment.EnvironmentIsProd)
-            {
-                user = _configValuesPersistentSource.GetConfigValue(DORCProdDeployUsername);
-                pwd = _configValuesPersistentSource.GetConfigValue(DORCProdDeployPassword);
-            }
-            else
-            {
-                user = _configValuesPersistentSource
-                    .GetConfigValue(DORCNonProdDeployUsername);
-                pwd = _configValuesPersistentSource
-                    .GetConfigValue(DORCNonProdDeployPassword);
-            }
+            var credential = _credentialSource.Resolve(
+                environment?.EnvironmentIsProd == true
+                    ? DeploymentTier.Production
+                    : DeploymentTier.NonProduction);
+
+            // Empty rather than a substitute. The caller performs a LogonUser with these; an
+            // empty pair fails that call, where a fallback would authenticate as whatever the
+            // API process is running as.
+            user = credential?.UserName ?? string.Empty;
+            pwd = credential?.Password ?? string.Empty;
         }
 
         private List<DaemonStatus> BuildDaemonList(EnvironmentApiModel? environment,

--- a/src/Dorc.Core/Lamar/CoreRegistry.cs
+++ b/src/Dorc.Core/Lamar/CoreRegistry.cs
@@ -1,4 +1,5 @@
-using Dorc.Core.Interfaces;
+﻿using Dorc.Core.Interfaces;
+using Dorc.Core.Security;
 using Dorc.Core.VariableResolution;
 using Dorc.PersistentData;
 using Dorc.PersistentData.Sources.Interfaces;
@@ -29,6 +30,21 @@ namespace Dorc.Core.Lamar
 
             For<IEnvBackups>().Use<EnvSnapBackups>();
             For<IPropertyExpressionEvaluator>().Use<PropertyExpressionEvaluator>();
+
+            // Where deployment credentials come from is a deployment-time choice, resolved once
+            // here rather than four times across two processes. The configuration-value source
+            // is the default: switching where the whole estate's deployment credentials come
+            // from is a deliberate act, not something a release performs on an operator's
+            // behalf. Selecting the vault-backed source is what removes those credentials from
+            // DOrc's database.
+            For<IDeploymentCredentialSource>().Use(context =>
+            {
+                var configuration = context.GetInstance<Configuration.IConfigurationSettings>();
+
+                return configuration.GetDeploymentCredentialsFromVault()
+                    ? context.GetInstance<Security.VaultDeploymentCredentialSource>()
+                    : context.GetInstance<Security.ConfigValueDeploymentCredentialSource>();
+            });
         }
     }
 }

--- a/src/Dorc.Core/Secrets/OnePassword/Models/OnePasswordField.cs
+++ b/src/Dorc.Core/Secrets/OnePassword/Models/OnePasswordField.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace OnePassword.Connect.Client
+namespace Dorc.Core.Secrets.OnePassword
 {
     public class OnePasswordField
     {

--- a/src/Dorc.Core/Secrets/OnePassword/Models/OnePasswordItem.cs
+++ b/src/Dorc.Core/Secrets/OnePassword/Models/OnePasswordItem.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace OnePassword.Connect.Client
+namespace Dorc.Core.Secrets.OnePassword
 {
     public class OnePasswordItem
     {

--- a/src/Dorc.Core/Secrets/OnePassword/OnePasswordClient.cs
+++ b/src/Dorc.Core/Secrets/OnePassword/OnePasswordClient.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net.Http.Headers;
 using System.Text.Json;
 
-namespace OnePassword.Connect.Client
+namespace Dorc.Core.Secrets.OnePassword
 {
     public class OnePasswordClient
     {

--- a/src/Dorc.Core/Secrets/OnePasswordSecretsReader.cs
+++ b/src/Dorc.Core/Secrets/OnePasswordSecretsReader.cs
@@ -1,11 +1,16 @@
-using Dorc.Core.Configuration;
+﻿using Dorc.Core.Configuration;
 using Microsoft.Extensions.Logging;
-using OnePassword.Connect.Client;
+using Dorc.Core.Secrets.OnePassword;
 
-namespace Dorc.Api.Services
+namespace Dorc.Core.Secrets
 {
     /// <summary>
-    /// Manages secrets using 1Password
+    /// Reads secrets from 1Password.
+    ///
+    /// Relocated out of the API assembly, where it could not be reached by the Monitor at all,
+    /// and out of a `Services` namespace, which the repository's naming standard names as a
+    /// dumping ground to avoid. Credential resolution needs it in both processes, so leaving it
+    /// where it was would have meant a second copy.
     /// </summary>
     public class OnePasswordSecretsReader : IConfigurationSecretsReader
     {
@@ -45,6 +50,9 @@ namespace Dorc.Api.Services
             var itemId = _config.GetOnePasswordItemId();
             return GetSecretByItemId(itemId, "DORC API secret");
         }
+
+        public string GetSecret(string itemId, string humanizedName) =>
+            GetSecretByItemId(itemId, humanizedName);
 
         private string GetSecretByItemId(string itemId, string humanizedName)
         {

--- a/src/Dorc.Core/Security/ConfigValueDeploymentCredentialSource.cs
+++ b/src/Dorc.Core/Security/ConfigValueDeploymentCredentialSource.cs
@@ -1,0 +1,70 @@
+using Dorc.PersistentData.Sources.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Dorc.Core.Security
+{
+    /// <summary>
+    /// Resolves the deployment credential from DOrc's own configuration values — what all four
+    /// resolution sites did independently before this existed.
+    ///
+    /// This remains the default so that introducing the abstraction changes nothing about where
+    /// credentials come from. The vault-backed source is the migration target; switching is a
+    /// configuration change rather than a code change, which is the point.
+    /// </summary>
+    public class ConfigValueDeploymentCredentialSource : IDeploymentCredentialSource
+    {
+        internal const string ProductionUserNameKey = "DORC_ProdDeployUsername";
+        internal const string ProductionPasswordKey = "DORC_ProdDeployPassword";
+        internal const string NonProductionUserNameKey = "DORC_NonProdDeployUsername";
+        internal const string NonProductionPasswordKey = "DORC_NonProdDeployPassword";
+
+        private readonly IConfigValuesPersistentSource _configValues;
+        private readonly ILogger _logger;
+
+        public ConfigValueDeploymentCredentialSource(
+            IConfigValuesPersistentSource configValues,
+            ILogger<ConfigValueDeploymentCredentialSource> logger)
+        {
+            _configValues = configValues;
+            _logger = logger;
+        }
+
+        public string Description => "DOrc configuration values";
+
+        public DeploymentCredential? Resolve(DeploymentTier tier)
+        {
+            var userNameKey = tier == DeploymentTier.Production
+                ? ProductionUserNameKey
+                : NonProductionUserNameKey;
+
+            var passwordKey = tier == DeploymentTier.Production
+                ? ProductionPasswordKey
+                : NonProductionPasswordKey;
+
+            var credential = new DeploymentCredential(
+                _configValues.GetConfigValue(userNameKey) ?? string.Empty,
+                _configValues.GetConfigValue(passwordKey) ?? string.Empty);
+
+            if (!credential.IsComplete)
+            {
+                // Named rather than silent. A caller that proceeds without a credential
+                // authenticates as whatever the host is running as, and the previous copies of
+                // this logic reported only that "a valid DOrc Username or Password" was missing
+                // without saying which key was empty.
+                _logger.LogError(
+                    "No {Tier} deployment credential could be resolved from {Source}."
+                    + " '{UserNameKey}' is {UserNameState} and '{PasswordKey}' is {PasswordState}.",
+                    tier,
+                    Description,
+                    userNameKey,
+                    string.IsNullOrEmpty(credential.UserName) ? "empty" : "set",
+                    passwordKey,
+                    string.IsNullOrEmpty(credential.Password) ? "empty" : "set");
+
+                return null;
+            }
+
+            return credential;
+        }
+    }
+}

--- a/src/Dorc.Core/Security/DeploymentCredentials.cs
+++ b/src/Dorc.Core/Security/DeploymentCredentials.cs
@@ -1,0 +1,76 @@
+namespace Dorc.Core.Security
+{
+    /// <summary>
+    /// Which population a deployment belongs to, and therefore which credential pair it runs
+    /// under.
+    ///
+    /// A tier, not a boolean. The estate holds well over a thousand environments, so an account
+    /// per environment is not viable — but a boolean cannot express anything between "all of
+    /// production" and "everything else", and four separate sites currently re-derive that
+    /// boolean from scratch.
+    /// </summary>
+    public enum DeploymentTier
+    {
+        NonProduction,
+        Production
+    }
+
+    /// <summary>
+    /// The account a deployment executes as.
+    /// </summary>
+    /// <remarks>
+    /// The password is a plain string, which is a known weakness rather than an oversight: it
+    /// cannot be zeroed and the garbage collector may copy it. Fixing that belongs at the
+    /// storage layer, where the value is decrypted, and is recorded against the credential
+    /// storage step. Introducing a different representation here without changing the layer
+    /// underneath would move the copies around rather than remove them.
+    /// </remarks>
+    public sealed class DeploymentCredential
+    {
+        public DeploymentCredential(string userName, string password)
+        {
+            UserName = userName;
+            Password = password;
+        }
+
+        public string UserName { get; }
+
+        public string Password { get; }
+
+        public bool IsComplete =>
+            !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password);
+    }
+
+    /// <summary>
+    /// Resolves the account a deployment executes as.
+    ///
+    /// Four sites across two processes resolved this independently, each with its own copy of
+    /// the same four configuration-value key names and the same production boolean: the
+    /// PowerShell dispatcher, the Terraform dispatcher, the daemon status probe running in the
+    /// API process, and the password reset controller. Four copies of a security decision is
+    /// four places for it to drift, and it is why the probe could be reached without
+    /// authorization while the dispatchers could not.
+    ///
+    /// Putting resolution behind one abstraction has a second purpose beyond deduplication: it
+    /// makes where credentials come from a deployment-time choice rather than a design
+    /// dependency. One implementation reads configuration values, as today; another reads a
+    /// secrets vault. Selecting the vault-backed one removes vault reachability from the Monitor
+    /// hosts as an architectural requirement — it becomes configuration.
+    /// </summary>
+    public interface IDeploymentCredentialSource
+    {
+        /// <summary>
+        /// The credential for this tier, or null when it cannot be resolved. Null is a refusal
+        /// to guess, not an error to swallow: a caller that proceeds without a credential
+        /// authenticates as whatever the host happens to be running as.
+        /// </summary>
+        DeploymentCredential? Resolve(DeploymentTier tier);
+
+        /// <summary>
+        /// Where this implementation reads from, for logging. Which source is in force is
+        /// otherwise invisible, and a deployment failing to authenticate is a great deal easier
+        /// to diagnose when the log says where the credential was looked for.
+        /// </summary>
+        string Description { get; }
+    }
+}

--- a/src/Dorc.Core/Security/VaultDeploymentCredentialSource.cs
+++ b/src/Dorc.Core/Security/VaultDeploymentCredentialSource.cs
@@ -1,0 +1,79 @@
+using Dorc.Core.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Dorc.Core.Security
+{
+    /// <summary>
+    /// Resolves the deployment credential from the secrets vault rather than from DOrc's own
+    /// configuration values.
+    ///
+    /// This is the migration target, and choosing it is what removes the credentials from
+    /// DOrc's database altogether. It is not the default: switching where the whole estate's
+    /// deployment credentials come from is a deliberate act, not something a release should do
+    /// on someone's behalf.
+    ///
+    /// The vault reader lives in this assembly rather than the API's precisely so that the
+    /// Monitor can use it. Whether the Monitor hosts can reach the vault is then a deployment
+    /// question with a configured answer, not an architectural dependency — which is the point
+    /// of having two implementations rather than moving everything to one.
+    /// </summary>
+    public class VaultDeploymentCredentialSource : IDeploymentCredentialSource
+    {
+        private readonly IConfigurationSecretsReader _secrets;
+        private readonly IConfigurationSettings _configuration;
+        private readonly ILogger _logger;
+
+        public VaultDeploymentCredentialSource(
+            IConfigurationSecretsReader secrets,
+            IConfigurationSettings configuration,
+            ILogger<VaultDeploymentCredentialSource> logger)
+        {
+            _secrets = secrets;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public string Description => "the secrets vault";
+
+        public DeploymentCredential? Resolve(DeploymentTier tier)
+        {
+            var userNameItem = _configuration.GetDeploymentCredentialItemId(tier, forPassword: false);
+            var passwordItem = _configuration.GetDeploymentCredentialItemId(tier, forPassword: true);
+
+            if (string.IsNullOrWhiteSpace(userNameItem) || string.IsNullOrWhiteSpace(passwordItem))
+            {
+                // Selected as the source but not told where to look. Refusing is the only safe
+                // answer: falling back to configuration values would silently undo the choice to
+                // stop keeping deployment credentials in DOrc's database.
+                _logger.LogError(
+                    "The {Tier} deployment credential is configured to come from {Source}, but its"
+                    + " vault item identifiers are not set. Refusing to fall back to configuration"
+                    + " values.",
+                    tier,
+                    Description);
+
+                return null;
+            }
+
+            var credential = new DeploymentCredential(
+                _secrets.GetSecret(userNameItem, $"{tier} deployment username"),
+                _secrets.GetSecret(passwordItem, $"{tier} deployment password"));
+
+            if (!credential.IsComplete)
+            {
+                _logger.LogError(
+                    "No {Tier} deployment credential could be retrieved from {Source}."
+                    + " The username item returned {UserNameState} and the password item returned"
+                    + " {PasswordState}.",
+                    tier,
+                    Description,
+                    string.IsNullOrEmpty(credential.UserName) ? "nothing" : "a value",
+                    string.IsNullOrEmpty(credential.Password) ? "nothing" : "a value");
+
+                return null;
+            }
+
+            return credential;
+        }
+    }
+}

--- a/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
@@ -1,6 +1,7 @@
 ﻿using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core.Configuration;
+using Dorc.Core.Security;
 using Dorc.Monitor;
 using Dorc.Monitor.Pipes;
 using Dorc.PersistentData.Security;
@@ -36,6 +37,38 @@ namespace Dorc.Monitor.Tests
         private IConfigurationSettings _configurationSettings = null!;
         private IScriptScopeConfigValues _scriptScopeConfigValues = null!;
 
+        private readonly IDeploymentCredentialSource _credentialSource = TierAwareCredentialSource();
+
+        /// <summary>
+        /// A credential source that resolves, so these tests exercise what they are about rather
+        /// than the missing-credential path.
+        /// </summary>
+        private static IDeploymentCredentialSource CredentialSourceFor(string userName, string password)
+        {
+            var source = Substitute.For<IDeploymentCredentialSource>();
+            source.Description.Returns("test");
+            source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential(userName, password));
+            return source;
+        }
+
+        /// <summary>
+        /// Tier selection now lives in the credential source, not the dispatcher — so this
+        /// returns a different account per tier, and the assertions below verify the dispatcher
+        /// asks for the RIGHT tier rather than that it knows which config key to read. The key
+        /// mapping is tested where it moved to.
+        /// </summary>
+        private static IDeploymentCredentialSource TierAwareCredentialSource()
+        {
+            var source = Substitute.For<IDeploymentCredentialSource>();
+            source.Description.Returns("test");
+            source.Resolve(DeploymentTier.Production)
+                .Returns(new DeploymentCredential(ProdAccount, "prod-password"));
+            source.Resolve(DeploymentTier.NonProduction)
+                .Returns(new DeploymentCredential(NonProdAccount, "nonprod-password"));
+            return source;
+        }
+
         [TestInitialize]
         public void Setup()
         {
@@ -60,7 +93,8 @@ namespace Dorc.Monitor.Tests
                 _pipeServer,
                 _configurationSettings,
                 Substitute.For<IRequestsPersistentSource>(),
-                _scriptScopeConfigValues);
+                _scriptScopeConfigValues,
+                _credentialSource);
 
         /// <summary>
         /// Dispatch is driven to the point where the Runner's security context is built and no
@@ -212,6 +246,21 @@ namespace Dorc.Monitor.Tests
     [TestClass]
     public class WithheldKeysAreNotDispatchedTests
     {
+        private const string _unused = "";
+
+        /// <summary>
+        /// A credential source that resolves, so these tests exercise what they are about rather
+        /// than the missing-credential path.
+        /// </summary>
+        private static IDeploymentCredentialSource CredentialSourceFor(string userName, string password)
+        {
+            var source = Substitute.For<IDeploymentCredentialSource>();
+            source.Description.Returns("test");
+            source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential(userName, password));
+            return source;
+        }
+
         private const string Withheld = "DORC_ProdDeployPassword";
 
         [TestMethod]
@@ -236,7 +285,8 @@ namespace Dorc.Monitor.Tests
                 pipeServer,
                 settings,
                 Substitute.For<IRequestsPersistentSource>(),
-                scopeValues);
+                scopeValues,
+                CredentialSourceFor("svc-dorc", "password"));
 
             var properties = new Dictionary<string, VariableValue>
             {

--- a/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
@@ -1,6 +1,7 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Core.Configuration;
+using Dorc.Core.Security;
 using Dorc.Monitor.Pipes;
 using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
@@ -30,6 +31,22 @@ namespace Dorc.Monitor.Tests
         private IScriptGroupPipeServer _pipeServer = null!;
         private IConfigurationSettings _settings = null!;
 
+        private readonly IDeploymentCredentialSource _credentialSource =
+            CredentialSourceFor("svc-dorc", "password");
+
+        /// <summary>
+        /// A credential source that resolves, so these tests exercise what they are about rather
+        /// than the missing-credential path.
+        /// </summary>
+        private static IDeploymentCredentialSource CredentialSourceFor(string userName, string password)
+        {
+            var source = Substitute.For<IDeploymentCredentialSource>();
+            source.Description.Returns("test");
+            source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential(userName, password));
+            return source;
+        }
+
         [TestInitialize]
         public void Setup()
         {
@@ -56,7 +73,8 @@ namespace Dorc.Monitor.Tests
                 _pipeServer,
                 _settings,
                 Substitute.For<IRequestsPersistentSource>(),
-                Substitute.For<IScriptScopeConfigValues>());
+                Substitute.For<IScriptScopeConfigValues>(),
+                _credentialSource);
 
         private bool Dispatch(string storedScriptPath)
         {

--- a/src/Dorc.Monitor/Program.cs
+++ b/src/Dorc.Monitor/Program.cs
@@ -1,7 +1,8 @@
-using Dorc.Core;
+﻿using Dorc.Core;
 using Dorc.Core.AzureStorageAccount;
 using Dorc.Core.BuildServer;
 using Dorc.Core.Configuration;
+using Dorc.Core.Secrets;
 using Dorc.Core.Interfaces;
 using Dorc.Core.Security;
 using Dorc.Core.VariableResolution;
@@ -214,6 +215,27 @@ builder.Services.AddHttpClient("GitHubActions", client =>
 builder.Services.AddTransient<IGitHubArtifactDownloader, GitHubArtifactDownloader>();
 
 builder.Services.AddTransient<IConfigurationSettings, ConfigurationSettings>();
+
+// Deployment credential resolution. The Monitor registers these itself rather than through the
+// Lamar core registry, which only the API includes.
+//
+// The vault reader is registered here at all because it was relocated out of the API assembly:
+// before that, the Monitor could not have read a credential from the vault even if configured
+// to. Whether these hosts can reach the vault is now a deployment question with a configured
+// answer rather than an architectural dependency.
+builder.Services.AddTransient<IConfigurationSecretsReader, OnePasswordSecretsReader>();
+builder.Services.AddTransient<ConfigValueDeploymentCredentialSource>();
+builder.Services.AddTransient<VaultDeploymentCredentialSource>();
+builder.Services.AddTransient<IDeploymentCredentialSource>(services =>
+{
+    var configuration = services.GetRequiredService<IConfigurationSettings>();
+
+    // Configuration values remain the default. Switching where the whole estate's deployment
+    // credentials come from is deliberate, not something a release does on an operator's behalf.
+    return configuration.GetDeploymentCredentialsFromVault()
+        ? services.GetRequiredService<VaultDeploymentCredentialSource>()
+        : services.GetRequiredService<ConfigValueDeploymentCredentialSource>();
+});
 
 var connectionString = monitorConfiguration.DOrcConnectionString;
 

--- a/src/Dorc.Monitor/ScriptDispatcher.cs
+++ b/src/Dorc.Monitor/ScriptDispatcher.cs
@@ -18,11 +18,6 @@ namespace Dorc.Monitor
 {
     public class ScriptDispatcher : IScriptDispatcher
     {
-        private string ProdDeployUsernamePropertyName = "DORC_ProdDeployUsername";   
-        private string ProdDeployPasswordPropertyName = "DORC_ProdDeployPassword";   
-        private string NonProdDeployUsernamePropertyName = "DORC_NonProdDeployUsername";   
-        private string NonProdDeployPasswordPropertyName = "DORC_NonProdDeployPassword";   
-
         private readonly ILogger logger;
         private readonly IDeploymentRequestProcessesPersistentSource processesPersistentSource;
         private readonly IConfigValuesPersistentSource _configValuesPersistentSource;
@@ -30,6 +25,7 @@ namespace Dorc.Monitor
         private readonly IConfigurationSettings configurationSettingsEngine;
         private readonly IRequestsPersistentSource requestsPersistentSource;
         private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
+        private readonly IDeploymentCredentialSource _credentialSource;
 
         private bool isScriptExecutionSuccessful; // This field is needed to be instance-wide since Runner process errors are processed as instance-wide events.
 
@@ -42,7 +38,8 @@ namespace Dorc.Monitor
             IScriptGroupPipeServer scriptGroupPipeServer,
             IConfigurationSettings configurationSettingsEngine,
             IRequestsPersistentSource requestsPersistentSource,
-            IScriptScopeConfigValues scriptScopeConfigValues)
+            IScriptScopeConfigValues scriptScopeConfigValues,
+            IDeploymentCredentialSource credentialSource)
         {
             this.processesPersistentSource = processesPersistentSource;
             this._configValuesPersistentSource = configValuesPersistentSource;
@@ -51,6 +48,7 @@ namespace Dorc.Monitor
             this.configurationSettingsEngine = configurationSettingsEngine;
             this.requestsPersistentSource = requestsPersistentSource;
             this._scriptScopeConfigValues = scriptScopeConfigValues;
+            this._credentialSource = credentialSource;
         }
 
         public bool Dispatch(string scriptsLocation,
@@ -69,17 +67,27 @@ namespace Dorc.Monitor
 
             this.componentResultLogBuilder = componentResultLogBuilder;
 
-            var processCredentials = GetProcessCredentials(isProduction, environmentName);
-            string processAccountName = processCredentials.Item1;
-            string processAccountPassword = processCredentials.Item2;
-            if (string.IsNullOrEmpty(processAccountName)
-                || string.IsNullOrEmpty(processAccountPassword))
+            // One resolution point, shared with the Terraform dispatcher, the daemon status
+            // probe and the password reset controller. Four independent copies of the same four
+            // key names and the same production boolean is four places for a security decision
+            // to drift.
+            var credential = _credentialSource.Resolve(
+                isProduction ? DeploymentTier.Production : DeploymentTier.NonProduction);
+
+            if (credential == null)
             {
-                logger.LogError($"Unable to find a valid DOrc Username or Password for environment '{environmentName}'.");
+                logger.LogError(
+                    "No deployment credential is available for environment '{EnvironmentName}'."
+                    + " Credentials are read from {Source}.",
+                    environmentName,
+                    _credentialSource.Description);
 
                 isScriptExecutionSuccessful = false;
                 return isScriptExecutionSuccessful;
             }
+
+            var processAccountName = credential.UserName;
+            var processAccountPassword = credential.Password;
 
             IList<ScriptGroup> scriptGroups = GetScriptsGroupedByPowerShellVersion(
                 script,
@@ -391,18 +399,6 @@ namespace Dorc.Monitor
             }
         }
 
-        private (string, string) GetProcessCredentials(bool isProduction, string environmentName)
-        {
-            if (isProduction)
-            {
-                return (GetConfigValue(ProdDeployUsernamePropertyName),
-                    GetConfigValue(ProdDeployPasswordPropertyName));
-            }
-
-            return (GetConfigValue(NonProdDeployUsernamePropertyName),
-                GetConfigValue(NonProdDeployPasswordPropertyName));
-        }
-
         private string GetDeploymentRunnerFileFullName(
             string powerShellVersionNumber)
         {
@@ -431,14 +427,6 @@ namespace Dorc.Monitor
 
             return fileInfo.FullName;
         }
-
-        private string GetConfigValue(string configValue)
-        {
-            if (string.IsNullOrEmpty(configValue))
-                throw new ApplicationException($"Config value name is empty, should have a value"); 
-            return _configValuesPersistentSource.GetConfigValue(configValue);
-        }
-
 
         private string ExtractPath(string scriptsLocation, ScriptApiModel scriptApiModel)
         {

--- a/src/Dorc.Monitor/TerraformDispatcher.cs
+++ b/src/Dorc.Monitor/TerraformDispatcher.cs
@@ -4,6 +4,7 @@ using Dorc.Core;
 using Dorc.Core.AzureStorageAccount;
 using Dorc.Core.BuildServer;
 using Dorc.Core.Configuration;
+using Dorc.Core.Security;
 using Dorc.Monitor.Pipes;
 using Dorc.Monitor.RunnerProcess;
 using Dorc.Monitor.RunnerProcess.Interop.Windows.Kernel32;
@@ -21,11 +22,6 @@ namespace Dorc.Monitor
 {
     public class TerraformDispatcher : ITerraformDispatcher
     {
-        private const string ProdDeployUsernamePropertyName = "DORC_ProdDeployUsername";
-        private const string ProdDeployPasswordPropertyName = "DORC_ProdDeployPassword";
-        private const string NonProdDeployUsernamePropertyName = "DORC_NonProdDeployUsername";
-        private const string NonProdDeployPasswordPropertyName = "DORC_NonProdDeployPassword";
-
         private readonly ILogger logger;
         private readonly IRequestsPersistentSource _requestsPersistentSource;
         private readonly IConfigValuesPersistentSource _configValuesPersistentSource;
@@ -36,6 +32,7 @@ namespace Dorc.Monitor
         private readonly IProjectsPersistentSource _projectsPersistentSource;
         private readonly TerraformSourceConfigurator _sourceConfigurator;
         private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
+        private readonly IDeploymentCredentialSource _credentialSource;
 
         private bool isScriptExecutionSuccessful; // This field is needed to be instance-wide since Runner process errors are processed as instance-wide events.
 
@@ -49,7 +46,8 @@ namespace Dorc.Monitor
             IAzureStorageAccountWorker azureStorageAccountWorker,
             IProjectsPersistentSource projectsPersistentSource,
             IGitHubHostValidator gitHubHostValidator,
-            IScriptScopeConfigValues scriptScopeConfigValues)
+            IScriptScopeConfigValues scriptScopeConfigValues,
+            IDeploymentCredentialSource credentialSource)
         {
             this.logger = logger;
             this._requestsPersistentSource = requestsPersistentSource;
@@ -60,6 +58,7 @@ namespace Dorc.Monitor
             this._azureStorageAccountWorker = azureStorageAccountWorker;
             this._projectsPersistentSource = projectsPersistentSource;
             this._scriptScopeConfigValues = scriptScopeConfigValues;
+            this._credentialSource = credentialSource;
             this._sourceConfigurator = new TerraformSourceConfigurator(logger, _configurationSettingsEngine, gitHubHostValidator);
         }
 
@@ -87,17 +86,24 @@ namespace Dorc.Monitor
 
             isScriptExecutionSuccessful = true;
 
-            var processCredentials = GetProcessCredentials(isProduction, environmentName);
-            string processAccountName = processCredentials.Item1;
-            string processAccountPassword = processCredentials.Item2;
-            if (string.IsNullOrEmpty(processAccountName)
-                || string.IsNullOrEmpty(processAccountPassword))
+            // See ScriptDispatcher: one resolution point rather than a copy per dispatch path.
+            var credential = _credentialSource.Resolve(
+                isProduction ? DeploymentTier.Production : DeploymentTier.NonProduction);
+
+            if (credential == null)
             {
-                logger.LogError($"Unable to find a valid DOrc Username or Password for environment '{environmentName}'.");
+                logger.LogError(
+                    "No deployment credential is available for environment '{EnvironmentName}'."
+                    + " Credentials are read from {Source}.",
+                    environmentName,
+                    _credentialSource.Description);
 
                 isScriptExecutionSuccessful = false;
                 return isScriptExecutionSuccessful;
             }
+
+            var processAccountName = credential.UserName;
+            var processAccountPassword = credential.Password;
 
             // Get request and project information for Terraform source configuration
             var request = _requestsPersistentSource.GetRequest(requestId);
@@ -314,25 +320,6 @@ namespace Dorc.Monitor
             return properties
                 .Where(property => !_scriptScopeConfigValues.IsWithheld(property.Key))
                 .ToDictionary(property => property.Key, property => property.Value);
-        }
-
-        private (string, string) GetProcessCredentials(bool isProduction, string environmentName)
-        {
-            if (isProduction)
-            {
-                return (GetConfigValue(ProdDeployUsernamePropertyName),
-                    GetConfigValue(ProdDeployPasswordPropertyName));
-            }
-
-            return (GetConfigValue(NonProdDeployUsernamePropertyName),
-                GetConfigValue(NonProdDeployPasswordPropertyName));
-        }
-
-        private string GetConfigValue(string configValue)
-        {
-            if (string.IsNullOrEmpty(configValue))
-                throw new ApplicationException($"Config value name is empty, should have a value");
-            return _configValuesPersistentSource.GetConfigValue(configValue);
         }
 
         private ScriptGroup GetScriptGroup(


### PR DESCRIPTION
Closes #861

**Stacked on #860.** Merge that first.

672 insertions across 21 files, much of it moved rather than new.

## What changes

All four resolution sites now go through `IDeploymentCredentialSource`, with two implementations selected by configuration: one reading DOrc's configuration values as today, one reading the secrets vault.

## The relocation is what makes the vault option real

The reader moves out of `Dorc.Api.Services` into `Dorc.Core.Secrets`. Before that the Monitor **could not have read a credential from the vault however it was configured** — so "vault-backed" would have been an API-only capability, and vault reachability from Monitor hosts would have stayed an architectural dependency instead of a deployment choice.

The vendor-shaped `OnePassword.Connect.Client` namespace is corrected to `Dorc.Core.Secrets.OnePassword` at the same time, and `Services` — which the coding standard names as a dumping ground to avoid — is gone.

## Configuration values stay the default

Switching where the whole estate's deployment credentials come from is a deliberate act, not something a release performs on an operator's behalf.

The vault-backed source **refuses rather than falling back** when it is selected but its item identifiers are unset. Falling back would silently undo the decision to stop keeping those credentials in DOrc's database — which is the entire reason to select it.

Resolution returns `null` rather than a partial credential, and every caller treats `null` as a refusal. A caller that proceeds without one authenticates as whatever the host happens to be running as.

## One thing preserved rather than quietly corrected

`ResetAppPasswordController` resolves the **non-production** credential regardless of which server it is resetting a password on. Either deliberate or a latent defect — it belongs to whoever owns that endpoint, and making it environment-keyed is the next step's business. It is now visible at a single call site instead of buried in a hard-coded key name.

## Note for reviewers

Tier selection moved out of the dispatchers, so the tests that asserted it moved too: the dispatcher tests now verify the right **tier** is requested, and the key mapping is tested where it now lives. That is the assertion following the logic rather than a weakening.

The plan listed a dependency on the config-value classification step; it did not bind. That dependency applies only if the configuration-value variant needs to cover keys minted per environment, which is the next step's concern — the abstraction itself is tier-based.

## Tests

9 new on the two sources, including that both resolve the same credential for the same reference, which is what makes switching a configuration change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_