### PR TITLE
[1/5] HLPS: Split Dorc.Api into Linux-compatible + Windows-only worker (#423)

### DIFF
--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -5,50 +5,53 @@ date: 2026-05-28
 issue: sefe/dorc#423
 folder: docs/api-split/
 supersedes_pr: sefe/dorc#424
+codebase_anchor: aab79d14 (main, 2026-05-28) — file counts, paths, and class names are pinned to this commit
+revision_round: 2
 ---
 
-# HLPS: Split `Dorc.Api` into Linux-compatible API + Windows-only worker
+# HLPS: Replace AD with Microsoft Graph + Split `Dorc.Api` into a Linux-compatible API and a Windows-only worker
 
 | Field      | Value                       |
 |------------|-----------------------------|
-| **Status** | IN REVIEW                   |
+| **Status** | IN REVIEW (Round 2 — Round 1 findings addressed; see Appendix A for disposition) |
 | **Author** | Agent                       |
 | **Date**   | 2026-05-28                  |
 | **Issue**  | sefe/dorc#423               |
 | **Folder** | docs/api-split/             |
 | **Supersedes** | sefe/dorc#424 (Copilot agent PR, closed unmerged) |
+| **Codebase anchor** | `aab79d14` (`main`, 2026-05-28). File counts/paths/classes valid at this SHA. |
 
 ---
 
 ## 1. Problem Statement
 
-`Dorc.Api` is a single ASP.NET Core process that cannot run on Linux because portions of it depend on Windows-only stacks: `System.DirectoryServices` (Active Directory), `WindowsIdentity` / Negotiate / Kerberos, `System.Management` (WMI), and the Windows registry. Issue #423 requires the API to be split so that:
+`Dorc.Api` is a single ASP.NET Core process that cannot run on Linux because portions of it (and its dependencies `Dorc.Core`, `Dorc.PersistentData`) depend on Windows-only stacks: `System.DirectoryServices` (Active Directory), `WindowsIdentity` / Negotiate / Kerberos, `System.Management` (WMI), and the Windows registry. Issue #423 requires the API to be split so that:
 
 1. A primary API contains only code that runs on Linux (and Windows).
 2. A secondary API contains the bare minimum Windows-only code.
 3. The primary API can call into the secondary when required.
 
-The motivating outcome is the ability to deploy the bulk of DORC on Linux hosts, treating Windows-only functionality (AD lookup, WMI service probing, registry reads, NTLM/Kerberos auth, password reset via impersonation) as an out-of-process Windows worker.
+To meet (1) end-to-end, the entire compile graph of the primary API — not just `Dorc.Api`, but `Dorc.Core` and `Dorc.PersistentData` it pulls in — must be free of Windows-only references. The Active Directory surface is the largest such reference and is replaced with Microsoft Graph rather than moved to the worker (see D-2). The motivating outcome is the ability to deploy the bulk of DORC on Linux hosts, treating WMI, remote registry, and password-reset impersonation as an out-of-process Windows worker.
 
 ---
 
 ## 2. Observed Constraints from Today's Codebase
 
-The research captured in [`research/WINDOWS_DEPENDENCIES_ANALYSIS.md`](research/WINDOWS_DEPENDENCIES_ANALYSIS.md) inventories the Windows surface. Summary:
+All file references in this section are pinned to `aab79d14` (see frontmatter). Research carried over from PR #424 lives in [`research/`](research/) and may have drifted; treat it as background, not the source of truth.
 
-| Surface                  | Files (approx.) | Linux alternative available?                     |
-|--------------------------|-----------------|--------------------------------------------------|
-| `System.DirectoryServices` (AD) | ~9        | Partially — `AzureEntraSearcher.cs` exists; full coverage requires either Graph or `Novell.Directory.Ldap.NETStandard` |
-| Windows Authentication (NTLM/Kerberos/impersonation) | ~9 | OAuth2/JWT already supported; full removal of Negotiate requires deployment-side decision |
-| WMI (`System.Management`) | ~9             | None drop-in. Remote service probing needs SSH/PowerShell-remoting/REST design |
-| Registry (`Microsoft.Win32`) | ~14         | `RuntimeInformation` covers local; remote registry has no portable equivalent |
+| Surface                  | Where it lives (`aab79d14`) | Linux alternative |
+|--------------------------|-------------------------------|--------------------|
+| `System.DirectoryServices` (AD) — package refs | `Dorc.Core.csproj`, `Dorc.PersistentData.csproj` | Microsoft Graph (see D-2) |
+| AD code (production) | `Dorc.Core/ActiveDirectorySearcher.cs`, `Dorc.Core/CompositeDirectorySearcher.cs` (class `CompositeActiveDirectorySearcher`), `Dorc.Core/AzureEntraSearcher.cs` (already Graph-backed, currently annotated `[SupportedOSPlatform("windows")]`), `Dorc.Core/IdentityServer/IdentityServerSearcher.cs`, `Dorc.Core/Interfaces/IActiveDirectorySearcher.cs`, `Dorc.Core/Interfaces/IDirectorySearcherFactory.cs`, `Dorc.Api/Services/DirectorySearcherFactory.cs`, `Dorc.Api/Services/CachedUserGroupReader.cs`, `Dorc.Api/Services/UserGroupReaderFactory.cs`, `Dorc.Api/Services/ApiRegistry.cs` (DI wiring), `Dorc.Api/Services/ActiveDirectorySearchService.cs`, `Dorc.Api/Controllers/AccessControlController.cs`, `Dorc.Api/Controllers/RefDataEnvironmentsUsersController.cs`, `Dorc.Api/Controllers/RefDataProjectsController.cs`, `Dorc.Api/Controllers/RequestController.cs`, `Dorc.Api/Controllers/PropertyValuesController.cs`. AD tests: `Dorc.Api.Tests/Controllers/AccessControlControllerTests.cs`, `Dorc.Api.Tests/Controllers/RefDataProjectsControllerDeleteTests.cs` |
+| Windows Auth (Negotiate, NTLM, Kerberos) | `Dorc.Api/Security/WinAuthClaimsPrincipalReader.cs`, `Dorc.Api/Security/WinAuthLoggingMiddleware.cs`, Negotiate scheme registration in `Dorc.Api/Program.cs`, `WindowsIdentity` impersonation in `Dorc.Api/Controllers/ResetAppPasswordController.cs` | OAuth2/JWT (already supported); Negotiate scheme removed from primary; impersonation moves to worker |
+| WMI (`System.Management`) | `Dorc.Core/DaemonStatusProbe.cs` (Windows-only probe path post-#649 rename), `Dorc.Api/Services/WmiUtil.cs` | None drop-in — moves to worker |
+| Registry (`Microsoft.Win32`) | `Dorc.Api/Controllers/RefDataServersController.cs` (remote OS-version detection) | `RuntimeInformation` for local; remote registry moves to worker |
 
-The PR #424 attempt mixed three concerns:
-1. Structural split (the stated goal).
-2. A bulk *banned-words* class rename (`PropertiesService→Properties`, `RequestService→Requests`, …) that misread CLAUDE.md's *naming principle* as a *naming blacklist* and produced grab-bag names (`Properties`, `Requests`, `Operations`) that are arguably worse than the originals.
-3. Speculative refactors and orchestrator extraction.
+PR #424's research docs cite "~9 / ~14" file counts as of their writing; the table above supersedes those numbers and reflects current `main`.
 
-Bundling (2) and (3) into the split caused a 5629-line diff with 113 files touched, persistent build-error cycles, and ~340 silently semantic-conflicted files once the parallel daemons-modernisation work landed on `main`. This HLPS deliberately scopes (1) only.
+### Why this HLPS (and not just a redo of #424)
+
+PR #424 mixed three concerns: the structural split (the stated goal), a bulk *banned-words* class rename that misread CLAUDE.md's naming *principle* as a *blacklist* (producing grab-bag names: `Properties`, `Requests`, `Operations`), and speculative orchestrator extraction. Bundling caused a 5629-line diff with 113 files touched, persistent build-error cycles, and ~340 silently semantic-conflicted files once #649 landed on `main`. This HLPS scopes only the structural and dependency work; the rename is explicitly out of scope.
 
 ---
 
@@ -57,65 +60,123 @@ Bundling (2) and (3) into the split caused a 5629-line diff with 113 files touch
 Resolved with architecture owner on 2026-05-28. Recorded here as the design anchors the IS and SPECs will build on.
 
 ### D-1 — Worker process topology: HTTP loopback (was U-1)
-The Windows worker is a **separate ASP.NET Core process** (working name `Dorc.Api.WindowsWorker.exe`) bound to `127.0.0.1` only. The primary holds an `IWindowsWorkerClient` whose implementation is an `HttpClient`. Per-request loopback cost is acceptable given the existing claims cache (see D-2 — most authz paths no longer touch the worker at all). Rationale: in-proc plugin defeats the Linux-deployment goal (Linux primary can't load a Windows assembly); queue sidecar is the wrong shape for synchronous request-path operations.
+The Windows worker is a **separate ASP.NET Core process** (working name `Dorc.Api.WindowsWorker.exe` — see U-4) bound to `127.0.0.1` only. The primary holds an `IWindowsWorkerClient` whose implementation is an `HttpClient`. Per-request loopback cost is acceptable given the existing claims cache and the fact that — per D-2 — the authz hot path no longer touches the worker at all. Rationale: in-proc plugin defeats the Linux-deployment goal (a Linux primary process cannot load a Windows assembly); queue sidecar is the wrong shape for synchronous request-path operations.
 
-### D-2 — AD replaced with Microsoft Graph in the primary (was U-2)
-`System.DirectoryServices` and `System.DirectoryServices.AccountManagement` are **removed from `Dorc.Api` and replaced with Microsoft Graph** by extending the existing `AzureEntraSearcher.cs`. AD code does **not** move to the worker — it is deleted from the codebase. Consequence: the worker's surface shrinks to the genuinely non-portable Windows operations (WMI, remote registry, password reset). The authorization hot path (`ClaimsTransformer` / `CachedUserGroupReader`) runs entirely in the Linux primary and never hits the worker.
+The worker is a **permanent architectural component**, not transitional. Future replacement of WMI/registry with SSH/PowerShell-remoting (separate HLPS if ever taken on) would change the worker's *internals*, not its existence.
 
-Implication for customers: every DORC install now requires an Entra ID tenant with an app registration and Graph permissions (delegated + application as appropriate). This is a deliberate forward-looking choice; pure on-prem AD installs are out of scope for the new architecture.
+### D-2 — AD replaced with Microsoft Graph codebase-wide (was U-2; expanded per review Round 1)
+`System.DirectoryServices` and `System.DirectoryServices.AccountManagement` are **removed from every project in the primary API's compile graph** (`Dorc.Api`, `Dorc.Core`, `Dorc.PersistentData`) and replaced with Microsoft Graph by promoting and extending the existing `Dorc.Core/AzureEntraSearcher.cs`. AD code does **not** move to the worker — it is deleted. Consequence: the worker's surface shrinks to genuinely non-portable Windows operations (WMI, remote registry, password reset).
+
+Specifically:
+- `Dorc.Core/AzureEntraSearcher.cs` becomes the production `IActiveDirectorySearcher`; its `[SupportedOSPlatform("windows")]` attribute is removed (it was inherited from the AD code path and is incorrect for Graph).
+- `Dorc.Core/ActiveDirectorySearcher.cs`, `Dorc.Core/CompositeDirectorySearcher.cs` (class `CompositeActiveDirectorySearcher`), `Dorc.Core/IdentityServer/IdentityServerSearcher.cs`, `Dorc.Api/Services/DirectorySearcherFactory.cs`, `Dorc.Api/Services/UserGroupReaderFactory.cs`, `Dorc.Api/Services/ActiveDirectorySearchService.cs` are deleted (or — for the interfaces — reduced to the Graph contract).
+- `Dorc.Api/Services/ApiRegistry.cs` DI registrations switch from the composite/factory pattern to direct registration of the Graph-backed searcher.
+- Consumers (`ClaimsTransformer`, `CachedUserGroupReader`, `DirectorySearchController`, `AccessControlController`, `RefDataEnvironmentsUsersController`, `RefDataProjectsController`, `PropertyValuesController`, `RequestController`, AD tests) keep their interface dependency (`IActiveDirectorySearcher`) and gain no behavioural change beyond Graph's documented semantic gaps (see C-5).
+- `Dorc.PersistentData`'s AD code path is removed; the `System.DirectoryServices` package ref drops from its csproj.
+
+Customer implication: every DORC install now requires an Entra ID tenant with an app registration and Graph permissions. Pure on-prem AD-only installs (no Entra tenant, no Entra Connect) **cannot upgrade** to this version without first establishing an Entra presence. See U-10 (escalated to product owner).
 
 ### D-3 — Inter-API auth: loopback-only + shared secret header (was U-3)
-The worker binds to `127.0.0.1` and rejects any request without a shared-secret header `X-Worker-Key`. The secret lives in `appsettings.json` alongside other DORC secrets (same protection class). Authorization decisions are made entirely in the primary (using Graph-backed claims) *before* the worker is called; the worker trusts that any call reaching it has already been authz'd. For password reset, the worker uses **its own service account** (an AD-delegated reset-password identity) — the caller's identity is forwarded in the request body for audit only, not for impersonation. Rationale: JWT/mTLS add machinery without material security benefit on loopback; loopback-only binding + shared secret matches the threat model.
+The worker binds to `127.0.0.1` and rejects any request without a shared-secret header `X-Worker-Key`. Authorization decisions are made entirely in the primary (using Graph-backed claims) *before* the worker is called; the worker trusts that any call reaching it has already been authz'd. For password reset, the worker uses **its own service account** (an AD-delegated reset-password identity) — the caller's identity is forwarded in the request body for audit only, not for impersonation.
+
+**Threat model:** the in-scope adversary is an unprivileged off-host attacker who has reached the API host's network but not the host itself. Loopback binding eliminates that adversary by construction; the shared secret is a second-layer defence against a co-located non-DORC process (defence in depth, not a primary control).
+
+**Secret protection class:** the shared secret is stored in `appsettings.json` (or its environment-specific overlay) with the same protection class as DORC's existing connection-string secrets — i.e., file-system ACLs restrict read to the service account, no application-level encryption today. Hardening to DPAPI/Azure Key Vault is a separate concern tracked outside this HLPS.
+
+**Rotation policy:** the shared secret is configured at install time. Rotation requires updating both processes' config and restarting both. There is no online rotation; secret mismatch on the worker returns a `401` with body `{"error":"worker_key_invalid"}` so the cause is diagnosable. The IS step that wires the worker host will codify this in the SPEC.
+
+Rationale: JWT/mTLS add machinery without material security benefit on loopback; loopback-only binding + shared secret matches the documented threat model.
 
 ---
 
 ## 4. Scope
 
 ### In Scope
-- New project `Dorc.Api.WindowsWorker` (separate ASP.NET Core process, see D-1).
-- Inter-API HTTP contract: `IWindowsWorkerClient` interface in `Dorc.Api`, REST surface in the worker.
-- Shared-secret auth scheme on the worker (per D-3) + matching `DelegatingHandler` on the primary.
-- **Replacing AD usage in `Dorc.Api` with Microsoft Graph** (per D-2):
-  - Extend `AzureEntraSearcher.cs` to full functional parity with `ActiveDirectorySearcher.cs` (user/group search, recursive group membership, SID-equivalent resolution via Entra object IDs, claims expansion).
-  - Wire `ClaimsTransformer`, `DirectorySearchController`, `CachedUserGroupReader`, and any other AD consumers to the Graph-backed path.
-  - Delete `ActiveDirectorySearcher.cs` and remove `System.DirectoryServices` / `System.DirectoryServices.AccountManagement` package refs from `Dorc.Api` and any project that no longer needs them.
-- Moving the genuinely Windows-only code to `Dorc.Api.WindowsWorker`:
-  - WMI service-status code (`Dorc.Core/ServiceStatus.cs` / `DaemonStatusProbe.cs` per the post-#649 rename — the Windows-only probe path only).
-  - Remote registry reads in `RefDataServersController` (Windows server OS-version detection).
-  - Password-reset impersonation (`ResetAppPasswordController` → worker endpoint that runs as the worker's service account).
-- Installer work: new MSI component for the worker (Windows-only deployments), shared-secret provisioning at install time, service account configuration.
-- Documentation: architecture note explaining the runtime topology, Graph-tenant setup requirements for customers, and the configuration knobs.
+
+**A. Graph migration (codebase-wide, per D-2):**
+- Promote `Dorc.Core/AzureEntraSearcher.cs` to the production implementation, removing its `[SupportedOSPlatform("windows")]` attribute.
+- Achieve parity with the deleted AD code for the **enumerated load-bearing behaviours** below (parity matrix). Behaviours not on this list are explicitly *not* parity-guaranteed and any consumer that depends on them must be identified and re-designed.
+- Delete the AD code listed in §2 / D-2.
+- Drop `System.DirectoryServices` and `System.DirectoryServices.AccountManagement` package refs from `Dorc.Core.csproj` and `Dorc.PersistentData.csproj`.
+- Update `Dorc.Api/Services/ApiRegistry.cs` DI to register the Graph-backed searcher directly.
+- Tests: `Dorc.Api.Tests/Controllers/AccessControlControllerTests.cs` and `Dorc.Api.Tests/Controllers/RefDataProjectsControllerDeleteTests.cs` updated against Graph-backed fixtures (or appropriate mocks at the `IActiveDirectorySearcher` boundary).
+
+**Parity matrix (load-bearing behaviours that must work post-Graph):**
+
+| Behaviour | Today (DirectoryServices) | Graph equivalent / strategy |
+|---|---|---|
+| User search by name | LDAP filter | `/users?$filter=startswith(displayName,...)` |
+| Group search by name | LDAP filter | `/groups?$filter=startswith(displayName,...)` |
+| Resolve identity by ID/SID | SID lookup | Entra `objectId` (UUID); SIDs from synced-from-AD users available via `onPremisesSecurityIdentifier` |
+| Recursive group membership ("is user X in group Y, transitively?") | `IsMemberOf` + walk | `/users/{id}/checkMemberGroups` (transitive, returns all groups user is in) |
+| All SIDs for a user (used for claims) | Walk groups | Transitive group IDs via `/users/{id}/transitiveMemberOf` |
+| Disabled account detection | `userAccountControl` bit | `accountEnabled` |
+| Display name + email | LDAP attribute | Graph `displayName` / `mail` / `userPrincipalName` |
+
+**Out of parity (explicitly):**
+- Local-machine SIDs (DORC didn't use these meaningfully).
+- Foreign Security Principals (cross-forest trusts) — must be flagged for any consumer that depends on this; none identified at `aab79d14`.
+- Well-known SIDs (`BUILTIN\Administrators` etc.) — DORC's RBAC uses domain groups, not well-known SIDs.
+
+**B. Worker process (per D-1):**
+- New project (working name `Dorc.Api.WindowsWorker` — see U-4).
+- Worker host binds to `127.0.0.1` only; rejects calls without the `X-Worker-Key` header (per D-3).
+- MSI component for Windows-only deployments (`Setup.Dorc/Web/RequestApi/ApiWindows.wxs` is a reference template from PR #424).
+- Service-account configuration for password reset; documented Graph-permissions setup for the primary.
+
+**C. Inter-API contract (per D-3):**
+- `IWindowsWorkerClient` interface in `Dorc.Api`; HTTP-based implementation behind a `DelegatingHandler` that injects the secret.
+- Null-pattern / `503`-returning implementation for Linux installs where the worker is absent.
+
+**D. Move Windows-only code from primary to worker:**
+- WMI service-status probe path in `Dorc.Core/DaemonStatusProbe.cs` and `Dorc.Api/Services/WmiUtil.cs`.
+- Remote registry reads in `Dorc.Api/Controllers/RefDataServersController.cs`.
+- `WindowsIdentity` impersonation in `Dorc.Api/Controllers/ResetAppPasswordController.cs` (controller stays in primary as a thin pass-through; impersonation logic moves).
+
+**E. Remove Windows authentication scheme from primary:**
+- Delete `Dorc.Api/Security/WinAuthClaimsPrincipalReader.cs` and `Dorc.Api/Security/WinAuthLoggingMiddleware.cs`.
+- Remove Negotiate authentication scheme registration from `Dorc.Api/Program.cs`.
+- Any remaining authentication flows continue to work via OAuth2/JWT (already supported).
+
+**F. Documentation:**
+- Architecture note: runtime topology, primary/worker relationship, configuration knobs.
+- Customer-facing: Entra tenant setup, required Graph permissions, AD-to-Entra migration prerequisites.
 
 ### Out of Scope (explicitly)
 - **Bulk class renaming** to remove the words *Service / Helper / Manager / Util*. CLAUDE.md's rule is principle-first; class-by-class renames belong in their own scoped PRs only when the new name is *more* specific than the old.
 - Supporting pure on-prem AD installs without an Entra tenant. Per D-2, an Entra tenant is now a hard prerequisite.
-- Replacing WMI with SSH/PowerShell-remoting (separate HLPS if/when desired).
-- Folder reorganisation by "function" (`Identity/`, `Build/`, `Orchestration/`) inside the existing API — orthogonal to the split.
-- Changing the public Swagger/REST surface of `Dorc.Api`. Existing clients (`Dorc.Api.Client`, `dorc-web`, CLIs) must continue to work unchanged.
+- Replacing WMI with SSH / PowerShell-remoting / REST agents (separate HLPS if/when desired). Worker is permanent (D-1).
+- Folder reorganisation by "function" (`Identity/`, `Build/`, `Orchestration/`) inside the existing API.
+- Changing the public Swagger/REST surface of `Dorc.Api` in shape. (Behaviour envelope on Linux installs is covered by C-1 and SC-4.)
+- Hardening the shared-secret storage to DPAPI / Azure Key Vault. Separate concern (M-1/D-3 acknowledged).
+- Log-injection findings in `BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs` — see SC-8b.
 
 ---
 
 ## 5. Constraints
 
-- **C-1 Backwards compatibility.** Existing API consumers (`dorc-web`, `Dorc.Api.Client`, CLI tools, MSI deployment) keep working with no client-side change.
-- **C-2 No bundled refactor.** Naming, folder layout, and DI cleanup do not ride along on this PR.
+- **C-1 No client-side compile-time change.** Existing API consumers (`dorc-web`, `Dorc.Api.Client`, CLI tools) compile and ship unchanged. Behavioural changes are scoped: on Windows installs they are nil (SC-3); on Linux installs the WMI / registry / password-reset endpoints return a documented `503` (SC-4). Customer-facing release notes must call out this behavioural envelope.
+- **C-2 No bundled refactor.** Naming, folder layout, and DI cleanup do not ride along on this HLPS.
 - **C-3 Single host on Windows.** On Windows installs, the worker process ships and runs alongside the primary as a separate MSI component, bound to loopback only.
-- **C-4 Customer infrastructure.** Every DORC install requires an Entra ID tenant + app registration with Graph permissions (per D-2). Document required permissions and provide setup guidance.
-- **C-5 No silent functional change.** Every endpoint behaves identically pre- and post-split, except where Graph semantics differ from `System.DirectoryServices` (those differences must be enumerated and documented in the IS step that does the Graph swap).
-- **C-6 Follow the HLPS → IS → SPEC process.** Each batch of file moves and the Graph migration each go through an IS step with their own SPEC and adversarial review.
+- **C-4 Customer infrastructure.** Every DORC install requires an Entra ID tenant + app registration with Graph permissions. Document required permissions (U-9) and the AD-to-Entra migration path (U-10) before release.
+- **C-5 Bounded functional change.** Endpoints behave identically pre- and post-split for the parity matrix in §4. Known semantic gaps outside the matrix (foreign security principals, well-known SIDs, local-machine SIDs — none currently relied on) are documented and any future use is gated on a follow-up HLPS.
+- **C-6 Follow the HLPS → IS → SPEC process.** Each batch of file moves and the Graph migration go through an IS step with their own SPEC and adversarial review.
+- **C-7 Installer-side secret handling requires security review.** The MSI component that provisions the shared secret at install time must pass an explicit security review pass before release (the secret-provisioning surface is a new attack vector).
 
 ---
 
 ## 6. Success Criteria
 
-- **SC-1** `Dorc.Api` builds and runs on a Linux container (no `<RuntimeIdentifier>win-*</RuntimeIdentifier>`, no `System.DirectoryServices*` package refs, no `System.Management` refs).
-- **SC-2** `Dorc.Api.WindowsWorker` builds and runs on Windows only; loopback-bound; rejects calls missing the shared-secret header.
-- **SC-3** On Windows installs with the worker present: WMI, registry, and password-reset endpoints behave identically to today.
-- **SC-4** On Linux installs (no worker): WMI / registry / password-reset endpoints return a documented `503` with a clear "this operation requires the Windows worker" body. AD-derived endpoints (search, claims expansion) work normally via Graph.
-- **SC-5** Existing client apps (`dorc-web`, `Dorc.Api.Client`) make no code changes.
-- **SC-6** Unit and integration tests pass at parity with pre-split coverage; new contract tests cover the primary↔worker HTTP surface; new tests cover the Graph-backed AD code path.
+- **SC-1** `Dorc.Api`, `Dorc.Core`, and `Dorc.PersistentData` build with no `System.DirectoryServices*` package refs and no `System.Management` package refs. `Dorc.Api` runs on a Linux container with no `<RuntimeIdentifier>win-*</RuntimeIdentifier>`. CI gate: a Linux build job that fails if Windows-only refs reappear.
+- **SC-2** `Dorc.Api.WindowsWorker` builds, runs on Windows only, binds to `127.0.0.1`, and rejects calls missing `X-Worker-Key` with a documented `401` body.
+- **SC-3** On Windows installs with the worker present: WMI, registry, and password-reset endpoints behave identically to today (verified by parity tests against pre-split fixtures).
+- **SC-4** On Linux installs (no worker): WMI / registry / password-reset endpoints return `503 Service Unavailable` with body `{"error":"windows_worker_unavailable", "endpoint":"<name>"}`. This is the documented behavioural envelope referenced in C-1.
+- **SC-5** Existing client apps (`dorc-web`, `Dorc.Api.Client`) require no code changes to compile and ship. Behavioural-envelope changes (SC-4) are handled by surfaced error messages, not by client logic changes.
+- **SC-6** All existing unit and integration tests pass at parity with pre-split coverage; new contract tests cover the primary↔worker HTTP surface; new tests cover the Graph-backed AD code path against the parity matrix in §4.
 - **SC-7** MSI installer adds the worker as a Windows-only component without breaking existing upgrade paths.
-- **SC-8** Security findings on PR #424 (LDAP injection in `DirectorySearchController`, log injection in 4 controllers) are addressed *as part of the migration*, not deferred. Note: LDAP-injection class disappears entirely once Graph replaces `System.DirectoryServices`.
+- **SC-8a** LDAP-injection findings on PR #424 (`DirectorySearchController` ×2) are eliminated by the Graph migration removing the LDAP code path. Verified by re-running the security scan post-merge.
+- **SC-8b** Log-injection findings (`BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs`) are addressed in dedicated SPECs carved out from the relevant IS steps (S-005 for `ResetAppPasswordController`; the others get their own SPEC under the step that touches them). Not deferred outside this HLPS.
+- **SC-9** Parity matrix in §4 is documented as a living artefact (`docs/api-split/parity-matrix.md`) and every behaviour in it has at least one test exercising the Graph-backed path.
 
 ---
 
@@ -124,14 +185,14 @@ The worker binds to `127.0.0.1` and rejects any request without a shared-secret 
 ### Blocking
 *None remaining.* Original U-1, U-2, U-3 resolved as D-1, D-2, D-3 above.
 
-### Non-blocking (resolved during IS)
-- **U-4** Naming of the new project: `Dorc.Api.Windows` vs. `Dorc.Api.WindowsWorker`. Prefer the latter for specificity (per CLAUDE.md naming principle); confirm in S-001.
+### Non-blocking (resolved during IS; some require named owner)
+- **U-4** Naming of the new project: `Dorc.Api.Windows` vs. `Dorc.Api.WindowsWorker`. Prefer the latter for specificity (per CLAUDE.md naming principle); confirm in the IS step that creates the project.
 - **U-5** Worker config: shared `appsettings.json` with the primary vs. its own. Affects secret-handling at install time.
 - **U-6** Worker URL discovery: config-file (likely) vs. service discovery.
-- **U-7** Contract-test strategy for the inter-API surface.
-- **U-8** `Setup.Acceptance` handling: install the worker for the test environment, or stub it.
-- **U-9 [NEW]** Graph permission set required (delegated vs application). Affects customer setup guidance. To be resolved in the IS step that does the Graph migration.
-- **U-10 [NEW]** Migration path for existing customers from AD to Entra. If a customer has on-prem AD only (no Entra Connect, no Entra tenant), the upgrade is a hard break — document upgrade prerequisites clearly.
+- **U-7** Contract-test strategy for the inter-API surface (consumer-driven vs. shared-DTO vs. OpenAPI-spec-driven). Recommendation pending in the IS step that wires the contract: shared-DTO via the existing `Dorc.ApiModel` pattern is the lowest-friction choice.
+- **U-8** `Setup.Acceptance` handling: install the worker MSI for the test environment, or stub the worker endpoints. Gates SC-6 (contract tests on a real worker vs. mock).
+- **U-9** Graph permission set required (delegated vs application; specific permission names). Affects customer setup guidance (C-4) and the IS step that does the Graph migration. **Recommendation pending architecture confirmation:** application-only permissions (`User.Read.All`, `Group.Read.All`, `GroupMember.Read.All`) with admin consent, since the worker runs as a service account and never acts on behalf of an end user.
+- **U-10** Migration path for existing customers from AD to Entra. **Owner: Product.** If a customer has on-prem AD only (no Entra Connect, no Entra tenant), the upgrade is a hard break. Product decision required before release: do we publish migration guidance only, or do we ship a back-compat shim? Default position absent product input: hard break, documented prerequisites, no shim.
 
 ---
 
@@ -139,27 +200,63 @@ The worker binds to `127.0.0.1` and rejects any request without a shared-secret 
 
 - Issue: [sefe/dorc#423](https://github.com/sefe/dorc/issues/423)
 - Superseded PR: [sefe/dorc#424](https://github.com/sefe/dorc/pull/424) (closed unmerged — see PR description for closure rationale)
-- Research carried over from PR #424:
-  - [`research/WINDOWS_DEPENDENCIES_ANALYSIS.md`](research/WINDOWS_DEPENDENCIES_ANALYSIS.md) — file-level inventory of Windows dependencies + cross-platform alternatives with historic-Windows compatibility matrices.
-  - [`research/ARCHITECTURE_API_SPLIT.md`](research/ARCHITECTURE_API_SPLIT.md) — PR #424's proposed architecture (HTTP-based split). Informational; the topology decision is U-1.
-  - [`research/REGISTRY_UPGRADE_EXAMPLE.md`](research/REGISTRY_UPGRADE_EXAMPLE.md) — concrete before/after for the registry dependency in `RefDataServersController`.
-  - [`research/FILES_TO_MOVE_ANALYSIS.md`](research/FILES_TO_MOVE_ANALYSIS.md) — PR #424's file-by-file move evaluation.
-  - [`research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md`](research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md) — analysis of hidden Windows deps in the Deployment folder.
+- This HLPS's PR: [sefe/dorc#706](https://github.com/sefe/dorc/pull/706)
+- Research carried over from PR #424 (informational; superseded by §2 for current file paths):
+  - [`research/WINDOWS_DEPENDENCIES_ANALYSIS.md`](research/WINDOWS_DEPENDENCIES_ANALYSIS.md)
+  - [`research/ARCHITECTURE_API_SPLIT.md`](research/ARCHITECTURE_API_SPLIT.md)
+  - [`research/REGISTRY_UPGRADE_EXAMPLE.md`](research/REGISTRY_UPGRADE_EXAMPLE.md)
+  - [`research/FILES_TO_MOVE_ANALYSIS.md`](research/FILES_TO_MOVE_ANALYSIS.md)
+  - [`research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md`](research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md)
 - CLAUDE.md naming principle: cohesive naming over banned-words blacklist. Memory: `feedback_naming_principle.md`.
 
 ---
 
-## 9. Next Steps
+## 9. Next Steps (indicative — IS document is binding)
 
-1. **Adversarial review of this HLPS** (CLAUDE.md checkpoint) — IN REVIEW until panel approval.
-2. On approval, draft `IS-api-split.md`. With D-1/D-2/D-3 anchored, the IS shape is:
-   - **S-001** — Create empty `Dorc.Api.WindowsWorker` project + worker host + shared-secret auth scheme + DI scaffolding + MSI component skeleton.
-   - **S-002** — Define `IWindowsWorkerClient` HTTP contract surface in `Dorc.Api`; null/notSupported implementation for Linux installs.
-   - **S-003** — Move the smallest Windows-only endpoint family end-to-end as the proof-of-pattern. Candidate: registry/remote-server probing (smallest, lowest blast radius).
-   - **S-004** — Move WMI service-status code (the Windows-only probe path in `DaemonStatusProbe.cs`) to the worker.
-   - **S-005** — Move `ResetAppPasswordController` impersonation to the worker; primary-side becomes thin pass-through with caller-identity-in-body for audit.
-   - **S-006** — Graph migration: extend `AzureEntraSearcher.cs` to full parity, switch `ClaimsTransformer` / `CachedUserGroupReader` / `DirectorySearchController` to Graph. Resolves SC-8's LDAP-injection findings by removing the LDAP code path.
-   - **S-007** — Remove `System.DirectoryServices*` and `System.Management` package refs from `Dorc.Api`; verify Linux container build (SC-1).
-   - **S-008** — Installer wiring: ship the worker MSI component on Windows installs; provision shared secret + service account at install time.
-   - **S-009** — Documentation: Entra tenant setup, Graph permissions, deployment topology.
+The step list below is **indicative**, not binding — the binding ordering lives in `IS-api-split.md` once drafted. Listed here so the HLPS's shape and the IS's shape are obviously aligned.
+
+1. **Adversarial review of this HLPS — Round 2** (CLAUDE.md checkpoint). After this revision lands, the document returns to `IN REVIEW` for a second panel pass.
+2. On approval, draft `IS-api-split.md`. Indicative ordering with the riskiest step first (per Round-1 finding M-7):
+   - **S-001 — Graph migration (the spike).** Promote `AzureEntraSearcher`, remove its `[SupportedOSPlatform]` attribute, achieve parity matrix coverage, switch consumers, delete AD code, drop `System.DirectoryServices*` refs from `Dorc.Core` and `Dorc.PersistentData`. The CI gate (Linux build) is part of this step. If parity proves harder than D-2 assumes, we learn it here, not after four worker steps.
+   - **S-002** — Create `Dorc.Api.WindowsWorker` project, worker host, shared-secret auth scheme, DI scaffolding, MSI skeleton.
+   - **S-003** — Define `IWindowsWorkerClient` HTTP contract; null/notSupported impl for Linux installs.
+   - **S-004** — Move smallest Windows-only endpoint family (registry/remote-server probing) as proof-of-pattern.
+   - **S-005** — Move WMI service-status probe path.
+   - **S-006** — Move `ResetAppPasswordController` impersonation (worker uses its own service account); includes SC-8b carve-out for that controller's log-injection fix.
+   - **S-007** — Remove Windows-auth scheme from primary (Negotiate scheme + `WinAuth*` files).
+   - **S-008** — Installer wiring: ship worker MSI component, provision shared secret + service account at install time (subject to C-7 security review).
+   - **S-009** — Remaining log-injection SPEC carve-outs (per SC-8b) for `BundledRequestsController`, `MakeLikeProdController`, `Deployment/Requests.cs`.
+   - **S-010** — Documentation: Entra tenant setup, Graph permissions, AD-to-Entra migration prerequisites, deployment topology.
 3. SPECs are drafted just-in-time per S-step, each adversarially reviewed before execution.
+
+---
+
+## Appendix A — Round-1 review findings disposition
+
+For audit. Disposition of findings from the 2026-05-28 adversarial panel (Round 1).
+
+| ID | Severity | Finding (one-line) | Disposition |
+|---|---|---|---|
+| H-1 | HIGH | `AzureEntraSearcher.cs` path wrong (it's in `Dorc.Core`) | Accept — fixed in §2 and D-2 |
+| H-2 | HIGH | `[SupportedOSPlatform("windows")]` on `AzureEntraSearcher` contradicts SC-1 | Accept — removal added to D-2 / Scope A |
+| H-3 | HIGH | AD-deletion scope broader than `Dorc.Api` (covers `Dorc.Core` + `Dorc.PersistentData`) | Accept — Scope A and D-2 expanded codebase-wide |
+| H-4 | HIGH | SC-4 "work normally via Graph" unmeasurable without parity matrix | Accept — parity matrix added to §4; SC-9 added |
+| H-5 | HIGH | C-1 "no client-side change" vs. SC-4 503 envelope | Accept — C-1 reworded; SC-4 clarified as documented envelope |
+| R2-1 | HIGH | U-8 (Setup.Acceptance) gates SC-6 contract tests | Acknowledged — U-8 reframed with explicit gating; remains non-blocking per user direction |
+| R2-4 | HIGH | U-9 (Graph permissions) should be blocking | Acknowledged with recommendation in U-9; remains non-blocking per user direction |
+| R2-5 | HIGH | Windows auth (Negotiate, WinAuth*) missing from In-Scope | Accept — Scope E added; S-007 added |
+| M-1 | MED | D-3 rotation/restart policy missing | Accept — added to D-3 |
+| M-2 | MED | D-3 threat model not stated | Accept — added to D-3 |
+| M-3 | MED | WMI long-term home unclear | Accept — D-1 clarified worker is permanent |
+| M-4 / R2-9 | MED | U-10 needs decision owner | Accept — U-10 owner = Product; default position recorded |
+| M-5 | MED | SC-8 conflates LDAP vs log injection | Accept — split into SC-8a / SC-8b |
+| M-6 | MED | SC-6 contract source unspecified | Accept — recommendation added to U-7 |
+| R2-7 | MED | S-001 should be Graph migration (riskiest spike first) | Accept — Next Steps reordered |
+| R2-8 / C-5 | MED | C-5 get-out clause for Graph parity | Accept — parity matrix in §4 closes the loophole |
+| L-1 | LOW | Next Steps pre-empts IS | Downgrade — labelled "indicative — IS document is binding" |
+| L-2 | LOW | Worker name in D-1 | Defer — U-4 tracks |
+| L-3 | LOW | File counts not pinned | Accept — frontmatter `codebase_anchor` field added |
+| L-4 | LOW | Secret protection class hand-wavy | Accept — named in D-3 |
+| R2-11 | LOW | Installer secret-handling security-review pass | Accept — C-7 added |
+| R2-12 | LOW | `ApiRegistry.cs` not listed | Accept — listed in §2 and D-2 |
+| R2-10 | LOW | Status-frontmatter timing nit | Reject — cosmetic |

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -1,5 +1,5 @@
 ---
-status: DRAFT
+status: IN REVIEW
 author: Agent
 date: 2026-05-28
 issue: sefe/dorc#423
@@ -7,11 +7,11 @@ folder: docs/api-split/
 supersedes_pr: sefe/dorc#424
 ---
 
-# HLPS: Split `Dorc.Api` into Linux-compatible and Windows-only APIs
+# HLPS: Split `Dorc.Api` into Linux-compatible API + Windows-only worker
 
 | Field      | Value                       |
 |------------|-----------------------------|
-| **Status** | DRAFT                       |
+| **Status** | IN REVIEW                   |
 | **Author** | Agent                       |
 | **Date**   | 2026-05-28                  |
 | **Issue**  | sefe/dorc#423               |
@@ -52,72 +52,90 @@ Bundling (2) and (3) into the split caused a 5629-line diff with 113 files touch
 
 ---
 
-## 3. Scope
+## 3. Resolved Decisions
+
+Resolved with architecture owner on 2026-05-28. Recorded here as the design anchors the IS and SPECs will build on.
+
+### D-1 — Worker process topology: HTTP loopback (was U-1)
+The Windows worker is a **separate ASP.NET Core process** (working name `Dorc.Api.WindowsWorker.exe`) bound to `127.0.0.1` only. The primary holds an `IWindowsWorkerClient` whose implementation is an `HttpClient`. Per-request loopback cost is acceptable given the existing claims cache (see D-2 — most authz paths no longer touch the worker at all). Rationale: in-proc plugin defeats the Linux-deployment goal (Linux primary can't load a Windows assembly); queue sidecar is the wrong shape for synchronous request-path operations.
+
+### D-2 — AD replaced with Microsoft Graph in the primary (was U-2)
+`System.DirectoryServices` and `System.DirectoryServices.AccountManagement` are **removed from `Dorc.Api` and replaced with Microsoft Graph** by extending the existing `AzureEntraSearcher.cs`. AD code does **not** move to the worker — it is deleted from the codebase. Consequence: the worker's surface shrinks to the genuinely non-portable Windows operations (WMI, remote registry, password reset). The authorization hot path (`ClaimsTransformer` / `CachedUserGroupReader`) runs entirely in the Linux primary and never hits the worker.
+
+Implication for customers: every DORC install now requires an Entra ID tenant with an app registration and Graph permissions (delegated + application as appropriate). This is a deliberate forward-looking choice; pure on-prem AD installs are out of scope for the new architecture.
+
+### D-3 — Inter-API auth: loopback-only + shared secret header (was U-3)
+The worker binds to `127.0.0.1` and rejects any request without a shared-secret header `X-Worker-Key`. The secret lives in `appsettings.json` alongside other DORC secrets (same protection class). Authorization decisions are made entirely in the primary (using Graph-backed claims) *before* the worker is called; the worker trusts that any call reaching it has already been authz'd. For password reset, the worker uses **its own service account** (an AD-delegated reset-password identity) — the caller's identity is forwarded in the request body for audit only, not for impersonation. Rationale: JWT/mTLS add machinery without material security benefit on loopback; loopback-only binding + shared secret matches the threat model.
+
+---
+
+## 4. Scope
 
 ### In Scope
-- Establishing a new project layout (working name `Dorc.Api.WindowsWorker`) for Windows-only endpoints currently inside `Dorc.Api`.
-- Defining the inter-API contract (HTTP client interface in `Dorc.Api` → `Dorc.Api.WindowsWorker`).
-- Identifying, moving, and minimally-adapting the smallest set of files that **must** be Windows-only:
-  - `DirectorySearchController` + `ActiveDirectorySearcher` paths (until a Linux LDAP/Graph alternative is selected — see U-2).
-  - `ResetAppPasswordController` (uses `WindowsIdentity` impersonation).
-  - `BundledRequestsController`, `MakeLikeProdController` (only their Windows-specific code paths — most logic is portable).
-  - WMI-using service-status code currently in `Dorc.Core/ServiceStatus.cs` / `DaemonStatusProbe.cs` (post-#649 rename).
-  - Remote registry reads in `RefDataServersController`.
-- Installer/wxs work to ship the new component (one MSI feature, one optional install on Windows-only deployments).
-- Documentation: ADR or architecture note explaining the runtime topology and how the worker is selected/configured.
+- New project `Dorc.Api.WindowsWorker` (separate ASP.NET Core process, see D-1).
+- Inter-API HTTP contract: `IWindowsWorkerClient` interface in `Dorc.Api`, REST surface in the worker.
+- Shared-secret auth scheme on the worker (per D-3) + matching `DelegatingHandler` on the primary.
+- **Replacing AD usage in `Dorc.Api` with Microsoft Graph** (per D-2):
+  - Extend `AzureEntraSearcher.cs` to full functional parity with `ActiveDirectorySearcher.cs` (user/group search, recursive group membership, SID-equivalent resolution via Entra object IDs, claims expansion).
+  - Wire `ClaimsTransformer`, `DirectorySearchController`, `CachedUserGroupReader`, and any other AD consumers to the Graph-backed path.
+  - Delete `ActiveDirectorySearcher.cs` and remove `System.DirectoryServices` / `System.DirectoryServices.AccountManagement` package refs from `Dorc.Api` and any project that no longer needs them.
+- Moving the genuinely Windows-only code to `Dorc.Api.WindowsWorker`:
+  - WMI service-status code (`Dorc.Core/ServiceStatus.cs` / `DaemonStatusProbe.cs` per the post-#649 rename — the Windows-only probe path only).
+  - Remote registry reads in `RefDataServersController` (Windows server OS-version detection).
+  - Password-reset impersonation (`ResetAppPasswordController` → worker endpoint that runs as the worker's service account).
+- Installer work: new MSI component for the worker (Windows-only deployments), shared-secret provisioning at install time, service account configuration.
+- Documentation: architecture note explaining the runtime topology, Graph-tenant setup requirements for customers, and the configuration knobs.
 
 ### Out of Scope (explicitly)
-- **Bulk class renaming** to remove the words *Service / Helper / Manager / Util*. CLAUDE.md's rule is principle-first (avoid grab-bag dumping-ground classes); class-by-class renames belong in their own scoped PRs only when the new name is *more* specific than the old.
-- Replacing `System.DirectoryServices` with `Novell.Directory.Ldap` or Graph (worthwhile, but separate HLPS — see U-2).
-- Replacing WMI with SSH/PowerShell-remoting (separate HLPS).
+- **Bulk class renaming** to remove the words *Service / Helper / Manager / Util*. CLAUDE.md's rule is principle-first; class-by-class renames belong in their own scoped PRs only when the new name is *more* specific than the old.
+- Supporting pure on-prem AD installs without an Entra tenant. Per D-2, an Entra tenant is now a hard prerequisite.
+- Replacing WMI with SSH/PowerShell-remoting (separate HLPS if/when desired).
 - Folder reorganisation by "function" (`Identity/`, `Build/`, `Orchestration/`) inside the existing API — orthogonal to the split.
 - Changing the public Swagger/REST surface of `Dorc.Api`. Existing clients (`Dorc.Api.Client`, `dorc-web`, CLIs) must continue to work unchanged.
 
 ---
 
-## 4. Constraints
+## 5. Constraints
 
 - **C-1 Backwards compatibility.** Existing API consumers (`dorc-web`, `Dorc.Api.Client`, CLI tools, MSI deployment) keep working with no client-side change.
 - **C-2 No bundled refactor.** Naming, folder layout, and DI cleanup do not ride along on this PR.
-- **C-3 Single deployable on Windows.** On Windows installs, the worker process must ship and run alongside the primary API as a separate MSI component (mirroring `Setup.Dorc/Web/RequestApi/ApiWindows.wxs` from the PR #424 attempt).
-- **C-4 Auth across the hop.** The primary API → worker call must propagate the calling user's identity in a way the worker can re-authenticate the original user when it needs to (AD lookups, impersonation for password reset).
-- **C-5 No silent functional change.** Every endpoint behaves identically pre- and post-split. The split is mechanical, not semantic.
-- **C-6 Follow the HLPS → IS → SPEC process.** Each batch of file moves goes through an IS step with its own SPEC and adversarial review.
+- **C-3 Single host on Windows.** On Windows installs, the worker process ships and runs alongside the primary as a separate MSI component, bound to loopback only.
+- **C-4 Customer infrastructure.** Every DORC install requires an Entra ID tenant + app registration with Graph permissions (per D-2). Document required permissions and provide setup guidance.
+- **C-5 No silent functional change.** Every endpoint behaves identically pre- and post-split, except where Graph semantics differ from `System.DirectoryServices` (those differences must be enumerated and documented in the IS step that does the Graph swap).
+- **C-6 Follow the HLPS → IS → SPEC process.** Each batch of file moves and the Graph migration each go through an IS step with their own SPEC and adversarial review.
 
 ---
 
-## 5. Success Criteria
+## 6. Success Criteria
 
-- **SC-1** `Dorc.Api` builds and runs on a Linux container (no `<RuntimeIdentifier>win-*</RuntimeIdentifier>` required, no Windows-only NuGet refs in the csproj).
-- **SC-2** All Windows-only endpoints respond correctly on a Windows install where the worker is present, and return a documented `503` (or equivalent) on installs where the worker is absent.
-- **SC-3** Existing client apps (`dorc-web`, `Dorc.Api.Client`) make no code changes.
-- **SC-4** Unit and integration tests pass at parity with pre-split coverage.
-- **SC-5** MSI installer adds the worker as an optional/required component without breaking existing upgrade paths.
-- **SC-6** Security findings on PR #424 (LDAP injection in `DirectorySearchController`, log injection in 4 controllers) are addressed *in the moved code* as part of the move, not deferred.
-
----
-
-## 6. Unknowns Register
-
-Per CLAUDE.md — blocking unknowns halt progress until resolved.
-
-### Blocking (must answer before IS)
-
-- **U-1 [BLOCKING]** Does the project want the worker to be a separate ASP.NET Core HTTP process, an in-proc plugin (`AssemblyLoadContext` with a Windows-only assembly conditionally loaded), or a queue-driven sidecar? PR #424 assumed HTTP. HTTP is simplest but the loopback cost matters for AD lookups on the hot path of authorization. **Decision required from architecture owner.**
-- **U-2 [BLOCKING]** What is the future of `System.DirectoryServices`? If a Linux LDAP alternative (Graph / Novell) will be adopted in the next 1–2 quarters, the AD code shouldn't be moved into the Windows worker at all — it should be replaced in-place. The scope of "what must be Windows-only" depends entirely on this decision.
-- **U-3 [BLOCKING]** Auth propagation across the inter-API hop — the worker needs to either (a) trust a signed token from the primary API and re-impersonate, or (b) receive the original client's Kerberos ticket via constrained delegation. Both have deployment implications that need stakeholder sign-off before code is written.
-
-### Non-blocking (can be resolved during IS)
-
-- **U-4** Naming of the new project: `Dorc.Api.Windows` (PR #424's choice) vs. `Dorc.Api.WindowsWorker` (more specific). Defer to first IS step.
-- **U-5** Should the worker share `appsettings.json` with the primary API or have its own? Affects config-secret handling.
-- **U-6** How does the primary API discover the worker URL? Config-file vs. service discovery. Likely config-file given current DORC topology.
-- **U-7** Test strategy for the inter-API contract: contract tests, mock worker for the primary's tests, etc.
-- **U-8** Whether `Setup.Acceptance` needs to install the worker for the test environment, or if a stub is sufficient.
+- **SC-1** `Dorc.Api` builds and runs on a Linux container (no `<RuntimeIdentifier>win-*</RuntimeIdentifier>`, no `System.DirectoryServices*` package refs, no `System.Management` refs).
+- **SC-2** `Dorc.Api.WindowsWorker` builds and runs on Windows only; loopback-bound; rejects calls missing the shared-secret header.
+- **SC-3** On Windows installs with the worker present: WMI, registry, and password-reset endpoints behave identically to today.
+- **SC-4** On Linux installs (no worker): WMI / registry / password-reset endpoints return a documented `503` with a clear "this operation requires the Windows worker" body. AD-derived endpoints (search, claims expansion) work normally via Graph.
+- **SC-5** Existing client apps (`dorc-web`, `Dorc.Api.Client`) make no code changes.
+- **SC-6** Unit and integration tests pass at parity with pre-split coverage; new contract tests cover the primary↔worker HTTP surface; new tests cover the Graph-backed AD code path.
+- **SC-7** MSI installer adds the worker as a Windows-only component without breaking existing upgrade paths.
+- **SC-8** Security findings on PR #424 (LDAP injection in `DirectorySearchController`, log injection in 4 controllers) are addressed *as part of the migration*, not deferred. Note: LDAP-injection class disappears entirely once Graph replaces `System.DirectoryServices`.
 
 ---
 
-## 7. References
+## 7. Unknowns Register
+
+### Blocking
+*None remaining.* Original U-1, U-2, U-3 resolved as D-1, D-2, D-3 above.
+
+### Non-blocking (resolved during IS)
+- **U-4** Naming of the new project: `Dorc.Api.Windows` vs. `Dorc.Api.WindowsWorker`. Prefer the latter for specificity (per CLAUDE.md naming principle); confirm in S-001.
+- **U-5** Worker config: shared `appsettings.json` with the primary vs. its own. Affects secret-handling at install time.
+- **U-6** Worker URL discovery: config-file (likely) vs. service discovery.
+- **U-7** Contract-test strategy for the inter-API surface.
+- **U-8** `Setup.Acceptance` handling: install the worker for the test environment, or stub it.
+- **U-9 [NEW]** Graph permission set required (delegated vs application). Affects customer setup guidance. To be resolved in the IS step that does the Graph migration.
+- **U-10 [NEW]** Migration path for existing customers from AD to Entra. If a customer has on-prem AD only (no Entra Connect, no Entra tenant), the upgrade is a hard break — document upgrade prerequisites clearly.
+
+---
+
+## 8. References
 
 - Issue: [sefe/dorc#423](https://github.com/sefe/dorc/issues/423)
 - Superseded PR: [sefe/dorc#424](https://github.com/sefe/dorc/pull/424) (closed unmerged — see PR description for closure rationale)
@@ -131,13 +149,17 @@ Per CLAUDE.md — blocking unknowns halt progress until resolved.
 
 ---
 
-## 8. Next Steps
+## 9. Next Steps
 
-1. Resolve U-1, U-2, U-3 with the architecture owner (checkpoint).
-2. On approval of this HLPS, draft `IS-api-split.md` ordering the work into atomic steps. Likely shape (subject to U-1/U-2/U-3):
-   - S-001 — Create empty `Dorc.Api.WindowsWorker` project + DI scaffolding + MSI component.
-   - S-002 — Define `IWindowsWorkerClient` HTTP contract surface.
-   - S-003 — Move first endpoint family (probable candidate: registry/remote-server probing) end-to-end as the proof-of-pattern.
-   - S-004+ — Move remaining Windows-only families in turn (DirectorySearch, ResetAppPassword, WMI/service-status).
-   - S-N — Remove Windows-only NuGet refs from `Dorc.Api.csproj` and add a Linux container build gate.
+1. **Adversarial review of this HLPS** (CLAUDE.md checkpoint) — IN REVIEW until panel approval.
+2. On approval, draft `IS-api-split.md`. With D-1/D-2/D-3 anchored, the IS shape is:
+   - **S-001** — Create empty `Dorc.Api.WindowsWorker` project + worker host + shared-secret auth scheme + DI scaffolding + MSI component skeleton.
+   - **S-002** — Define `IWindowsWorkerClient` HTTP contract surface in `Dorc.Api`; null/notSupported implementation for Linux installs.
+   - **S-003** — Move the smallest Windows-only endpoint family end-to-end as the proof-of-pattern. Candidate: registry/remote-server probing (smallest, lowest blast radius).
+   - **S-004** — Move WMI service-status code (the Windows-only probe path in `DaemonStatusProbe.cs`) to the worker.
+   - **S-005** — Move `ResetAppPasswordController` impersonation to the worker; primary-side becomes thin pass-through with caller-identity-in-body for audit.
+   - **S-006** — Graph migration: extend `AzureEntraSearcher.cs` to full parity, switch `ClaimsTransformer` / `CachedUserGroupReader` / `DirectorySearchController` to Graph. Resolves SC-8's LDAP-injection findings by removing the LDAP code path.
+   - **S-007** — Remove `System.DirectoryServices*` and `System.Management` package refs from `Dorc.Api`; verify Linux container build (SC-1).
+   - **S-008** — Installer wiring: ship the worker MSI component on Windows installs; provision shared secret + service account at install time.
+   - **S-009** — Documentation: Entra tenant setup, Graph permissions, deployment topology.
 3. SPECs are drafted just-in-time per S-step, each adversarially reviewed before execution.

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -6,14 +6,14 @@ issue: sefe/dorc#423
 folder: docs/api-split/
 supersedes_pr: sefe/dorc#424
 codebase_anchor: aab79d14 (main, 2026-05-28) — file counts, paths, and class names are pinned to this commit
-revision_round: 2
+revision_round: 3
 ---
 
 # HLPS: Replace AD with Microsoft Graph + Split `Dorc.Api` into a Linux-compatible API and a Windows-only worker
 
 | Field      | Value                       |
 |------------|-----------------------------|
-| **Status** | IN REVIEW (Round 2 — Round 1 findings addressed; see Appendix A for disposition) |
+| **Status** | IN REVIEW (Round 3 — Round 2 NH-1/NH-2 addressed; see Appendix A) |
 | **Author** | Agent                       |
 | **Date**   | 2026-05-28                  |
 | **Issue**  | sefe/dorc#423               |
@@ -68,13 +68,13 @@ The worker is a **permanent architectural component**, not transitional. Future 
 `System.DirectoryServices` and `System.DirectoryServices.AccountManagement` are **removed from every project in the primary API's compile graph** (`Dorc.Api`, `Dorc.Core`, `Dorc.PersistentData`) and replaced with Microsoft Graph by promoting and extending the existing `Dorc.Core/AzureEntraSearcher.cs`. AD code does **not** move to the worker — it is deleted. Consequence: the worker's surface shrinks to genuinely non-portable Windows operations (WMI, remote registry, password reset).
 
 Specifically:
-- `Dorc.Core/AzureEntraSearcher.cs` becomes the production `IActiveDirectorySearcher`; its `[SupportedOSPlatform("windows")]` attribute is removed (it was inherited from the AD code path and is incorrect for Graph).
+- `Dorc.Core/AzureEntraSearcher.cs` becomes the production `IActiveDirectorySearcher`; its `[SupportedOSPlatform("windows")]` attribute is removed (the attribute is incorrect — Graph is cross-platform).
 - `Dorc.Core/ActiveDirectorySearcher.cs`, `Dorc.Core/CompositeDirectorySearcher.cs` (class `CompositeActiveDirectorySearcher`), `Dorc.Core/IdentityServer/IdentityServerSearcher.cs`, `Dorc.Api/Services/DirectorySearcherFactory.cs`, `Dorc.Api/Services/UserGroupReaderFactory.cs`, `Dorc.Api/Services/ActiveDirectorySearchService.cs` are deleted (or — for the interfaces — reduced to the Graph contract).
 - `Dorc.Api/Services/ApiRegistry.cs` DI registrations switch from the composite/factory pattern to direct registration of the Graph-backed searcher.
-- Consumers (`ClaimsTransformer`, `CachedUserGroupReader`, `DirectorySearchController`, `AccessControlController`, `RefDataEnvironmentsUsersController`, `RefDataProjectsController`, `PropertyValuesController`, `RequestController`, AD tests) keep their interface dependency (`IActiveDirectorySearcher`) and gain no behavioural change beyond Graph's documented semantic gaps (see C-5).
+- Consumers (`ClaimsTransformer`, `CachedUserGroupReader`, `DirectorySearchController`, `AccessControlController`, `RefDataEnvironmentsUsersController`, `RefDataProjectsController`, `PropertyValuesController`, `RequestController`, AD tests) keep their interface dependency (`IActiveDirectorySearcher`) and gain no behavioural change beyond Graph's documented semantic gaps (see C-5 + parity matrix in §4).
 - `Dorc.PersistentData`'s AD code path is removed; the `System.DirectoryServices` package ref drops from its csproj.
 
-Customer implication: every DORC install now requires an Entra ID tenant with an app registration and Graph permissions. Pure on-prem AD-only installs (no Entra tenant, no Entra Connect) **cannot upgrade** to this version without first establishing an Entra presence. See U-10 (escalated to product owner).
+Customer implication: every DORC install now requires an Entra ID tenant + app registration + Graph permissions, **and** (for any install with existing `AccessControl.Sid` rows or AD-rooted `RBAC` mappings) requires **Entra Connect (or Cloud Sync)** so on-prem SIDs are mirrored to Entra `onPremisesSecurityIdentifier`. Without Entra Connect, P-4 / P-7 in the parity matrix cannot resolve existing ACLs. Pure on-prem AD-only installs (no Entra tenant) **cannot upgrade** to this version. See U-10 (Product-owner decision).
 
 ### D-3 — Inter-API auth: loopback-only + shared secret header (was U-3)
 The worker binds to `127.0.0.1` and rejects any request without a shared-secret header `X-Worker-Key`. Authorization decisions are made entirely in the primary (using Graph-backed claims) *before* the worker is called; the worker trusts that any call reaching it has already been authz'd. For password reset, the worker uses **its own service account** (an AD-delegated reset-password identity) — the caller's identity is forwarded in the request body for audit only, not for impersonation.
@@ -94,29 +94,39 @@ Rationale: JWT/mTLS add machinery without material security benefit on loopback;
 ### In Scope
 
 **A. Graph migration (codebase-wide, per D-2):**
-- Promote `Dorc.Core/AzureEntraSearcher.cs` to the production implementation, removing its `[SupportedOSPlatform("windows")]` attribute.
-- Achieve parity with the deleted AD code for the **enumerated load-bearing behaviours** below (parity matrix). Behaviours not on this list are explicitly *not* parity-guaranteed and any consumer that depends on them must be identified and re-designed.
+- Promote `Dorc.Core/AzureEntraSearcher.cs` to the production implementation, removing its (incorrect) `[SupportedOSPlatform("windows")]` attribute.
+- Close the parity-matrix gaps flagged below as ❌:
+  - **P-4 (legacy AD SID lookup):** extend `GetUserDataById` so that when the input matches the SID shape (`S-1-5-...`) and the direct `Users[id]` lookup 404s, it falls back to `/users?$filter=onPremisesSecurityIdentifier eq '<sid>'` and the equivalent for groups.
+  - **P-5 (sAMAccountName resolution):** extend `GetGroupSidIfUserIsMemberRecursive` to resolve the `userName` argument via `/users?$filter=onPremisesSamAccountName eq '<name>' or userPrincipalName eq '<name>'` before calling `checkMemberGroups`.
+  - **P-7 (claims expansion emits both Pid and Sid):** rework whatever path expands a user's group memberships into claims so that it surfaces both the Entra `id` (→ `Pid`) and the `onPremisesSecurityIdentifier` (→ `Sid`), supporting the existing `ac.Pid ?? ac.Sid` resolution pattern.
+- Achieve parity with the deleted AD code for the load-bearing behaviours in the parity matrix. Behaviours not in the matrix are explicitly *not* parity-guaranteed and any consumer that depends on them must be identified and re-designed.
 - Delete the AD code listed in §2 / D-2.
 - Drop `System.DirectoryServices` and `System.DirectoryServices.AccountManagement` package refs from `Dorc.Core.csproj` and `Dorc.PersistentData.csproj`.
 - Update `Dorc.Api/Services/ApiRegistry.cs` DI to register the Graph-backed searcher directly.
-- Tests: `Dorc.Api.Tests/Controllers/AccessControlControllerTests.cs` and `Dorc.Api.Tests/Controllers/RefDataProjectsControllerDeleteTests.cs` updated against Graph-backed fixtures (or appropriate mocks at the `IActiveDirectorySearcher` boundary).
+- Tests (SC-6 / SC-9): **every row in the parity matrix gets at least one integration-level test against a Graph SDK fake (e.g. `Microsoft.Graph` request-adapter mock or a recorded HTTP harness) in addition to any mocked-interface unit tests.** Mocks at the `IActiveDirectorySearcher` boundary alone do *not* satisfy SC-9 because they don't exercise the Graph payload shape. Update `Dorc.Api.Tests/Controllers/AccessControlControllerTests.cs` and `Dorc.Api.Tests/Controllers/RefDataProjectsControllerDeleteTests.cs` to the Graph-backed pattern.
 
 **Parity matrix (load-bearing behaviours that must work post-Graph):**
 
-| Behaviour | Today (DirectoryServices) | Graph equivalent / strategy |
-|---|---|---|
-| User search by name | LDAP filter | `/users?$filter=startswith(displayName,...)` |
-| Group search by name | LDAP filter | `/groups?$filter=startswith(displayName,...)` |
-| Resolve identity by ID/SID | SID lookup | Entra `objectId` (UUID); SIDs from synced-from-AD users available via `onPremisesSecurityIdentifier` |
-| Recursive group membership ("is user X in group Y, transitively?") | `IsMemberOf` + walk | `/users/{id}/checkMemberGroups` (transitive, returns all groups user is in) |
-| All SIDs for a user (used for claims) | Walk groups | Transitive group IDs via `/users/{id}/transitiveMemberOf` |
-| Disabled account detection | `userAccountControl` bit | `accountEnabled` |
-| Display name + email | LDAP attribute | Graph `displayName` / `mail` / `userPrincipalName` |
+The matrix below is derived from the `IActiveDirectorySearcher` contract *and* its call sites (notably `AccessControlPersistentSource`, `EnvironmentsPersistentSource`, `ClaimsTransformer`). Every row in this table represents behaviour an existing customer install relies on; the Graph implementation in `aab79d14` already covers some rows but has gaps in others — those gaps are flagged below and are in-scope for S-001.
+
+| # | Behaviour | Today (DirectoryServices) | Graph equivalent / strategy | Current Graph impl status at `aab79d14` |
+|---|---|---|---|---|
+| P-1 | User search by name | LDAP filter | `/users?$filter=startswith(displayName,...) or startswith(userPrincipalName,...) or startswith(onPremisesSamAccountName,...)` | ✅ Already implemented (`Search`, line ~74) |
+| P-2 | Group search by name | LDAP filter | `/groups?$filter=startswith(displayName,...) or startswith(mailNickname,...) or startswith(onPremisesSamAccountName,...)` | ✅ Already implemented (line ~116) |
+| P-3 | Resolve identity by Entra object ID | n/a | `/users/{id}` then `/groups/{id}` fallback | ✅ Already implemented (`GetUserDataById`, line ~163) |
+| P-4 | **Resolve identity by legacy AD SID** (existing `AccessControl.Sid` rows) | SID lookup | `/users?$filter=onPremisesSecurityIdentifier eq '<sid>'` then `/groups?$filter=onPremisesSecurityIdentifier eq '<sid>'` fallback | ❌ **Gap — must be added in S-001.** Without this, every existing `AccessControl.Sid` row 404s post-migration (see `AccessControlPersistentSource.cs:77/180/196`, `EnvironmentsPersistentSource` lines 165/166/203/373/422/728/932 which use `ac.Sid` in EF queries). |
+| P-5 | **Resolve user by sAMAccountName** (for recursive membership) | LDAP `sAMAccountName=` | `/users?$filter=onPremisesSamAccountName eq '<name>'` then fall back to `/users/<upn>` | ❌ **Gap — must be added in S-001.** Current impl (`GetGroupSidIfUserIsMemberRecursive`, line ~325) treats the `userName` parameter as an Entra object ID / UPN and calls `graphClient.Users[userName]`, so sAMAccountName-only callers silently return empty. |
+| P-6 | Recursive group membership ("is user X in group Y, transitively?") | `IsMemberOf` + walk | After P-5 resolves user, `/users/{id}/checkMemberGroups` (transitive) | ✅ Logic already present; depends on P-5 |
+| P-7 | All group SIDs for a user (used for claims expansion) | Walk groups | `/users/{id}/transitiveMemberOf?$select=id,onPremisesSecurityIdentifier` returning both `id` and `onPremisesSecurityIdentifier` so consumers can match against either `Pid` or `Sid` columns | ❌ **Gap — must be added in S-001.** `EnvironmentsPersistentSource` line 894 (`ac.Pid ?? ac.Sid`) shows the codebase already accommodates dual ID worlds; the claims-expansion path must emit both values. |
+| P-8 | Disabled account detection | `userAccountControl` bit | `accountEnabled` | ✅ Already used (`GetUserDataById` checks `AccountEnabled == true`) |
+| P-9 | Display name + email | LDAP attribute | Graph `displayName` / `mail` / `userPrincipalName` | ✅ Already implemented |
 
 **Out of parity (explicitly):**
 - Local-machine SIDs (DORC didn't use these meaningfully).
 - Foreign Security Principals (cross-forest trusts) — must be flagged for any consumer that depends on this; none identified at `aab79d14`.
 - Well-known SIDs (`BUILTIN\Administrators` etc.) — DORC's RBAC uses domain groups, not well-known SIDs.
+
+**Data-migration implication:** P-4 and P-7 depend on the customer's Entra tenant having `onPremisesSecurityIdentifier` populated, which requires **Entra Connect (or Cloud Sync) to be present and to have synced the on-prem AD users/groups whose SIDs are persisted in `AccessControl.Sid`**. Without that, existing ACL rows cannot be resolved. This is folded into U-10 (customer migration prerequisite).
 
 **B. Worker process (per D-1):**
 - New project (working name `Dorc.Api.WindowsWorker` — see U-4).
@@ -176,7 +186,8 @@ Rationale: JWT/mTLS add machinery without material security benefit on loopback;
 - **SC-7** MSI installer adds the worker as a Windows-only component without breaking existing upgrade paths.
 - **SC-8a** LDAP-injection findings on PR #424 (`DirectorySearchController` ×2) are eliminated by the Graph migration removing the LDAP code path. Verified by re-running the security scan post-merge.
 - **SC-8b** Log-injection findings (`BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs`) are addressed in dedicated SPECs carved out from the relevant IS steps (S-005 for `ResetAppPasswordController`; the others get their own SPEC under the step that touches them). Not deferred outside this HLPS.
-- **SC-9** Parity matrix in §4 is documented as a living artefact (`docs/api-split/parity-matrix.md`) and every behaviour in it has at least one test exercising the Graph-backed path.
+- **SC-9** Parity matrix in §4 is documented as a living artefact (`docs/api-split/parity-matrix.md`) and every row has at least one **integration-level** test exercising the Graph-backed path against a Graph SDK fake or recorded HTTP harness. Interface-level mocks at the `IActiveDirectorySearcher` boundary alone do not satisfy this criterion.
+- **SC-10** Existing customer installs with `AccessControl.Sid` rows backed by on-prem AD SIDs continue to resolve correctly after migration, provided their Entra tenant has Entra Connect (or Cloud Sync) populating `onPremisesSecurityIdentifier`. Verified by an integration test against a Graph fake that exposes `onPremisesSecurityIdentifier` for sample users/groups.
 
 ---
 
@@ -192,7 +203,11 @@ Rationale: JWT/mTLS add machinery without material security benefit on loopback;
 - **U-7** Contract-test strategy for the inter-API surface (consumer-driven vs. shared-DTO vs. OpenAPI-spec-driven). Recommendation pending in the IS step that wires the contract: shared-DTO via the existing `Dorc.ApiModel` pattern is the lowest-friction choice.
 - **U-8** `Setup.Acceptance` handling: install the worker MSI for the test environment, or stub the worker endpoints. Gates SC-6 (contract tests on a real worker vs. mock).
 - **U-9** Graph permission set required (delegated vs application; specific permission names). Affects customer setup guidance (C-4) and the IS step that does the Graph migration. **Recommendation pending architecture confirmation:** application-only permissions (`User.Read.All`, `Group.Read.All`, `GroupMember.Read.All`) with admin consent, since the worker runs as a service account and never acts on behalf of an end user.
-- **U-10** Migration path for existing customers from AD to Entra. **Owner: Product.** If a customer has on-prem AD only (no Entra Connect, no Entra tenant), the upgrade is a hard break. Product decision required before release: do we publish migration guidance only, or do we ship a back-compat shim? Default position absent product input: hard break, documented prerequisites, no shim.
+- **U-10** Migration path for existing customers from AD to Entra. **Owner: Product.** Two customer cohorts and two outcomes:
+  - **Cohort A — has Entra tenant + Entra Connect populating `onPremisesSecurityIdentifier`.** Upgrade is transparent: P-4 / P-7 in the parity matrix resolve existing `AccessControl.Sid` rows via Entra. SC-10 covers this.
+  - **Cohort B — pure on-prem AD, no Entra tenant.** Hard break. Existing ACLs cannot be resolved post-migration.
+  Product decision required before release: do we publish migration guidance only, or do we ship a back-compat shim (e.g. an on-prem LDAP fallback for the SID-resolution path)? Default position absent product input: hard break for Cohort B; published prerequisites; no shim.
+- **U-11** Worker-absence detection on Linux: how does the primary know the worker is not available? Options: explicit config flag (`WindowsWorker:Enabled=false`), startup health-probe, null-impl registration based on `OperatingSystem.IsLinux()`. Decision in S-003's SPEC; recommendation pending: config flag (explicit, environment-agnostic, debuggable).
 
 ---
 
@@ -217,7 +232,7 @@ The step list below is **indicative**, not binding — the binding ordering live
 
 1. **Adversarial review of this HLPS — Round 2** (CLAUDE.md checkpoint). After this revision lands, the document returns to `IN REVIEW` for a second panel pass.
 2. On approval, draft `IS-api-split.md`. Indicative ordering with the riskiest step first (per Round-1 finding M-7):
-   - **S-001 — Graph migration (the spike).** Promote `AzureEntraSearcher`, remove its `[SupportedOSPlatform]` attribute, achieve parity matrix coverage, switch consumers, delete AD code, drop `System.DirectoryServices*` refs from `Dorc.Core` and `Dorc.PersistentData`. The CI gate (Linux build) is part of this step. If parity proves harder than D-2 assumes, we learn it here, not after four worker steps.
+   - **S-001 — Graph migration (the spike).** Promote `AzureEntraSearcher`, remove its `[SupportedOSPlatform]` attribute, close the parity-matrix ❌ gaps (P-4 SID lookup, P-5 sAMAccountName resolution, P-7 dual-ID claims emission), switch consumers, delete AD code, drop `System.DirectoryServices*` refs from `Dorc.Core` and `Dorc.PersistentData`, **ship the Linux build CI gate** that enforces SC-1 going forward. If parity proves harder than D-2 assumes, we learn it here, not after four worker steps.
    - **S-002** — Create `Dorc.Api.WindowsWorker` project, worker host, shared-secret auth scheme, DI scaffolding, MSI skeleton.
    - **S-003** — Define `IWindowsWorkerClient` HTTP contract; null/notSupported impl for Linux installs.
    - **S-004** — Move smallest Windows-only endpoint family (registry/remote-server probing) as proof-of-pattern.
@@ -260,3 +275,15 @@ For audit. Disposition of findings from the 2026-05-28 adversarial panel (Round 
 | R2-11 | LOW | Installer secret-handling security-review pass | Accept — C-7 added |
 | R2-12 | LOW | `ApiRegistry.cs` not listed | Accept — listed in §2 and D-2 |
 | R2-10 | LOW | Status-frontmatter timing nit | Reject — cosmetic |
+
+### Round 2 findings disposition
+
+| ID | Severity | Finding (one-line) | Disposition |
+|---|---|---|---|
+| NH-1 | HIGH | Parity matrix missed legacy AD SID lookup (every existing `AccessControl.Sid` row would 404 post-migration) | Accept — added as P-4 in §4 parity matrix with explicit Graph strategy (`$filter=onPremisesSecurityIdentifier eq '...'`); P-7 added to ensure claims-expansion path emits both `Pid` and `Sid`; SC-10 added; U-10 reframed with Cohort A / Cohort B distinction; Scope A bullet added requiring `GetUserDataById` SID-fallback in S-001 |
+| NH-2 | HIGH | `GetGroupSidIfUserIsMemberRecursive` silently broken for sAMAccountName callers (Graph impl treats userName as Entra ID) | Accept — added as P-5 in §4 parity matrix; Scope A bullet added requiring `GetGroupSidIfUserIsMemberRecursive` to resolve `userName` via `onPremisesSamAccountName` filter before calling `checkMemberGroups` |
+| NM-1 | MED | D-2 misdiagnosed `[SupportedOSPlatform("windows")]` attribute as "inherited" | Accept — D-2 reworded: "the attribute is incorrect — Graph is cross-platform" |
+| NM-2 | MED | Scope A "tests via mocks at the boundary" insufficient for SC-9 | Accept — Scope A tightened: every parity-matrix row requires an integration-level test against a Graph SDK fake; SC-9 reinforced with the same requirement |
+| NM-3 | MED | SC-4 `503` envelope doesn't say how primary detects worker absence | Accept — added as new non-blocking U-11 with config-flag recommendation; decision in S-003 SPEC |
+| NL-1 | LOW | CI gate not visible in Next Steps | Accept — S-001 step description updated to call out the Linux build CI gate explicitly |
+| NL-2 | LOW | Appendix A maps R2-8 to MED but Round 1 had it as HIGH | Accept (cosmetic) — original Round 1 review listed R2-8 in its MEDIUM section ("'No silent functional change… except where Graph semantics differ' is a get-out clause"), so the mapping is correct; this row clarifies the trace |

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -1,5 +1,5 @@
 ---
-status: IN REVIEW
+status: APPROVED
 author: Agent
 date: 2026-05-28
 issue: sefe/dorc#423
@@ -13,7 +13,7 @@ revision_round: 3
 
 | Field      | Value                       |
 |------------|-----------------------------|
-| **Status** | IN REVIEW (Round 3 — Round 2 NH-1/NH-2 addressed; see Appendix A) |
+| **Status** | APPROVED (Round 3 verification passed 2026-05-28; see Appendix A for full disposition trail) |
 | **Author** | Agent                       |
 | **Date**   | 2026-05-28                  |
 | **Issue**  | sefe/dorc#423               |

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -1,0 +1,143 @@
+---
+status: DRAFT
+author: Agent
+date: 2026-05-28
+issue: sefe/dorc#423
+folder: docs/api-split/
+supersedes_pr: sefe/dorc#424
+---
+
+# HLPS: Split `Dorc.Api` into Linux-compatible and Windows-only APIs
+
+| Field      | Value                       |
+|------------|-----------------------------|
+| **Status** | DRAFT                       |
+| **Author** | Agent                       |
+| **Date**   | 2026-05-28                  |
+| **Issue**  | sefe/dorc#423               |
+| **Folder** | docs/api-split/             |
+| **Supersedes** | sefe/dorc#424 (Copilot agent PR, closed unmerged) |
+
+---
+
+## 1. Problem Statement
+
+`Dorc.Api` is a single ASP.NET Core process that cannot run on Linux because portions of it depend on Windows-only stacks: `System.DirectoryServices` (Active Directory), `WindowsIdentity` / Negotiate / Kerberos, `System.Management` (WMI), and the Windows registry. Issue #423 requires the API to be split so that:
+
+1. A primary API contains only code that runs on Linux (and Windows).
+2. A secondary API contains the bare minimum Windows-only code.
+3. The primary API can call into the secondary when required.
+
+The motivating outcome is the ability to deploy the bulk of DORC on Linux hosts, treating Windows-only functionality (AD lookup, WMI service probing, registry reads, NTLM/Kerberos auth, password reset via impersonation) as an out-of-process Windows worker.
+
+---
+
+## 2. Observed Constraints from Today's Codebase
+
+The research captured in [`research/WINDOWS_DEPENDENCIES_ANALYSIS.md`](research/WINDOWS_DEPENDENCIES_ANALYSIS.md) inventories the Windows surface. Summary:
+
+| Surface                  | Files (approx.) | Linux alternative available?                     |
+|--------------------------|-----------------|--------------------------------------------------|
+| `System.DirectoryServices` (AD) | ~9        | Partially — `AzureEntraSearcher.cs` exists; full coverage requires either Graph or `Novell.Directory.Ldap.NETStandard` |
+| Windows Authentication (NTLM/Kerberos/impersonation) | ~9 | OAuth2/JWT already supported; full removal of Negotiate requires deployment-side decision |
+| WMI (`System.Management`) | ~9             | None drop-in. Remote service probing needs SSH/PowerShell-remoting/REST design |
+| Registry (`Microsoft.Win32`) | ~14         | `RuntimeInformation` covers local; remote registry has no portable equivalent |
+
+The PR #424 attempt mixed three concerns:
+1. Structural split (the stated goal).
+2. A bulk *banned-words* class rename (`PropertiesService→Properties`, `RequestService→Requests`, …) that misread CLAUDE.md's *naming principle* as a *naming blacklist* and produced grab-bag names (`Properties`, `Requests`, `Operations`) that are arguably worse than the originals.
+3. Speculative refactors and orchestrator extraction.
+
+Bundling (2) and (3) into the split caused a 5629-line diff with 113 files touched, persistent build-error cycles, and ~340 silently semantic-conflicted files once the parallel daemons-modernisation work landed on `main`. This HLPS deliberately scopes (1) only.
+
+---
+
+## 3. Scope
+
+### In Scope
+- Establishing a new project layout (working name `Dorc.Api.WindowsWorker`) for Windows-only endpoints currently inside `Dorc.Api`.
+- Defining the inter-API contract (HTTP client interface in `Dorc.Api` → `Dorc.Api.WindowsWorker`).
+- Identifying, moving, and minimally-adapting the smallest set of files that **must** be Windows-only:
+  - `DirectorySearchController` + `ActiveDirectorySearcher` paths (until a Linux LDAP/Graph alternative is selected — see U-2).
+  - `ResetAppPasswordController` (uses `WindowsIdentity` impersonation).
+  - `BundledRequestsController`, `MakeLikeProdController` (only their Windows-specific code paths — most logic is portable).
+  - WMI-using service-status code currently in `Dorc.Core/ServiceStatus.cs` / `DaemonStatusProbe.cs` (post-#649 rename).
+  - Remote registry reads in `RefDataServersController`.
+- Installer/wxs work to ship the new component (one MSI feature, one optional install on Windows-only deployments).
+- Documentation: ADR or architecture note explaining the runtime topology and how the worker is selected/configured.
+
+### Out of Scope (explicitly)
+- **Bulk class renaming** to remove the words *Service / Helper / Manager / Util*. CLAUDE.md's rule is principle-first (avoid grab-bag dumping-ground classes); class-by-class renames belong in their own scoped PRs only when the new name is *more* specific than the old.
+- Replacing `System.DirectoryServices` with `Novell.Directory.Ldap` or Graph (worthwhile, but separate HLPS — see U-2).
+- Replacing WMI with SSH/PowerShell-remoting (separate HLPS).
+- Folder reorganisation by "function" (`Identity/`, `Build/`, `Orchestration/`) inside the existing API — orthogonal to the split.
+- Changing the public Swagger/REST surface of `Dorc.Api`. Existing clients (`Dorc.Api.Client`, `dorc-web`, CLIs) must continue to work unchanged.
+
+---
+
+## 4. Constraints
+
+- **C-1 Backwards compatibility.** Existing API consumers (`dorc-web`, `Dorc.Api.Client`, CLI tools, MSI deployment) keep working with no client-side change.
+- **C-2 No bundled refactor.** Naming, folder layout, and DI cleanup do not ride along on this PR.
+- **C-3 Single deployable on Windows.** On Windows installs, the worker process must ship and run alongside the primary API as a separate MSI component (mirroring `Setup.Dorc/Web/RequestApi/ApiWindows.wxs` from the PR #424 attempt).
+- **C-4 Auth across the hop.** The primary API → worker call must propagate the calling user's identity in a way the worker can re-authenticate the original user when it needs to (AD lookups, impersonation for password reset).
+- **C-5 No silent functional change.** Every endpoint behaves identically pre- and post-split. The split is mechanical, not semantic.
+- **C-6 Follow the HLPS → IS → SPEC process.** Each batch of file moves goes through an IS step with its own SPEC and adversarial review.
+
+---
+
+## 5. Success Criteria
+
+- **SC-1** `Dorc.Api` builds and runs on a Linux container (no `<RuntimeIdentifier>win-*</RuntimeIdentifier>` required, no Windows-only NuGet refs in the csproj).
+- **SC-2** All Windows-only endpoints respond correctly on a Windows install where the worker is present, and return a documented `503` (or equivalent) on installs where the worker is absent.
+- **SC-3** Existing client apps (`dorc-web`, `Dorc.Api.Client`) make no code changes.
+- **SC-4** Unit and integration tests pass at parity with pre-split coverage.
+- **SC-5** MSI installer adds the worker as an optional/required component without breaking existing upgrade paths.
+- **SC-6** Security findings on PR #424 (LDAP injection in `DirectorySearchController`, log injection in 4 controllers) are addressed *in the moved code* as part of the move, not deferred.
+
+---
+
+## 6. Unknowns Register
+
+Per CLAUDE.md — blocking unknowns halt progress until resolved.
+
+### Blocking (must answer before IS)
+
+- **U-1 [BLOCKING]** Does the project want the worker to be a separate ASP.NET Core HTTP process, an in-proc plugin (`AssemblyLoadContext` with a Windows-only assembly conditionally loaded), or a queue-driven sidecar? PR #424 assumed HTTP. HTTP is simplest but the loopback cost matters for AD lookups on the hot path of authorization. **Decision required from architecture owner.**
+- **U-2 [BLOCKING]** What is the future of `System.DirectoryServices`? If a Linux LDAP alternative (Graph / Novell) will be adopted in the next 1–2 quarters, the AD code shouldn't be moved into the Windows worker at all — it should be replaced in-place. The scope of "what must be Windows-only" depends entirely on this decision.
+- **U-3 [BLOCKING]** Auth propagation across the inter-API hop — the worker needs to either (a) trust a signed token from the primary API and re-impersonate, or (b) receive the original client's Kerberos ticket via constrained delegation. Both have deployment implications that need stakeholder sign-off before code is written.
+
+### Non-blocking (can be resolved during IS)
+
+- **U-4** Naming of the new project: `Dorc.Api.Windows` (PR #424's choice) vs. `Dorc.Api.WindowsWorker` (more specific). Defer to first IS step.
+- **U-5** Should the worker share `appsettings.json` with the primary API or have its own? Affects config-secret handling.
+- **U-6** How does the primary API discover the worker URL? Config-file vs. service discovery. Likely config-file given current DORC topology.
+- **U-7** Test strategy for the inter-API contract: contract tests, mock worker for the primary's tests, etc.
+- **U-8** Whether `Setup.Acceptance` needs to install the worker for the test environment, or if a stub is sufficient.
+
+---
+
+## 7. References
+
+- Issue: [sefe/dorc#423](https://github.com/sefe/dorc/issues/423)
+- Superseded PR: [sefe/dorc#424](https://github.com/sefe/dorc/pull/424) (closed unmerged — see PR description for closure rationale)
+- Research carried over from PR #424:
+  - [`research/WINDOWS_DEPENDENCIES_ANALYSIS.md`](research/WINDOWS_DEPENDENCIES_ANALYSIS.md) — file-level inventory of Windows dependencies + cross-platform alternatives with historic-Windows compatibility matrices.
+  - [`research/ARCHITECTURE_API_SPLIT.md`](research/ARCHITECTURE_API_SPLIT.md) — PR #424's proposed architecture (HTTP-based split). Informational; the topology decision is U-1.
+  - [`research/REGISTRY_UPGRADE_EXAMPLE.md`](research/REGISTRY_UPGRADE_EXAMPLE.md) — concrete before/after for the registry dependency in `RefDataServersController`.
+  - [`research/FILES_TO_MOVE_ANALYSIS.md`](research/FILES_TO_MOVE_ANALYSIS.md) — PR #424's file-by-file move evaluation.
+  - [`research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md`](research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md) — analysis of hidden Windows deps in the Deployment folder.
+- CLAUDE.md naming principle: cohesive naming over banned-words blacklist. Memory: `feedback_naming_principle.md`.
+
+---
+
+## 8. Next Steps
+
+1. Resolve U-1, U-2, U-3 with the architecture owner (checkpoint).
+2. On approval of this HLPS, draft `IS-api-split.md` ordering the work into atomic steps. Likely shape (subject to U-1/U-2/U-3):
+   - S-001 — Create empty `Dorc.Api.WindowsWorker` project + DI scaffolding + MSI component.
+   - S-002 — Define `IWindowsWorkerClient` HTTP contract surface.
+   - S-003 — Move first endpoint family (probable candidate: registry/remote-server probing) end-to-end as the proof-of-pattern.
+   - S-004+ — Move remaining Windows-only families in turn (DirectorySearch, ResetAppPassword, WMI/service-status).
+   - S-N — Remove Windows-only NuGet refs from `Dorc.Api.csproj` and add a Linux container build gate.
+3. SPECs are drafted just-in-time per S-step, each adversarially reviewed before execution.

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -1,25 +1,26 @@
 ---
-status: APPROVED
+status: IN REVIEW
 author: Agent
 date: 2026-05-28
+revised: 2026-08-17 (Round 4)
 issue: sefe/dorc#423
 folder: docs/api-split/
 supersedes_pr: sefe/dorc#424
-codebase_anchor: aab79d14 (main, 2026-05-28) — file counts, paths, and class names are pinned to this commit
-revision_round: 3
+codebase_anchor: aebd286 (main, 2026-08-10) — re-anchored in Round 4; was aab79d14, 214 commits behind
+revision_round: 4
 ---
 
 # HLPS: Replace AD with Microsoft Graph + Split `Dorc.Api` into a Linux-compatible API and a Windows-only worker
 
 | Field      | Value                       |
 |------------|-----------------------------|
-| **Status** | APPROVED (Round 3 verification passed 2026-05-28; see Appendix A for full disposition trail) |
+| **Status** | IN REVIEW (Round 4). Was APPROVED at Round 3; **re-opened 2026-08-17** because implementation of S-001/S-002/S-003/S-004/S-007 falsified four success criteria and surfaced five undocumented behavioural changes. See Appendix B. |
 | **Author** | Agent                       |
 | **Date**   | 2026-05-28                  |
 | **Issue**  | sefe/dorc#423               |
 | **Folder** | docs/api-split/             |
 | **Supersedes** | sefe/dorc#424 (Copilot agent PR, closed unmerged) |
-| **Codebase anchor** | `aab79d14` (`main`, 2026-05-28). File counts/paths/classes valid at this SHA. |
+| **Codebase anchor** | `aebd286` (`main`, 2026-08-10). Re-anchored in Round 4 — the Round 3 anchor `aab79d14` was 214 commits stale, predating the Kafka substrate, the daemons modernisation follow-ups, and an LDAP-injection fix on `ActiveDirectorySearcher` (see Appendix B, R4-6). |
 
 ---
 
@@ -107,6 +108,12 @@ Rationale: JWT/mTLS add machinery without material security benefit on loopback;
 
 **Parity matrix (load-bearing behaviours that must work post-Graph):**
 
+> **Round 4:** the authoritative matrix now lives at [`parity-matrix.md`](parity-matrix.md) per
+> SC-9. The table below is retained as the record of what was known at drafting time; where the
+> two differ, the living artefact wins. Three rows the table marked ✅ at Round 3 turned out to
+> have no test behind them (P-6's negative case, P-9 entirely) or a test that could not detect a
+> wrong query (P-1/P-2/P-4). See Appendix B.
+
 The matrix below is derived from the `IActiveDirectorySearcher` contract *and* its call sites (notably `AccessControlPersistentSource`, `EnvironmentsPersistentSource`, `ClaimsTransformer`). Every row in this table represents behaviour an existing customer install relies on; the Graph implementation in `aab79d14` already covers some rows but has gaps in others — those gaps are flagged below and are in-scope for S-001.
 
 | # | Behaviour | Today (DirectoryServices) | Graph equivalent / strategy | Current Graph impl status at `aab79d14` |
@@ -161,6 +168,21 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 - Hardening the shared-secret storage to DPAPI / Azure Key Vault. Separate concern (M-1/D-3 acknowledged).
 - Log-injection findings in `BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs` — see SC-8b.
 
+**Added in Round 4 — consequences of S-001 that were not stated at Round 3.** These are recorded
+as scope decisions rather than left as silent behaviour changes; each needs an explicit accept or
+reject from the panel:
+
+- **M2M / IdentityServer client principals leave the identity picker.** Deleting
+  `IdentityServerSearcher` removes the only searcher returning IdentityServer clients from
+  `AccessControlController.SearchUsers`. Existing M2M grants continue to work; new ones cannot be
+  created through the UI. `IdentityServerClient.cs` and `GetIdentityServerClientId()` remain in
+  the tree but unreachable. **Proposed disposition: accept, and remove the dead client code in
+  S-010.** If rejected, S-001 must keep a Graph service-principal search path.
+- **Graph result truncation and loss of composite fault tolerance** — tracked as U-14 and U-13
+  rather than silently accepted.
+- **`AppSettings:ActiveDirectoryRoles` becomes dead configuration** — tracked as U-12.
+- **`AppSettings:IsUseAdSidsForAccessControl` becomes a no-op** — tracked as U-17.
+
 ---
 
 ## 5. Constraints
@@ -177,7 +199,10 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 
 ## 6. Success Criteria
 
-- **SC-1** `Dorc.Api`, `Dorc.Core`, and `Dorc.PersistentData` build with no `System.DirectoryServices*` package refs and no `System.Management` package refs. `Dorc.Api` runs on a Linux container with no `<RuntimeIdentifier>win-*</RuntimeIdentifier>`. CI gate: a Linux build job that fails if Windows-only refs reappear.
+- **SC-1** `Dorc.Api`, `Dorc.Core`, and `Dorc.PersistentData` build on Linux with no Windows-only dependencies, enforced by CI. **Phased, because the two halves land in different steps and stating them as one criterion made SC-1 unsatisfiable from S-001 until S-005:**
+  - **SC-1a (S-001):** no `System.DirectoryServices*` package refs; no `<RuntimeIdentifier>win-*</RuntimeIdentifier>`; no *new* Windows-only API usage. Enforced by the Linux build gate.
+  - **SC-1b (S-005):** no `System.Management` package refs, and the gate's accepted-backlog list is empty.
+  - The gate must enforce this at **three** layers, not one: a `csproj` guard (catches the dependency being *declared*), CA1416-as-error (catches the API being *used* — a Windows-only API compiles clean on Linux unless the warning is promoted, so a package-ref grep alone is not a gate), and a Linux test run. Added in Round 4 after the original single-layer gate was shown to pass with full `System.DirectoryServices.AccountManagement` usage reintroduced.
 - **SC-2** `Dorc.Api.WindowsWorker` builds, runs on Windows only, binds to `127.0.0.1`, and rejects calls missing `X-Worker-Key` with a documented `401` body.
 - **SC-3** On Windows installs with the worker present: WMI, registry, and password-reset endpoints behave identically to today (verified by parity tests against pre-split fixtures).
 - **SC-4** On Linux installs (no worker): WMI / registry / password-reset endpoints return `503 Service Unavailable` with body `{"error":"windows_worker_unavailable", "endpoint":"<name>"}`. This is the documented behavioural envelope referenced in C-1.
@@ -185,8 +210,9 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 - **SC-6** All existing unit and integration tests pass at parity with pre-split coverage; new contract tests cover the primary↔worker HTTP surface; new tests cover the Graph-backed AD code path against the parity matrix in §4.
 - **SC-7** MSI installer adds the worker as a Windows-only component without breaking existing upgrade paths.
 - **SC-8a** LDAP-injection findings on PR #424 (`DirectorySearchController` ×2) are eliminated by the Graph migration removing the LDAP code path. Verified by re-running the security scan post-merge.
-- **SC-8b** Log-injection findings (`BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs`) are addressed in dedicated SPECs carved out from the relevant IS steps (S-005 for `ResetAppPasswordController`; the others get their own SPEC under the step that touches them). Not deferred outside this HLPS.
-- **SC-9** Parity matrix in §4 is documented as a living artefact (`docs/api-split/parity-matrix.md`) and every row has at least one **integration-level** test exercising the Graph-backed path against a Graph SDK fake or recorded HTTP harness. Interface-level mocks at the `IActiveDirectorySearcher` boundary alone do not satisfy this criterion.
+- **SC-8b** Log-injection findings (`BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs`) are addressed in dedicated SPECs carved out from the relevant IS steps (**S-006** for `ResetAppPasswordController` — corrected in Round 4, this said S-005, which is the WMI probe step and never touches that file; the others get their own SPEC under the step that touches them). Not deferred outside this HLPS.
+- **SC-9** The parity matrix lives at [`docs/api-split/parity-matrix.md`](parity-matrix.md) — created in Round 4; SC-9 had mandated it since Round 1 but it was never written, and the matrix lived only inside §4 and SPEC-S-001, both of which go stale when their step merges. Every row has at least one **integration-level** test exercising the Graph-backed path against a Graph SDK fake or recorded HTTP harness. Interface-level mocks at the `IActiveDirectorySearcher` boundary alone do not satisfy this criterion.
+  - **Added in Round 4:** for rows whose risk is a *wrong query* rather than a wrong response, the test must assert the emitted `$filter` / `$select`. A response-only test cannot detect a wrong filter, because the fake answers regardless of what was asked. A row is not ✅ until its test **fails when the behaviour is removed**.
 - **SC-10** Existing customer installs with `AccessControl.Sid` rows backed by on-prem AD SIDs continue to resolve correctly after migration, provided their Entra tenant has Entra Connect (or Cloud Sync) populating `onPremisesSecurityIdentifier`. Verified by an integration test against a Graph fake that exposes `onPremisesSecurityIdentifier` for sample users/groups.
 
 ---
@@ -194,16 +220,58 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 ## 7. Unknowns Register
 
 ### Blocking
-*None remaining.* Original U-1, U-2, U-3 resolved as D-1, D-2, D-3 above.
 
-### Non-blocking (resolved during IS; some require named owner)
+Per CLAUDE.md, **blocking unknowns halt progress**. Original U-1, U-2, U-3 were resolved as D-1,
+D-2, D-3. Round 4 promotes one existing unknown and adds two, all of which gate *release*
+rather than further implementation — S-001 through S-007 can continue, but none of this may
+ship to a customer until they are answered.
+
+- **U-10 (promoted from non-blocking in Round 4) — migration path for Cohort B.** Customers on
+  pure on-prem AD with no Entra tenant lose all ACL resolution at upgrade. This was filed as
+  non-blocking with a default of "hard break, no shim, published prerequisites", but a default
+  chosen by the authors is not a product decision, and by Round 3 the HLPS was APPROVED with a
+  customer-breaking change resting on an unanswered question. **Owner: Product.** Required
+  before release: confirm the hard break, or fund a back-compat shim.
+- **U-12 (new) — role-claim prerequisite.** S-007 deletes `ClaimsTransformer`, which was the only
+  reader of `AppSettings:ActiveDirectoryRoles`. `User.IsInRole("Admin")` / `("PowerUser")` remain
+  load-bearing across `RefDataController`, `RefDataPermissionController`, `RefDataSqlPortsController`,
+  `DeploymentsHub`, `RolePrivilegesChecker` and `SecurityObjectFilter`, and now resolve **solely**
+  from the JWT `role` claim. The installer still writes the AD group settings, so an operator who
+  upgrades and configures them as always gets 403 on every admin endpoint if their Entra app
+  registration does not emit `role`. **Owner: architecture + docs.** Required before release:
+  either the app-registration guidance makes `role` emission a documented prerequisite, or the
+  dead config and its WiX writes are removed so the knob stops lying about being effective.
+- **U-16 (new) — worker provisioning ordering.** S-004 routes a live endpoint through the worker
+  while `WindowsWorker:Enabled` ships `false` and nothing sets it `true`, because provisioning is
+  S-008's job and S-008 has no PR. As sequenced, merging S-004 turns a working endpoint into a
+  503 on every existing Windows install. **Owner: architecture.** Required before S-004 merges:
+  land S-008 first, or flip the shipped default. The same ordering trap applies to S-007, whose
+  startup guard rejects the `AuthenticationScheme` value the MSI itself writes.
+
+### Non-blocking (added in Round 4)
+
+- **U-13** Graph fault tolerance. Removing `CompositeActiveDirectorySearcher` means a Graph 429/503
+  is now a 500 rather than a degraded result, and no retry handler is configured on the Kiota
+  adapter. Decide whether to configure Graph SDK retry/backoff or accept the change.
+- **U-14** Result-set truncation. `Search` reads one Graph page (100 users + 100 groups) with no
+  signal to the caller; the AD path returned up to ~1000. Pre-existing on the OAuth path, but
+  S-001 makes it the only path, including for `DirectorySearchController`.
+- **U-15** Multi-domain tenants. `onPremisesSamAccountName` is unique per domain, not per tenant.
+  Current behaviour refuses to resolve an ambiguous name (fails closed). Confirm that refusing is
+  preferred over a domain-scoped filter.
+- **U-17** `IsUseAdSidsForAccessControl` is a no-op after S-007 — `ClaimsPrincipalReaderFactory`,
+  its only reader, is left unregistered when `ConfigureBoth` is deleted. Decide: delete the flag
+  and the class, or re-register it. Note that re-registering does not restore the behaviour, since
+  its AD branch resolves names that Graph cannot match.
+
+### Non-blocking (from Rounds 1-3; resolved during IS; some require named owner)
 - **U-4** Naming of the new project: `Dorc.Api.Windows` vs. `Dorc.Api.WindowsWorker`. Prefer the latter for specificity (per CLAUDE.md naming principle); confirm in the IS step that creates the project.
 - **U-5** Worker config: shared `appsettings.json` with the primary vs. its own. Affects secret-handling at install time.
 - **U-6** Worker URL discovery: config-file (likely) vs. service discovery.
 - **U-7** Contract-test strategy for the inter-API surface (consumer-driven vs. shared-DTO vs. OpenAPI-spec-driven). Recommendation pending in the IS step that wires the contract: shared-DTO via the existing `Dorc.ApiModel` pattern is the lowest-friction choice.
 - **U-8** `Setup.Acceptance` handling: install the worker MSI for the test environment, or stub the worker endpoints. Gates SC-6 (contract tests on a real worker vs. mock).
 - **U-9** Graph permission set required (delegated vs application; specific permission names). Affects customer setup guidance (C-4) and the IS step that does the Graph migration. **Recommendation pending architecture confirmation:** application-only permissions (`User.Read.All`, `Group.Read.All`, `GroupMember.Read.All`) with admin consent, since the worker runs as a service account and never acts on behalf of an end user.
-- **U-10** Migration path for existing customers from AD to Entra. **Owner: Product.** Two customer cohorts and two outcomes:
+- **U-10** *(promoted to Blocking in Round 4 — detail retained here.)* Migration path for existing customers from AD to Entra. **Owner: Product.** Two customer cohorts and two outcomes:
   - **Cohort A — has Entra tenant + Entra Connect populating `onPremisesSecurityIdentifier`.** Upgrade is transparent: P-4 / P-7 in the parity matrix resolve existing `AccessControl.Sid` rows via Entra. SC-10 covers this.
   - **Cohort B — pure on-prem AD, no Entra tenant.** Hard break. Existing ACLs cannot be resolved post-migration.
   Product decision required before release: do we publish migration guidance only, or do we ship a back-compat shim (e.g. an on-prem LDAP fallback for the SID-resolution path)? Default position absent product input: hard break for Cohort B; published prerequisites; no shim.
@@ -287,3 +355,38 @@ For audit. Disposition of findings from the 2026-05-28 adversarial panel (Round 
 | NM-3 | MED | SC-4 `503` envelope doesn't say how primary detects worker absence | Accept — added as new non-blocking U-11 with config-flag recommendation; decision in S-003 SPEC |
 | NL-1 | LOW | CI gate not visible in Next Steps | Accept — S-001 step description updated to call out the Linux build CI gate explicitly |
 | NL-2 | LOW | Appendix A maps R2-8 to MED but Round 1 had it as HIGH | Accept (cosmetic) — original Round 1 review listed R2-8 in its MEDIUM section ("'No silent functional change… except where Graph semantics differ' is a get-out clause"), so the mapping is correct; this row clarifies the trace |
+
+---
+
+## Appendix B — Round 4 revision: why an APPROVED HLPS was re-opened
+
+Round 3 approved this document on 2026-05-28 against codebase anchor `aab79d14`. Between then and
+2026-08-17, steps S-001, S-002, S-003, S-004 and S-007 were implemented and adversarially reviewed.
+That work falsified four success criteria and surfaced five behavioural changes the HLPS never
+stated. Approval at Round 3 was therefore premature — not wrong in its decisions (D-1/D-2/D-3 all
+held up under implementation), but wrong in claiming its criteria were sound and its scope complete.
+
+The pattern worth recording: **every one of these was invisible to document review and only
+became visible when something executed.** A plan review cannot tell you that a CI gate does not
+fail, or that a test passes against a mutated implementation.
+
+| ID | Severity | Finding | Disposition |
+|---|---|---|---|
+| R4-1 | HIGH | SC-9 mandated `docs/api-split/parity-matrix.md` since Round 1. The file was never created; the matrix lived only in §4 and SPEC-S-001, both of which go stale when their step merges. | Accept — artefact created; SC-9 reworded to reference it and to require request-level assertions. |
+| R4-2 | HIGH | Three matrix rows marked ✅ had no evidence: P-6's negative case and P-9 had no test at all, and P-1/P-2/P-4's tests asserted only the response, so a wrong `$filter` passed. Mutation testing showed six of eight injected defects — including an authorization bypass and removal of the OData escaping — passing the suite. | Accept — SC-9 now requires a row's test to fail when the behaviour is removed; matrix records mutation evidence per row. |
+| R4-3 | HIGH | SC-1 combined `System.DirectoryServices*` (removed at S-001) with `System.Management` (removed at S-005) into one criterion, making it unsatisfiable for the entire span between those steps and giving no way to state partial compliance. | Accept — split into SC-1a / SC-1b. |
+| R4-4 | HIGH | SC-1's CI gate was specified as "a Linux build job that fails if Windows-only refs reappear". A build job does not fail: CA1416 is a warning unless promoted, so full `System.DirectoryServices.AccountManagement` usage compiles clean on Linux. The criterion described an enforcement mechanism that cannot enforce. | Accept — SC-1 now specifies three layers and names CA1416-as-error explicitly. |
+| R4-5 | MEDIUM | SC-8b assigned the `ResetAppPasswordController` log-injection fix to S-005, which is the WMI probe step and never touches that file. The IS assigns that controller to S-006. | Accept — corrected to S-006. |
+| R4-6 | MEDIUM | The Round 3 anchor was 214 commits stale. In that window `main` gained the Kafka substrate and an LDAP-injection fix to `ActiveDirectorySearcher` — a file S-001 deletes. The identical vulnerable regex in `AzureEntraSearcher` was never covered by that fix, so migrating as planned would have reverted a security fix in effect, with no git conflict to signal it. | Accept — re-anchored to `aebd286`; carry-forward performed in S-001. Recorded because an HLPS pinned to a stale anchor cannot see this class of interaction. |
+| R4-7 | MEDIUM | U-10 (Cohort B hard break) sat in the non-blocking list with an authors' default standing in for a Product decision, while the HLPS was APPROVED and implementation proceeded. | Accept — promoted to Blocking. |
+| R4-8 | MEDIUM | Five consequences of S-001/S-007 were absent from Scope: M2M principals leaving the identity picker, `ActiveDirectoryRoles` becoming dead config with a new IdP prerequisite, `IsUseAdSidsForAccessControl` becoming a no-op, loss of composite fault tolerance, and Graph result truncation. | Accept — added to Scope / Out of Scope and tracked as U-12 through U-17. |
+| R4-9 | MEDIUM | The step sequence lets S-004 and S-007 merge before S-008 provisions them, turning working endpoints into 503s and a failed startup on existing installs. The HLPS records step *dependencies* but has no notion of a step being un-shippable without a later one. | Accept — U-16 added as blocking; IS dependency column should distinguish "builds on" from "cannot ship without". |
+
+### What Round 4 does not resolve
+
+- U-10, U-12 and U-16 are blocking and need named owners, not author defaults.
+- SC-3 ("verified by parity tests against pre-split fixtures") still has no fixtures. S-004 shipped
+  with no test asserting the worker's registry endpoint rejects an unauthenticated request, and the
+  worker projects are `net8.0-windows`, so they cannot be verified in Linux CI at all. SC-2 and SC-3
+  need a stated verification host before S-005 and S-006 add more worker surface.
+- SC-6 depends on U-8 (`Setup.Acceptance` strategy), still unanswered.

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -2,19 +2,19 @@
 status: IN REVIEW
 author: Agent
 date: 2026-05-28
-revised: 2026-08-17 (Round 4)
+revised: 2026-08-17 (Round 5 — Round 4 rejected by panel)
 issue: sefe/dorc#423
 folder: docs/api-split/
 supersedes_pr: sefe/dorc#424
 codebase_anchor: aebd286 (main, 2026-08-10) — re-anchored in Round 4; was aab79d14, 214 commits behind
-revision_round: 4
+revision_round: 5
 ---
 
 # HLPS: Replace AD with Microsoft Graph + Split `Dorc.Api` into a Linux-compatible API and a Windows-only worker
 
 | Field      | Value                       |
 |------------|-----------------------------|
-| **Status** | IN REVIEW (Round 4). Was APPROVED at Round 3; **re-opened 2026-08-17** because implementation of S-001/S-002/S-003/S-004/S-007 falsified four success criteria and surfaced five undocumented behavioural changes. See Appendix B. |
+| **Status** | IN REVIEW (Round 5 — the panel returned REVISION REQUIRED on Round 4; see Appendix C). Was APPROVED at Round 3; **re-opened 2026-08-17** because implementation of S-001/S-002/S-003/S-004/S-007 falsified four success criteria and surfaced five undocumented behavioural changes. See Appendix B. |
 | **Author** | Agent                       |
 | **Date**   | 2026-05-28                  |
 | **Issue**  | sefe/dorc#423               |
@@ -38,7 +38,7 @@ To meet (1) end-to-end, the entire compile graph of the primary API — not just
 
 ## 2. Observed Constraints from Today's Codebase
 
-All file references in this section are pinned to `aab79d14` (see frontmatter). Research carried over from PR #424 lives in [`research/`](research/) and may have drifted; treat it as background, not the source of truth.
+All file references in this section are pinned to `aebd286` (see frontmatter). Paths were re-verified at that commit in Round 5; the Round 4 re-anchor updated the frontmatter only, which is how a since-deleted file survived in SC-8b. Research carried over from PR #424 lives in [`research/`](research/) and may have drifted; treat it as background, not the source of truth.
 
 | Surface                  | Where it lives (`aab79d14`) | Linux alternative |
 |--------------------------|-------------------------------|--------------------|
@@ -166,7 +166,7 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 - Folder reorganisation by "function" (`Identity/`, `Build/`, `Orchestration/`) inside the existing API.
 - Changing the public Swagger/REST surface of `Dorc.Api` in shape. (Behaviour envelope on Linux installs is covered by C-1 and SC-4.)
 - Hardening the shared-secret storage to DPAPI / Azure Key Vault. Separate concern (M-1/D-3 acknowledged).
-- Log-injection findings in `BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs` — see SC-8b.
+- Log-injection findings in `BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Dorc.Api/Services/RequestService.cs` (was `Deployment/Requests.cs`, which does not exist at `aebd286`) — see SC-8b.
 
 **Added in Round 4 — consequences of S-001 that were not stated at Round 3.** These are recorded
 as scope decisions rather than left as silent behaviour changes; each needs an explicit accept or
@@ -210,7 +210,7 @@ reject from the panel:
 - **SC-6** All existing unit and integration tests pass at parity with pre-split coverage; new contract tests cover the primary↔worker HTTP surface; new tests cover the Graph-backed AD code path against the parity matrix in §4.
 - **SC-7** MSI installer adds the worker as a Windows-only component without breaking existing upgrade paths.
 - **SC-8a** LDAP-injection findings on PR #424 (`DirectorySearchController` ×2) are eliminated by the Graph migration removing the LDAP code path. Verified by re-running the security scan post-merge.
-- **SC-8b** Log-injection findings (`BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Deployment/Requests.cs`) are addressed in dedicated SPECs carved out from the relevant IS steps (**S-006** for `ResetAppPasswordController` — corrected in Round 4, this said S-005, which is the WMI probe step and never touches that file; the others get their own SPEC under the step that touches them). Not deferred outside this HLPS.
+- **SC-8b** Log-injection findings (`BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Dorc.Api/Services/RequestService.cs` (was `Deployment/Requests.cs`, which does not exist at `aebd286`)) are addressed in dedicated SPECs carved out from the relevant IS steps (**S-009** for all four sites — see R4-5/R5-1: Round 3 said S-005, Round 4 changed it to S-006, and *both were wrong*. The IS assigns every log-injection fix to S-009 and states explicitly that S-006 is the worker-move only, keeping the security diff on its own reviewable surface). Not deferred outside this HLPS.
 - **SC-9** The parity matrix lives at [`docs/api-split/parity-matrix.md`](parity-matrix.md) — created in Round 4; SC-9 had mandated it since Round 1 but it was never written, and the matrix lived only inside §4 and SPEC-S-001, both of which go stale when their step merges. Every row has at least one **integration-level** test exercising the Graph-backed path against a Graph SDK fake or recorded HTTP harness. Interface-level mocks at the `IActiveDirectorySearcher` boundary alone do not satisfy this criterion.
   - **Added in Round 4:** for rows whose risk is a *wrong query* rather than a wrong response, the test must assert the emitted `$filter` / `$select`. A response-only test cannot detect a wrong filter, because the fake answers regardless of what was asked. A row is not ✅ until its test **fails when the behaviour is removed**.
 - **SC-10** Existing customer installs with `AccessControl.Sid` rows backed by on-prem AD SIDs continue to resolve correctly after migration, provided their Entra tenant has Entra Connect (or Cloud Sync) populating `onPremisesSecurityIdentifier`. Verified by an integration test against a Graph fake that exposes `onPremisesSecurityIdentifier` for sample users/groups.
@@ -222,9 +222,10 @@ reject from the panel:
 ### Blocking
 
 Per CLAUDE.md, **blocking unknowns halt progress**. Original U-1, U-2, U-3 were resolved as D-1,
-D-2, D-3. Round 4 promotes one existing unknown and adds two, all of which gate *release*
-rather than further implementation — S-001 through S-007 can continue, but none of this may
-ship to a customer until they are answered.
+D-2, D-3. Round 4 promotes one existing unknown and adds two, **U-10 and U-12 gate release**; **U-16 gates the S-004 and S-007 merges** and is not a
+release-only concern. Implementation of the remaining steps may continue. Note this section
+reads CLAUDE.md's "blocking unknowns halt progress" as halting *the affected merge or the
+release*, not all work — an explicit deviation, recorded here rather than left implicit.
 
 - **U-10 (promoted from non-blocking in Round 4) — migration path for Cohort B.** Customers on
   pure on-prem AD with no Entra tenant lose all ACL resolution at upgrade. This was filed as
@@ -308,7 +309,7 @@ The step list below is **indicative**, not binding — the binding ordering live
    - **S-006** — Move `ResetAppPasswordController` impersonation (worker uses its own service account); includes SC-8b carve-out for that controller's log-injection fix.
    - **S-007** — Remove Windows-auth scheme from primary (Negotiate scheme + `WinAuth*` files).
    - **S-008** — Installer wiring: ship worker MSI component, provision shared secret + service account at install time (subject to C-7 security review).
-   - **S-009** — Remaining log-injection SPEC carve-outs (per SC-8b) for `BundledRequestsController`, `MakeLikeProdController`, `Deployment/Requests.cs`.
+   - **S-009** — Remaining log-injection SPEC carve-outs (per SC-8b) for `BundledRequestsController`, `MakeLikeProdController`, `Dorc.Api/Services/RequestService.cs` (was `Deployment/Requests.cs`, which does not exist at `aebd286`).
    - **S-010** — Documentation: Entra tenant setup, Graph permissions, AD-to-Entra migration prerequisites, deployment topology.
 3. SPECs are drafted just-in-time per S-step, each adversarially reviewed before execution.
 
@@ -390,3 +391,48 @@ fail, or that a test passes against a mutated implementation.
   worker projects are `net8.0-windows`, so they cannot be verified in Linux CI at all. SC-2 and SC-3
   need a stated verification host before S-005 and S-006 add more worker surface.
 - SC-6 depends on U-8 (`Setup.Acceptance` strategy), still unanswered.
+
+---
+
+## Appendix C — Round 5: the panel rejected Round 4
+
+Two independent reviewers returned **REVISION REQUIRED** on the Round 4 revision. Both were
+right, and the pattern is worth recording because it repeats Round 3's failure one level up:
+Round 4 claimed to close R4-2 (tests that cannot detect a wrong query) and R4-4 (a gate that
+cannot enforce), and **both defects survived inside the artefacts written to close them.**
+
+Round 4 was also, in three places, a *documentation* fix applied without reading the documents
+it cited. R5-1 is the clearest case: it "corrected" SC-8b on a premise about the IS that the IS
+contradicts in two places.
+
+| ID | Severity | Finding | Disposition |
+|---|---|---|---|
+| R5-1 | HIGH | SC-8b's Round-4 correction (S-005 → S-006) was wrong, and Appendix B justified it with a false statement about the IS. The IS assigns all four log-injection sites to **S-009** and says explicitly that S-006 is the worker-move only. Executing SC-8b as revised would have duplicated a security fix into S-006 and reversed an IS Round-1 decision without review. | Accept — corrected to S-009; R4-5's false claim called out in place rather than quietly overwritten. |
+| R5-2 | CRITICAL | Parity-matrix P-4 and SC-10 were ✅ under a rule the matrix itself states ("a row is not ✅ until its test fails when the behaviour is removed"). `MapFilter` matched on the property *name*, so hardcoding a wrong SID into the filter passed 164/164 — every legacy `AccessControl.Sid` row could resolve to the wrong principal, undetected. | Accept — value assertions added; mutation now fails 2 tests. |
+| R5-3 | CRITICAL | Same class: removing `accountEnabled eq true` from the membership resolution path passed 164/164. A disabled leaver would resolve and receive group claims. | Accept — assertion added; mutation now fails. |
+| R5-4 | CRITICAL | SC-1's CA1416 layer does not fire inside a type annotated `[SupportedOSPlatform("windows")]`, and a `#pragma warning disable CA1416` silences it outright. Six `Dorc.Api` controllers still carry the attribute, including the two AD-facing ones S-001 was meant to clean. Windows-only code inside them passes all three layers. | Accept — a fourth grep layer added; known sites allow-listed with the step that clears each. **The HLPS's "three-layer gate" claim was wrong as stated.** |
+| R5-5 | HIGH | SC-1b's terminal condition ("the accepted-backlog list is empty") would have *disabled* the gate: `grep -vE ""` matches nothing, so an empty backlog makes the check a permanent pass. Satisfying the criterion removed the enforcement. | Accept — empty case handled explicitly; `System.Management` check added so SC-1b has a mechanism at all. |
+| R5-6 | HIGH | Out of Scope forbids changing the REST surface "in shape", but S-001 added `UserElementApiModel.SamAccountName` and S-004 changed a 400 body from string to object while leaving `[SwaggerResponse(400, Type = typeof(string))]` in place. The worker's 400 body was also double-wrapped: `{"error":"{\"error\":\"...\"}"}`. | Partially accepted — the double-wrap was a live bug and is fixed. The two surface deltas need a panel decision: carve them out of Out of Scope, or revert them. Tracked as U-20. |
+| R5-7 | HIGH | D-3 and SC-2 both state the worker "rejects any request without `X-Worker-Key`". `/health` is deliberately unauthenticated. The implementation also ships *both* U-11 options (config flag **and** health probe) while U-11 still records "recommendation pending". | Accept in principle — needs the D-3/SC-2 wording amended and U-11 closed with the decision actually shipped. Not yet done; tracked as U-21. |
+| R5-8 | MEDIUM | Scope A describes P-4 as falling back "when the direct `Users[id]` lookup 404s". The code deliberately *skips* the direct lookup for SID-shaped input because Graph returns 400. The P-4 tests still mock a 404 route that is never taken — which is how R5-2's false ✅ went unnoticed. | Accept — matrix corrected; §4's P-4 bullet still needs rewriting. |
+| R5-9 | MEDIUM | Scope A mandates updating two `Dorc.Api.Tests` files to the Graph-backed pattern. `git diff` shows neither was touched. | Open — unrecorded incomplete scope item. |
+| R5-10 | MEDIUM | Scope E's deletion list omits `ContextExtensions.cs`, `ClaimsTransformer.cs`, `IUserGroupsReaderFactory.cs` and the added `EntraDirectorySearchService.cs`. D-2 still asserts `ClaimsTransformer` "keeps its interface dependency and gains no behavioural change" — it was deleted. | Open — scope lists and D-2 need correcting. |
+| R5-11 | MEDIUM | HLPS U-12..U-17 collide with the IS's own U-12 (worker hosting model), which can force retroactive revision of S-002 and appears in no HLPS register. | Open — renumber, and lift the worker-hosting unknown into the HLPS register. |
+| R5-12 | MEDIUM | Five unknowns (U-4, U-5, U-6, U-7, U-11) are listed open with "recommendation pending" but were resolved in the IS and are in shipped code. Round 4 closed none of them. | Open. |
+| R5-13 | MEDIUM | SC-2/SC-3/SC-5/SC-6/SC-7 remain unverifiable: no fixtures exist for SC-3, no SPEC-S-004 was ever written, no step verifies `dorc-web` for SC-5, SC-6's baseline is unrecoverable after the re-anchor, and **no step owns `RequestApi.wxs`** — so S-007 ships an API that will not start on an upgraded install while SC-7 passes anyway. | Open — R5-13 is the largest remaining hole and needs a scope item plus an IS step. |
+
+### Status after Round 5
+
+`IN REVIEW`. The CRITICAL and gate findings (R5-2 through R5-5) are fixed and re-verified by
+mutation. R5-1 and the stale file/anchor citations are corrected. **R5-6 through R5-13 are
+recorded and unresolved** — several need panel or owner decisions rather than an author's, which
+is exactly the failure mode that produced the premature Round 3 approval. This document should
+not be marked APPROVED until at least R5-13 has an owning step.
+
+### Process note carried from the panel
+
+One reviewer observed that R5-1, and the stale-path and ID-collision findings, are cross-document
+contradictions a mechanical pass would have caught before any code ran: every SC that names a step
+checked against the IS, every file path checked against the anchor, every unknown ID checked for
+collisions. That pass should be a checklist item on every future revision, not left to reviewer
+diligence. Adopted.

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -164,7 +164,11 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 - Supporting pure on-prem AD installs without an Entra tenant. Per D-2, an Entra tenant is now a hard prerequisite.
 - Replacing WMI with SSH / PowerShell-remoting / REST agents (separate HLPS if/when desired). Worker is permanent (D-1).
 - Folder reorganisation by "function" (`Identity/`, `Build/`, `Orchestration/`) inside the existing API.
-- Changing the public Swagger/REST surface of `Dorc.Api` in shape. (Behaviour envelope on Linux installs is covered by C-1 and SC-4.)
+- Changing the public Swagger/REST surface of `Dorc.Api` in shape, **except the two deltas
+  carved out in Round 6 under U-20**: `UserElementApiModel.SamAccountName` (additive, nullable)
+  and the `GetServerOperatingFromTarget` 400 body reshaped from string to object, whose
+  `[SwaggerResponse]` annotation is corrected to match. Both are listed in release notes.
+  (Behaviour envelope on Linux installs is covered by C-1 and SC-4.)
 - Hardening the shared-secret storage to DPAPI / Azure Key Vault. Separate concern (M-1/D-3 acknowledged).
 - Log-injection findings in `BundledRequestsController`, `MakeLikeProdController`, `ResetAppPasswordController`, `Dorc.Api/Services/RequestService.cs` (was `Deployment/Requests.cs`, which does not exist at `aebd286`) — see SC-8b.
 
@@ -172,7 +176,10 @@ The matrix below is derived from the `IActiveDirectorySearcher` contract *and* i
 as scope decisions rather than left as silent behaviour changes; each needs an explicit accept or
 reject from the panel:
 
-- **M2M / IdentityServer client principals leave the identity picker.** Deleting
+- **M2M / IdentityServer client principals leave the identity picker.** **REVERSED in Round 6:**
+  the panel decision was to *restore* them via a Graph `/servicePrincipals` search in S-001,
+  keyed on `appId` (the value `AccessControl.Pid` holds for M2M callers). The IdentityServer
+  client code remains unreachable and is removed in a follow-up step. Original text: deleting
   `IdentityServerSearcher` removes the only searcher returning IdentityServer clients from
   `AccessControlController.SearchUsers`. Existing M2M grants continue to work; new ones cannot be
   created through the UI. `IdentityServerClient.cs` and `GetIdentityServerClientId()` remain in
@@ -187,7 +194,10 @@ reject from the panel:
 
 ## 5. Constraints
 
-- **C-1 No client-side compile-time change.** Existing API consumers (`dorc-web`, `Dorc.Api.Client`, CLI tools) compile and ship unchanged. Behavioural changes are scoped: on Windows installs they are nil (SC-3); on Linux installs the WMI / registry / password-reset endpoints return a documented `503` (SC-4). Customer-facing release notes must call out this behavioural envelope.
+- **C-1 No client-side compile-time change.** Existing API consumers (`dorc-web`, `Dorc.Api.Client`, CLI tools) compile and ship unchanged. Behavioural changes are scoped: on Windows installs the moved endpoints are unchanged (SC-3), but Round 6 records a
+  non-empty Windows-install delta that release notes must carry: the two REST-surface changes
+  under U-20, the `ActiveDirectoryRoles` removal and its `role`-claim prerequisite (U-12), and
+  the requirement for `Application.Read.All` consent (U-9). "Nil" was wrong; on Linux installs the WMI / registry / password-reset endpoints return a documented `503` (SC-4). Customer-facing release notes must call out this behavioural envelope.
 - **C-2 No bundled refactor.** Naming, folder layout, and DI cleanup do not ride along on this HLPS.
 - **C-3 Single host on Windows.** On Windows installs, the worker process ships and runs alongside the primary as a separate MSI component, bound to loopback only.
 - **C-4 Customer infrastructure.** Every DORC install requires an Entra ID tenant + app registration with Graph permissions. Document required permissions (U-9) and the AD-to-Entra migration path (U-10) before release.
@@ -227,13 +237,25 @@ release-only concern. Implementation of the remaining steps may continue. Note t
 reads CLAUDE.md's "blocking unknowns halt progress" as halting *the affected merge or the
 release*, not all work — an explicit deviation, recorded here rather than left implicit.
 
-- **U-10 (promoted from non-blocking in Round 4) — migration path for Cohort B.** Customers on
+- **U-10 — RESOLVED (Round 6). Owner: Ben Hegarty.** Decision: **hard break with published
+  prerequisites.** Customers with no Entra tenant cannot upgrade; an Entra tenant plus Entra
+  Connect (or Cloud Sync) populating `onPremisesSecurityIdentifier` is a documented upgrade
+  prerequisite. No back-compat shim. S-010 publishes the prerequisite; release notes must lead
+  with it. Original text retained below for the reasoning trail.
+
+  *(was)* Migration path for Cohort B. Customers on
   pure on-prem AD with no Entra tenant lose all ACL resolution at upgrade. This was filed as
   non-blocking with a default of "hard break, no shim, published prerequisites", but a default
   chosen by the authors is not a product decision, and by Round 3 the HLPS was APPROVED with a
   customer-breaking change resting on an unanswered question. **Owner: Product.** Required
   before release: confirm the hard break, or fund a back-compat shim.
-- **U-12 (new) — role-claim prerequisite.** S-007 deletes `ClaimsTransformer`, which was the only
+- **U-12 — RESOLVED (Round 6). Owner: Ben Hegarty.** Decision: **delete `ActiveDirectoryRoles`
+  and its WiX writes.** The config knob stops lying about being effective, and the Entra app
+  registration emitting a `role` claim becomes a documented prerequisite in S-010. Implemented
+  in S-007 (config + `RequestApi.wxs` writes) — note the WiX half depends on S-008 owning that
+  file, and on #808 which relocates it. Original text retained.
+
+  *(was)* Role-claim prerequisite. S-007 deletes `ClaimsTransformer`, which was the only
   reader of `AppSettings:ActiveDirectoryRoles`. `User.IsInRole("Admin")` / `("PowerUser")` remain
   load-bearing across `RefDataController`, `RefDataPermissionController`, `RefDataSqlPortsController`,
   `DeploymentsHub`, `RolePrivilegesChecker` and `SecurityObjectFilter`, and now resolve **solely**
@@ -242,7 +264,17 @@ release*, not all work — an explicit deviation, recorded here rather than left
   registration does not emit `role`. **Owner: architecture + docs.** Required before release:
   either the app-registration guidance makes `role` emission a documented prerequisite, or the
   dead config and its WiX writes are removed so the knob stops lying about being effective.
-- **U-16 (new) — worker provisioning ordering.** S-004 routes a live endpoint through the worker
+- **U-16 — RESOLVED (Round 6). Owner: Ben Hegarty.** Decision: **S-008 owns both** worker
+  provisioning *and* the `RequestApi.wxs` auth/roles migration. S-004 and S-007 stay in draft
+  until it lands. **Sequencing constraint discovered in Round 6: #808 relocates
+  `RequestApi.wxs` from `src/Setup.Dorc/Web/RequestApi/` to `src/Setup.Dorc.Api/` and carries
+  every line S-008 must change (IIS `Negotiate,NTLM`, the `ActiveDirectoryRoles` writes, and
+  the `AuthenticationScheme` write, each duplicated across dev and prod blocks). #808 must
+  merge first, or S-008 is written against a path that moves.** #808 also touches
+  `Setup.Acceptance`, which U-8 now makes responsible for installing the worker MSI — a second
+  dependency between the two work streams. Original text retained.
+
+  *(was)* Worker provisioning ordering. S-004 routes a live endpoint through the worker
   while `WindowsWorker:Enabled` ships `false` and nothing sets it `true`, because provisioning is
   S-008's job and S-008 has no PR. As sequenced, merging S-004 turns a working endpoint into a
   503 on every existing Windows install. **Owner: architecture.** Required before S-004 merges:
@@ -251,10 +283,13 @@ release*, not all work — an explicit deviation, recorded here rather than left
 
 ### Non-blocking (added in Round 4)
 
-- **U-13** Graph fault tolerance. Removing `CompositeActiveDirectorySearcher` means a Graph 429/503
+- **U-13 — RESOLVED (Round 6).** Decision: **fix in S-001.** Kiota's `RetryHandler` configured
+  for 429/503/504 with backoff, honouring Graph's `Retry-After`. *(was)* Graph fault tolerance. Removing `CompositeActiveDirectorySearcher` means a Graph 429/503
   is now a 500 rather than a degraded result, and no retry handler is configured on the Kiota
   adapter. Decide whether to configure Graph SDK retry/backoff or accept the change.
-- **U-14** Result-set truncation. `Search` reads one Graph page (100 users + 100 groups) with no
+- **U-14 — RESOLVED (Round 6).** Decision: **fix in S-001.** `Search` now requests `$top=999`
+  and drains `@odata.nextLink` for users, groups and service principals, capped at 10 pages.
+  *(was)* Result-set truncation. `Search` reads one Graph page (100 users + 100 groups) with no
   signal to the caller; the AD path returned up to ~1000. Pre-existing on the OAuth path, but
   S-001 makes it the only path, including for `DirectorySearchController`.
 - **U-15** Multi-domain tenants. `onPremisesSamAccountName` is unique per domain, not per tenant.
@@ -267,17 +302,26 @@ release*, not all work — an explicit deviation, recorded here rather than left
 
 ### Non-blocking (added in Round 5)
 
-- **U-18** Six `Dorc.Api` controllers still carry `[SupportedOSPlatform("windows")]`
+- **U-18 — PARTIALLY RESOLVED (Round 6).** `AccessControlController` and
+  `DirectorySearchController` had their attribute stripped in S-001: both were verified to have
+  no remaining Windows-only usage, so the annotation was purely stale and each was a live hole
+  in the SC-1 gate. The remaining four (`AccountController`, `BundledRequestsController`,
+  `MakeLikeProdController`, `ResetAppPasswordController`) clear at S-005/S-006 and remain on the
+  gate's allow-list, which must only shrink. *(was)* Six `Dorc.Api` controllers still carry `[SupportedOSPlatform("windows")]`
   (`AccessControlController`, `AccountController`, `BundledRequestsController`,
   `DirectorySearchController`, `MakeLikeProdController`, `ResetAppPasswordController`). CA1416
   does not fire inside an annotated type, so each is a hole in the SC-1 gate. Two of them are
   the AD-facing controllers S-001 was supposed to make Linux-clean and should no longer need
   the attribute at all. Decide per controller: strip the attribute, or move the code to the
   worker. The gate's suppression allow-list is the tracking list and must only shrink.
-- **U-19** Owner for [`parity-matrix.md`](parity-matrix.md). SC-9 makes it authoritative and
+- **U-19 — RESOLVED (Round 6). Owner: Ben Hegarty.** *(was)* Owner for [`parity-matrix.md`](parity-matrix.md). SC-9 makes it authoritative and
   `status: LIVING` claims upkeep, but the `owner` field points at a success criterion, which
   cannot be chased. Needs a named human.
-- **U-20** Two REST-surface changes contradict the Out-of-Scope line "changing the public
+- **U-20 — RESOLVED (Round 6).** Decision: **carve both out of Out of Scope** and correct the
+  Swagger annotation. `UserElementApiModel.SamAccountName` is load-bearing — without it logon
+  names resolve to nobody — and the 400 reshape carries the worker's actual error message.
+  Both are additive/nullable, so SC-5 (clients compile unchanged) still holds; release notes must
+  list them. *(was)* Two REST-surface changes contradict the Out-of-Scope line "changing the public
   Swagger/REST surface in shape": `UserElementApiModel.SamAccountName` added by S-001, and the
   `GetServerOperatingFromTarget` 400 body changed from string to object by S-004 while its
   `[SwaggerResponse(400, Type = typeof(string))]` annotation was left in place. Decide: carve
@@ -293,8 +337,17 @@ release*, not all work — an explicit deviation, recorded here rather than left
 - **U-5** Worker config: shared `appsettings.json` with the primary vs. its own. Affects secret-handling at install time.
 - **U-6** Worker URL discovery: config-file (likely) vs. service discovery.
 - **U-7** Contract-test strategy for the inter-API surface (consumer-driven vs. shared-DTO vs. OpenAPI-spec-driven). Recommendation pending in the IS step that wires the contract: shared-DTO via the existing `Dorc.ApiModel` pattern is the lowest-friction choice.
-- **U-8** `Setup.Acceptance` handling: install the worker MSI for the test environment, or stub the worker endpoints. Gates SC-6 (contract tests on a real worker vs. mock).
-- **U-9** Graph permission set required (delegated vs application; specific permission names). Affects customer setup guidance (C-4) and the IS step that does the Graph migration. **Recommendation pending architecture confirmation:** application-only permissions (`User.Read.All`, `Group.Read.All`, `GroupMember.Read.All`) with admin consent, since the worker runs as a service account and never acts on behalf of an end user.
+- **U-8 — RESOLVED (Round 6).** Decision: **install the worker MSI** in the acceptance
+  environment. This couples `Setup.Acceptance` to S-008 and a Windows host, so SC-6's contract
+  tests cannot be satisfied until S-008 lands — and #808 also modifies `Setup.Acceptance`.
+  *(was)* `Setup.Acceptance` handling: install the worker MSI for the test environment, or stub the worker endpoints. Gates SC-6 (contract tests on a real worker vs. mock).
+- **U-9 — RESOLVED (Round 6).** Decision: **application-only permissions with admin consent** —
+  `User.Read.All`, `Group.Read.All`, `GroupMember.Read.All`, **`Application.Read.All`**. The last
+  is new in Round 6: restoring M2M clients to the identity picker requires reading
+  `/servicePrincipals`. It is a broader consent than the original set and should be flagged in
+  the customer conversation. The service-principal query is implemented as non-fatal so a tenant
+  that has not consented degrades to "no machine clients" rather than losing user search.
+  *(was)* Graph permission set required (delegated vs application; specific permission names). Affects customer setup guidance (C-4) and the IS step that does the Graph migration. **Recommendation pending architecture confirmation:** application-only permissions (`User.Read.All`, `Group.Read.All`, `GroupMember.Read.All`) with admin consent, since the worker runs as a service account and never acts on behalf of an end user.
 - **U-10** *(promoted to Blocking in Round 4 — detail retained here.)* Migration path for existing customers from AD to Entra. **Owner: Product.** Two customer cohorts and two outcomes:
   - **Cohort A — has Entra tenant + Entra Connect populating `onPremisesSecurityIdentifier`.** Upgrade is transparent: P-4 / P-7 in the parity matrix resolve existing `AccessControl.Sid` rows via Entra. SC-10 covers this.
   - **Cohort B — pure on-prem AD, no Entra tenant.** Hard break. Existing ACLs cannot be resolved post-migration.

--- a/docs/api-split/HLPS-api-split.md
+++ b/docs/api-split/HLPS-api-split.md
@@ -265,6 +265,29 @@ release*, not all work — an explicit deviation, recorded here rather than left
   and the class, or re-register it. Note that re-registering does not restore the behaviour, since
   its AD branch resolves names that Graph cannot match.
 
+### Non-blocking (added in Round 5)
+
+- **U-18** Six `Dorc.Api` controllers still carry `[SupportedOSPlatform("windows")]`
+  (`AccessControlController`, `AccountController`, `BundledRequestsController`,
+  `DirectorySearchController`, `MakeLikeProdController`, `ResetAppPasswordController`). CA1416
+  does not fire inside an annotated type, so each is a hole in the SC-1 gate. Two of them are
+  the AD-facing controllers S-001 was supposed to make Linux-clean and should no longer need
+  the attribute at all. Decide per controller: strip the attribute, or move the code to the
+  worker. The gate's suppression allow-list is the tracking list and must only shrink.
+- **U-19** Owner for [`parity-matrix.md`](parity-matrix.md). SC-9 makes it authoritative and
+  `status: LIVING` claims upkeep, but the `owner` field points at a success criterion, which
+  cannot be chased. Needs a named human.
+- **U-20** Two REST-surface changes contradict the Out-of-Scope line "changing the public
+  Swagger/REST surface in shape": `UserElementApiModel.SamAccountName` added by S-001, and the
+  `GetServerOperatingFromTarget` 400 body changed from string to object by S-004 while its
+  `[SwaggerResponse(400, Type = typeof(string))]` annotation was left in place. Decide: carve
+  both out of Out of Scope, or revert them. The annotation must be corrected either way.
+- **U-21** D-3 and SC-2 both state the worker "rejects any request without `X-Worker-Key`";
+  `/health` is deliberately unauthenticated. Amend the wording and record the threat-model
+  justification. The implementation also ships *both* U-11 options (`WindowsWorker:Enabled`
+  **and** a health probe) while U-11 still reads "recommendation pending" — close U-11 with
+  what actually shipped.
+
 ### Non-blocking (from Rounds 1-3; resolved during IS; some require named owner)
 - **U-4** Naming of the new project: `Dorc.Api.Windows` vs. `Dorc.Api.WindowsWorker`. Prefer the latter for specificity (per CLAUDE.md naming principle); confirm in the IS step that creates the project.
 - **U-5** Worker config: shared `appsettings.json` with the primary vs. its own. Affects secret-handling at install time.

--- a/docs/api-split/parity-matrix.md
+++ b/docs/api-split/parity-matrix.md
@@ -23,6 +23,15 @@ once their step merges, which is precisely why SC-9 asked for a standalone file.
 - A row is not ✅ until its test exists **and** fails when the behaviour is removed. Mutation
   results are recorded in the Evidence column where they have been run.
 
+## Maintenance
+
+`status: LIVING` is a claim about upkeep, so state the upkeep rather than implying it:
+
+- **Trigger.** Any PR modifying `Dorc.Core/AzureEntraSearcher.cs`, `Dorc.Core/Interfaces/IActiveDirectorySearcher.cs`, or `Dorc.Core.Tests/Graph/` must update this file *in the same PR*.
+- **Owner.** Unassigned — this needs a named human, not a pointer at a success criterion. Tracked as U-19.
+- **Re-verification.** `last_verified` is refreshed only when the mutation results below are re-run, not when the file is merely edited.
+- **Evidence location.** The tests cited below live on `claude/423-4-graph-migration` and downstream, **not** on the branch carrying this file or on `main`. A row may not be considered settled until its test is on `main`.
+
 ## Matrix
 
 | # | Behaviour | Graph strategy | Status | Evidence |
@@ -30,13 +39,13 @@ once their step merges, which is precisely why SC-9 asked for a standalone file.
 | P-1 | User search by name | `/users?$filter=accountEnabled eq true and (startsWith(displayName,…) or startsWith(givenName,…) or startsWith(onPremisesSamAccountName,…) or startsWith(surname,…) or startsWith(mail,…) or startsWith(userPrincipalName,…))` | ✅ | `P1_Search_FindsUserByDisplayName` + `P1_Search_EmitsEnabledOnlyFilterAcrossExpectedProperties` (asserts `$filter`). Mutation: replacing the filter fails the suite. |
 | P-2 | Group search by name | `/groups?$filter=startsWith(displayName,…) or startsWith(mailNickname,…) or startsWith(onPremisesSamAccountName,…)` | ✅ | `P2_Search_FindsGroupByDisplayName` + `P2_Search_EmitsGroupFilterAcrossExpectedProperties` (asserts `$filter`). |
 | P-3 | Resolve identity by Entra object id | `/users/{id}` then `/groups/{id}` | ✅ | `P3_GetUserDataById_ResolvesByEntraId`. |
-| P-4 | Resolve identity by legacy AD SID | `/users?$filter=onPremisesSecurityIdentifier eq '<sid>'`, then groups | ✅ | `P4_GetUserDataById_ResolvesByAdSidViaOnPremisesFilter`, `P4_…_ResolvesGroupByAdSidWhenUserMisses`. Filter matching is now parsed from `$filter` specifically — matching the whole query string was unsound because `$select` contains the same property name. |
-| P-5 | Resolve user by sAMAccountName (incl. `DOMAIN\name`, `(External)`) | `/users?$filter=accountEnabled eq true and (onPremisesSamAccountName eq '<name>' or userPrincipalName eq '<name>')`, `$top=2` | ✅ | `P5_…_ResolvesUserBySamAccountName`, `P5_…_StripsDomainPrefix`, `P5_…_NoUserMatch_ReturnsEmptyString`, `GetGroupSidIfUserIsMemberRecursive_AmbiguousName_RefusesToGuess`. |
+| P-4 | Resolve identity by legacy AD SID | `/users?$filter=onPremisesSecurityIdentifier eq '<sid>'`, then groups (direct `/users/{sid}` is **skipped** — Graph answers 400, not 404, for a SID-shaped segment) | ✅ | `P4_…_ResolvesByAdSidViaOnPremisesFilter`, `P4_…_ResolvesGroupByAdSidWhenUserMisses`, plus `P4_…_SendsTheCallersSidInTheFilter` / `…InTheGroupFilter`. **Mutation: hardcoding a wrong SID into the filter fails 2 tests.** It passed 164/164 before those two assertions existed — routing on the property *name* is not evidence the *value* is sent. |
+| P-5 | Resolve user by sAMAccountName (incl. `DOMAIN\name`, `(External)`) | `/users?$filter=accountEnabled eq true and (onPremisesSamAccountName eq '<name>' or userPrincipalName eq '<name>')`, `$top=2` | ✅ | `P5_…_ResolvesUserBySamAccountName`, `…_StripsDomainPrefix`, `…_NoUserMatch_ReturnsEmptyString`, `…_AmbiguousName_RefusesToGuess`, plus `P5_ResolveUserIdFromName_ExcludesDisabledAndRequestsTwoMatches`. **Mutation: removing `accountEnabled eq true` fails 1 test.** It passed 164/164 before — a disabled leaver would have resolved and received group claims on the authorization path. |
 | P-6 | Recursive group membership | `/users/{id}/checkMemberGroups` | ✅ | `P6_…_NonMember_ReturnsEmptyString` — the **negative** case is the load-bearing one here. Previously untested: a mutation making the method ignore the `checkMemberGroups` result and always return the group id passed the entire suite (an authorization bypass). |
 | P-7 | All group ids + SIDs for a user | `/users/{id}/transitiveMemberOf/microsoft.graph.group?$select=id,onPremisesSecurityIdentifier&$top=999`, draining `@odata.nextLink` | ✅ | `P7_GetSidsForUser_EmitsBothPidAndSid`, `GetSidsForUser_DrainsAllPagesOfTransitiveMemberOf`, `GetSidsForUser_ResolvesBareSamAccountNameBeforeAddressingGraph`. The `$select` is asserted directly — the fake does not honour `$select`, so a response-only test cannot catch its removal. |
 | P-8 | Disabled account detection | `accountEnabled` | ✅ | `P8_GetUserDataById_DisabledUserButGroupHit_ReturnsGroup`, `P8_…_DisabledUserNoGroup_Throws`. |
 | P-9 | Display name + email | `displayName` / `mail` / `userPrincipalName` fallback | ✅ | `P9_GetUserData_PopulatesDisplayNameAndEmail`, `P9_GetUserData_FallsBackToUpnWhenMailUnset`. Previously claimed covered with **no test calling `GetUserData` at all**. |
-| SC-10 | Legacy `AccessControl.Sid` rows resolve post-migration | `onPremisesSecurityIdentifier` filter | ✅ | `SC10_AccessControlSidRow_ResolvesViaOnPremisesIdentifier`. See caveat below. |
+| SC-10 | Legacy `AccessControl.Sid` rows resolve post-migration | `onPremisesSecurityIdentifier` filter | ✅ | `SC10_AccessControlSidRow_ResolvesViaOnPremisesIdentifier` + the P-4 value assertions (same helpers). Covers **synced principals only** — see the cloud-only caveat below, which contradicts U-10's "upgrade is transparent" for hybrid tenants. |
 
 ## Explicitly out of parity
 

--- a/docs/api-split/parity-matrix.md
+++ b/docs/api-split/parity-matrix.md
@@ -1,0 +1,62 @@
+---
+status: LIVING
+issue: sefe/dorc#423
+owner: HLPS-api-split.md SC-9
+codebase_anchor: aebd286 (main, 2026-08-10)
+last_verified: 2026-08-17
+---
+
+# AD → Microsoft Graph parity matrix
+
+The living artefact SC-9 requires. It was previously embedded in `HLPS-api-split.md` §4 and
+duplicated in `SPEC-S-001-graph-migration.md`; both are point-in-time documents that go stale
+once their step merges, which is precisely why SC-9 asked for a standalone file.
+
+**Rules of use**
+
+- Every row must have at least one **integration-level** test driving the Graph payload through
+  the real Kiota deserialization path (the `MockHttpHandler` harness in
+  `Dorc.Core.Tests/Graph/`). Mocks at the `IActiveDirectorySearcher` boundary do **not** satisfy
+  SC-9 — they prove nothing about the request or the payload shape.
+- A test that only asserts the *response* is insufficient for rows whose risk is a wrong query.
+  Those rows must assert the emitted `$filter` / `$select`. This is recorded per row below.
+- A row is not ✅ until its test exists **and** fails when the behaviour is removed. Mutation
+  results are recorded in the Evidence column where they have been run.
+
+## Matrix
+
+| # | Behaviour | Graph strategy | Status | Evidence |
+|---|---|---|---|---|
+| P-1 | User search by name | `/users?$filter=accountEnabled eq true and (startsWith(displayName,…) or startsWith(givenName,…) or startsWith(onPremisesSamAccountName,…) or startsWith(surname,…) or startsWith(mail,…) or startsWith(userPrincipalName,…))` | ✅ | `P1_Search_FindsUserByDisplayName` + `P1_Search_EmitsEnabledOnlyFilterAcrossExpectedProperties` (asserts `$filter`). Mutation: replacing the filter fails the suite. |
+| P-2 | Group search by name | `/groups?$filter=startsWith(displayName,…) or startsWith(mailNickname,…) or startsWith(onPremisesSamAccountName,…)` | ✅ | `P2_Search_FindsGroupByDisplayName` + `P2_Search_EmitsGroupFilterAcrossExpectedProperties` (asserts `$filter`). |
+| P-3 | Resolve identity by Entra object id | `/users/{id}` then `/groups/{id}` | ✅ | `P3_GetUserDataById_ResolvesByEntraId`. |
+| P-4 | Resolve identity by legacy AD SID | `/users?$filter=onPremisesSecurityIdentifier eq '<sid>'`, then groups | ✅ | `P4_GetUserDataById_ResolvesByAdSidViaOnPremisesFilter`, `P4_…_ResolvesGroupByAdSidWhenUserMisses`. Filter matching is now parsed from `$filter` specifically — matching the whole query string was unsound because `$select` contains the same property name. |
+| P-5 | Resolve user by sAMAccountName (incl. `DOMAIN\name`, `(External)`) | `/users?$filter=accountEnabled eq true and (onPremisesSamAccountName eq '<name>' or userPrincipalName eq '<name>')`, `$top=2` | ✅ | `P5_…_ResolvesUserBySamAccountName`, `P5_…_StripsDomainPrefix`, `P5_…_NoUserMatch_ReturnsEmptyString`, `GetGroupSidIfUserIsMemberRecursive_AmbiguousName_RefusesToGuess`. |
+| P-6 | Recursive group membership | `/users/{id}/checkMemberGroups` | ✅ | `P6_…_NonMember_ReturnsEmptyString` — the **negative** case is the load-bearing one here. Previously untested: a mutation making the method ignore the `checkMemberGroups` result and always return the group id passed the entire suite (an authorization bypass). |
+| P-7 | All group ids + SIDs for a user | `/users/{id}/transitiveMemberOf/microsoft.graph.group?$select=id,onPremisesSecurityIdentifier&$top=999`, draining `@odata.nextLink` | ✅ | `P7_GetSidsForUser_EmitsBothPidAndSid`, `GetSidsForUser_DrainsAllPagesOfTransitiveMemberOf`, `GetSidsForUser_ResolvesBareSamAccountNameBeforeAddressingGraph`. The `$select` is asserted directly — the fake does not honour `$select`, so a response-only test cannot catch its removal. |
+| P-8 | Disabled account detection | `accountEnabled` | ✅ | `P8_GetUserDataById_DisabledUserButGroupHit_ReturnsGroup`, `P8_…_DisabledUserNoGroup_Throws`. |
+| P-9 | Display name + email | `displayName` / `mail` / `userPrincipalName` fallback | ✅ | `P9_GetUserData_PopulatesDisplayNameAndEmail`, `P9_GetUserData_FallsBackToUpnWhenMailUnset`. Previously claimed covered with **no test calling `GetUserData` at all**. |
+| SC-10 | Legacy `AccessControl.Sid` rows resolve post-migration | `onPremisesSecurityIdentifier` filter | ✅ | `SC10_AccessControlSidRow_ResolvesViaOnPremisesIdentifier`. See caveat below. |
+
+## Explicitly out of parity
+
+- Local-machine SIDs — not meaningfully used by DORC.
+- Foreign Security Principals (cross-forest trusts) — no consumer identified.
+- Well-known SIDs (`BUILTIN\Administrators` etc.) — DORC's RBAC uses domain groups.
+- **IdentityServer / M2M client principals in the identity picker.** Deleting
+  `IdentityServerSearcher` removed the only searcher that returned IdentityServer clients from
+  `AccessControlController.SearchUsers`. Existing M2M grants keep working (`GetSidsForUser`
+  short-circuits for M2M), but new grants cannot be made through the UI. Added in Round 4 — this
+  was an undocumented consequence of S-001, not a decision.
+
+## Known gaps not covered by any row
+
+These are real behavioural differences from the AD implementation. They are recorded here rather
+than silently omitted, and are tracked in the HLPS Unknowns Register.
+
+| Gap | Difference | Tracking |
+|---|---|---|
+| Result-set truncation | `DirectorySearcher.FindAll()` returned up to the server limit (~1000). `Search` reads a single Graph page (100 users + 100 groups) with no truncation signal to the caller. | U-14 |
+| Fault tolerance | `CompositeActiveDirectorySearcher` caught per-searcher failures and returned partial results. With one searcher, a Graph 429/503 surfaces as a 500. No retry policy is configured on the Kiota adapter. | U-13 |
+| Tenant-wide name resolution | `onPremisesSamAccountName` is unique per *domain*, not per *tenant*. In a multi-domain tenant the same name can resolve to more than one principal. Current behaviour: refuse and return empty (fail closed) rather than bind to an arbitrary identity. | U-15 |
+| Cloud-only accounts | Any row depending on `onPremisesSecurityIdentifier` (P-4, P-7, SC-10) yields nothing for accounts that never existed on-prem. Correct, but means SC-10 covers Cohort A only. | U-10 |

--- a/docs/api-split/research/ARCHITECTURE_API_SPLIT.md
+++ b/docs/api-split/research/ARCHITECTURE_API_SPLIT.md
@@ -1,0 +1,214 @@
+# API Split Implementation Summary
+
+## Overview
+Split Dorc.Api into two separate APIs to enable Linux compatibility:
+- **Dorc.Api**: Cross-platform API (runs on Linux and Windows)
+- **Dorc.Api.Windows**: Windows-specific API (requires Windows OS)
+
+## Changes Made
+
+### 1. Created Dorc.Api.Windows Project
+**Location**: `src/Dorc.Api.Windows/`
+
+**Structure**:
+```
+Dorc.Api.Windows/
+├── Controllers/          # 6 Windows-specific controllers
+│   ├── DirectorySearchController.cs
+│   ├── ResetAppPasswordController.cs
+│   ├── AccessControlController.cs
+│   ├── AccountController.cs
+│   ├── BundledRequestsController.cs
+│   └── MakeLikeProdController.cs
+├── Security/             # Windows authentication components
+│   ├── WinAuthClaimsPrincipalReader.cs
+│   └── WinAuthLoggingMiddleware.cs
+├── Services/             # Windows-specific services
+│   ├── ApiRegistry.cs
+│   ├── DirectorySearcherFactory.cs
+│   ├── ClaimsTransformer.cs
+│   ├── CachedUserGroupReader.cs
+│   ├── UserGroupReaderFactory.cs
+│   └── [other supporting services]
+├── Interfaces/           # Service interfaces
+├── Model/                # API models
+├── Program.cs            # Windows-only API bootstrapping
+├── appsettings.json      # Configuration
+└── README.md             # Documentation
+```
+
+**Project File**: `Dorc.Api.Windows.csproj`
+- Target: `net8.0-windows`
+- References: Dorc.Core, Dorc.OpenSearchData
+- NuGet packages for Windows Authentication, Entity Framework, Swagger
+
+### 2. Modified Dorc.Api for Cross-Platform Support
+
+**Dorc.Api/Dorc.Api.csproj**:
+- Added conditional compilation symbol `WINDOWS` when building on Windows
+- Added `<Compile Remove>` directives to exclude Windows-specific files on Linux
+
+**Dorc.Api/Program.cs**:
+- Wrapped Windows-specific code in `#if WINDOWS` blocks:
+  - `ConfigureWinAuth()` method
+  - `ConfigureBoth()` method  
+  - `WinAuthLoggingMiddleware` usage
+  - `ApiRegistry` registration
+- Changed default authentication to OAuth on non-Windows platforms
+
+**Dorc.Api/appsettings.json**:
+- Added `WindowsApiUrl` configuration: `"https://localhost:5002"`
+
+### 3. Created WindowsApiClient for Remote Calls
+
+**Dorc.Api/Interfaces/IWindowsApiClient.cs**:
+- Interface for calling Windows API endpoints from Linux
+
+**Dorc.Api/Services/WindowsApiClient.cs**:
+- HTTP client implementation
+- Maps to all 6 Windows-specific controllers
+- Registered in DI only on non-Windows platforms (`#if !WINDOWS`)
+
+### 4. Updated Configuration System
+
+**Dorc.Core/Configuration/IConfigurationSettings.cs**:
+- Added `GetWindowsApiUrl()` method
+
+**Dorc.Core/Configuration/ConfigurationSettings.cs**:
+- Implemented `GetWindowsApiUrl()` returning `AppSettings:WindowsApiUrl`
+- Default value: `https://localhost:5002`
+
+### 5. Solution Updates
+
+**src/Dorc.sln**:
+- Added Dorc.Api.Windows project to solution
+
+## Architecture
+
+### On Linux
+```
+[Dorc.Api on Linux:5000]
+         |
+         | HTTP calls via WindowsApiClient
+         |
+         v
+[Dorc.Api.Windows on Windows Server:5002]
+         |
+         v
+    Active Directory
+    Windows Services
+```
+
+### On Windows
+Two deployment options:
+
+**Option 1**: Run both APIs (recommended)
+```
+[Dorc.Api on Windows:5000]  +  [Dorc.Api.Windows on Windows:5002]
+         |                              |
+         +------------------------------+
+                      |
+                      v
+                Active Directory
+                Windows Services
+```
+
+**Option 2**: Run main API with Windows features (legacy)
+```
+[Dorc.Api on Windows:5000]
+    (includes Windows controllers via conditional compilation)
+         |
+         v
+    Active Directory
+    Windows Services
+```
+
+## Configuration Requirements
+
+### Main API (Dorc.Api) on Linux
+```json
+{
+  "AppSettings": {
+    "WindowsApiUrl": "https://windows-server:5002",
+    "AuthenticationScheme": "OAuth"
+  }
+}
+```
+
+### Windows API (Dorc.Api.Windows)
+```json
+{
+  "AppSettings": {
+    "DomainName": "your-domain.com",
+    "DomainNameIntra": "INTRA",
+    "ADUserCacheTimeMinutes": "30"
+  },
+  "ConnectionStrings": {
+    "DOrcConnectionString": "Server=...;Database=DOrc;..."
+  }
+}
+```
+
+## Windows-Specific Controllers
+
+1. **DirectorySearchController**: Search AD users/groups
+2. **AccountController**: Check user/group existence in AD
+3. **ResetAppPasswordController**: Reset app passwords via Windows APIs
+4. **AccessControlController**: Manage AD-based access control
+5. **BundledRequestsController**: Handle bundled deployment requests
+6. **MakeLikeProdController**: Environment cloning operations
+
+## Testing
+
+### Dorc.Api (Main API)
+- ✅ Builds successfully on Linux
+- ✅ Excludes Windows-specific controllers on Linux
+- ✅ Includes WindowsApiClient on Linux for remote calls
+- ✅ Conditional compilation directives work correctly
+
+### Dorc.Api.Windows
+- ⚠️  Can only be built and tested on Windows OS
+- Requires Windows platform for:
+  - System.DirectoryServices
+  - Windows Authentication
+  - Active Directory access
+
+## Deployment
+
+### Development
+```bash
+# Main API (Linux or Windows)
+cd src/Dorc.Api
+dotnet run --urls "https://localhost:5000"
+
+# Windows API (Windows only)
+cd src/Dorc.Api.Windows
+dotnet run --urls "https://localhost:5002"
+```
+
+### Production
+
+**Linux Server** (Main API):
+- Deploy Dorc.Api
+- Configure WindowsApiUrl to point to Windows server
+
+**Windows Server** (Windows API):
+- Deploy Dorc.Api.Windows
+- Ensure access to Active Directory
+- Configure firewall for API port
+
+## Benefits
+
+1. **Linux Compatibility**: Main API can run on Linux
+2. **Minimal Changes**: Surgical modifications to existing code
+3. **Backward Compatible**: Can still run everything on Windows
+4. **Clear Separation**: Windows-specific code isolated
+5. **Type-Safe Client**: WindowsApiClient provides typed interface
+
+## Standards Compliance
+
+Follows .NET coding standards:
+- No "Manager", "Helper", "Service" in new type names (interfaces use existing names)
+- Descriptive namespaces: `Dorc.Api.Windows`
+- .NET 8.0 LTS for new Windows API
+- Proper separation of concerns

--- a/docs/api-split/research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md
+++ b/docs/api-split/research/DEPLOYMENT_DEPENDENCY_ANALYSIS.md
@@ -1,0 +1,177 @@
+# Deployment Folder Dependency Analysis
+
+## Summary
+
+Analysis of the 6 files in `Dorc.Api.Windows/Deployment/` to determine if they have hidden Windows dependencies and whether they can be moved to the main Dorc.Api.
+
+## Files Analyzed
+
+1. **EnvironmentMapper.cs** - Maps environment configurations
+2. **FileSystemHelper.cs** - File system operations
+3. **ManageUsers.cs** - User management operations
+4. **PropertiesService.cs** - Property management
+5. **PropertyValuesService.cs** - Property value management
+6. **RequestService.cs** - Request orchestration
+
+## Dependency Analysis
+
+### Direct Windows Dependencies
+
+**Result:** ✅ **NONE FOUND**
+
+All 6 files have:
+- ❌ No `System.DirectoryServices` imports
+- ❌ No `WindowsIdentity` or Windows authentication
+- ❌ No `Microsoft.Win32` (Registry)
+- ❌ No `System.Management` (WMI)
+- ❌ No `[SupportedOSPlatform("windows")]` attributes
+
+### Indirect Dependencies (Used By)
+
+**EnvironmentMapper (IEnvironmentMapper):**
+- Used by: ❓ Not used by any Windows-specific controllers or orchestrators in current PR files
+- Recommendation: ⚠️ **CONDITIONAL** - Check if used by main Dorc.Api
+
+**FileSystemHelper (IFileSystemHelper):**
+- Used by: 
+  - ✅ `Build/DeployableBuildFactory.cs` (moving to Dorc.Api)
+  - ✅ `Build/FileShareDeployableBuild.cs` (moving to Dorc.Api)
+- Recommendation: ✅ **MOVE** - Required by Build files
+
+**ManageUsers (IManageUsers):**
+- Used by: 
+  - ❌ `Orchestration/EnvironmentOrchestrator.cs` (Windows-specific orchestrator)
+- Recommendation: ❌ **KEEP** - Used by Windows API orchestration
+
+**PropertiesService (IPropertiesService):**
+- Used by: ❓ Not directly used in PR files
+- Recommendation: ⚠️ **CONDITIONAL** - Likely used by Windows controllers via DI
+
+**PropertyValuesService (IPropertyValuesService):**
+- Used by: ❓ Not directly used in PR files  
+- Recommendation: ⚠️ **CONDITIONAL** - Likely used by Windows controllers via DI
+
+**RequestService (IRequestService):**
+- Used by: ❓ Not directly used in PR files
+- Recommendation: ⚠️ **CONDITIONAL** - Likely used by Windows controllers via DI
+
+### Dependencies on Other Deployment Files
+
+**FileSystemHelper** - No dependencies on other Deployment files
+**ManageUsers** - No dependencies on other Deployment files
+**EnvironmentMapper** - No dependencies on other Deployment files
+**PropertiesService** - No dependencies on other Deployment files
+**PropertyValuesService** - May depend on PropertiesService (need to check implementation)
+**RequestService** - May depend on other services (need to check implementation)
+
+## Hidden Windows Dependencies - NONE FOUND ✅
+
+**Conclusion:** All Deployment files are **technically cross-platform** (no direct Windows API usage).
+
+However, they are **architecturally Windows-specific** because they:
+1. Support Windows-only controllers (BundledRequests, MakeLikeProd, etc.)
+2. Are registered in WindowsDependencyRegistry
+3. Part of Windows API business logic
+
+## Recommendations
+
+### ✅ MUST Move (1 file) - Required by Build files
+
+**FileSystemHelper.cs + IFileSystemHelper.cs**
+- **Reason:** Required by Build files that are moving to Dorc.Api
+- **Windows Dependencies:** None
+- **Impact:** Low risk, enables Build files to function
+- **Action:** Move to `Dorc.Api/Deployment/` along with interface
+
+### ❌ SHOULD Stay (5 files) - Windows API architecture
+
+**ManageUsers.cs + IManageUsers.cs**
+- **Reason:** Used by EnvironmentOrchestrator (Windows-specific)
+- **Used by:** Windows API orchestration layer
+- **Action:** Keep in Dorc.Api.Windows
+
+**PropertiesService.cs + IPropertiesService.cs**
+- **Reason:** Likely used by Windows controllers
+- **Registered in:** WindowsDependencyRegistry
+- **Action:** Keep in Dorc.Api.Windows
+
+**PropertyValuesService.cs + IPropertyValuesService.cs**
+- **Reason:** Likely used by Windows controllers
+- **Registered in:** WindowsDependencyRegistry
+- **Action:** Keep in Dorc.Api.Windows
+
+**RequestService.cs + IRequestService.cs**
+- **Reason:** Request orchestration for Windows API
+- **Registered in:** WindowsDependencyRegistry
+- **Action:** Keep in Dorc.Api.Windows
+
+**EnvironmentMapper.cs + IEnvironmentMapper.cs**
+- **Reason:** Environment configuration mapping
+- **Registered in:** WindowsDependencyRegistry
+- **Action:** Keep in Dorc.Api.Windows
+
+## Implementation Plan
+
+### Phase 1: Move Build Files + FileSystemHelper (Required)
+
+1. Move `Build/DeployableBuildFactory.cs` to `Dorc.Api/Build/`
+2. Move `Build/AzureDevOpsDeployableBuild.cs` to `Dorc.Api/Build/`
+3. Move `Build/FileShareDeployableBuild.cs` to `Dorc.Api/Build/`
+4. Move `Deployment/FileSystemHelper.cs` to `Dorc.Api/Deployment/`
+5. Move `Interfaces/IFileSystemHelper.cs` to `Dorc.Api/Interfaces/`
+6. Move `Interfaces/IDeployableBuildFactory.cs` to `Dorc.Api/Interfaces/`
+7. Move `Interfaces/IDeployableBuild.cs` to `Dorc.Api/Interfaces/`
+8. Move `Interfaces/IBuildInterface.cs` to `Dorc.Api/Interfaces/`
+9. Update namespaces from `Dorc.Api.Windows.*` to `Dorc.Api.*`
+10. Update Dorc.Api dependency injection to register these services
+
+**Files moving: 8 total**
+- 3 Build implementation files
+- 1 Deployment file (FileSystemHelper)
+- 4 Interface files
+
+### Phase 2: Update Remaining Files (Optional - Future Work)
+
+The other 5 Deployment files **can technically be moved** but:
+- They're used exclusively by Windows API
+- Moving them would require extensive refactoring
+- Current architecture is cleaner with them in Windows API
+
+**Recommendation:** Keep them in Dorc.Api.Windows unless the main API needs them.
+
+## Validation Checklist
+
+After moving files:
+
+- [ ] Update namespace references in all moved files
+- [ ] Update `using` statements to remove `Dorc.Api.Windows` references
+- [ ] Register services in Dorc.Api dependency injection
+- [ ] Remove services from WindowsDependencyRegistry in Windows API
+- [ ] Build Dorc.Api successfully
+- [ ] Build Dorc.Api.Windows successfully (verify it still works without moved files)
+- [ ] Update .csproj file references if needed
+- [ ] Run tests
+
+## Impact Assessment
+
+**Low Risk:**
+- FileSystemHelper has no Windows dependencies
+- Build files are self-contained
+- Clear separation of concerns
+
+**Medium Risk:**
+- May need to add Dorc.PersistentData reference to Dorc.Api if not already present
+- Need to ensure all transitive dependencies are available
+
+**High Risk:**
+- None identified
+
+## Conclusion
+
+**Hidden Windows Dependencies Found:** ✅ **NONE**
+
+All Deployment files are cross-platform compatible at the code level. However:
+- **FileSystemHelper** must move (required by Build files)
+- **Other 5 files** should stay (Windows API business logic)
+
+This maintains clean architectural separation while enabling Build file movement.

--- a/docs/api-split/research/FILES_TO_MOVE_ANALYSIS.md
+++ b/docs/api-split/research/FILES_TO_MOVE_ANALYSIS.md
@@ -1,0 +1,256 @@
+# Analysis: Files That Can Be Moved from Dorc.Api.Windows to Dorc.Api
+
+This document analyzes the current files in `Dorc.Api.Windows` to determine which ones can be moved back to the main `Dorc.Api` project.
+
+## Summary
+
+**Files that MUST stay in Dorc.Api.Windows**: 14 files (Windows-specific APIs)  
+**Files that CAN be moved to Dorc.Api**: 35 files (cross-platform compatible)
+
+---
+
+## Files That MUST Stay in Dorc.Api.Windows (Windows-Only)
+
+These files contain Windows-specific APIs and must remain in the Windows API:
+
+### Controllers (6 files) - All marked with [SupportedOSPlatform("windows")]
+1. ✅ **Controllers/DirectorySearchController.cs** - Uses System.DirectoryServices for Active Directory
+2. ✅ **Controllers/AccountController.cs** - AD account validation
+3. ✅ **Controllers/AccessControlController.cs** - AD group management
+4. ✅ **Controllers/ResetAppPasswordController.cs** - Windows impersonation + Registry
+5. ✅ **Controllers/BundledRequestsController.cs** - Marked as Windows-only
+6. ✅ **Controllers/MakeLikeProdController.cs** - Environment cloning with Windows dependencies
+
+### Identity (4 files) - Active Directory and Windows Authentication
+7. ✅ **Identity/DirectorySearchProvider.cs** - Creates ActiveDirectorySearcher (System.DirectoryServices)
+8. ✅ **Identity/ClaimsTransformer.cs** - WindowsIdentity transformation
+9. ✅ **Identity/CachedUserGroupReader.cs** - Uses IActiveDirectorySearcher
+10. ✅ **Identity/UserGroupProvider.cs** - Uses DirectorySearchProvider
+
+### Security (2 files) - Windows Authentication
+11. ✅ **Security/WinAuthClaimsPrincipalReader.cs** - Windows claims
+12. ✅ **Security/WinAuthLoggingMiddleware.cs** - Windows auth middleware
+
+### Configuration (1 file)
+13. ✅ **Configuration/WindowsDependencyRegistry.cs** - Registers Windows-specific services
+
+### Program (1 file)
+14. ✅ **Program.cs** - Windows API entry point with Windows auth configuration
+
+**Total: 14 files must stay**
+
+---
+
+## Files That CAN Be Moved to Dorc.Api (Cross-Platform)
+
+These files have NO Windows-specific dependencies and could be moved to the main API:
+
+### Build (3 files) - ✅ Cross-platform build handling
+1. **Build/DeployableBuildFactory.cs** - Creates build instances, no Windows APIs
+2. **Build/AzureDevOpsDeployableBuild.cs** - Azure DevOps integration, cross-platform
+3. **Build/FileShareDeployableBuild.cs** - File share builds, works on Linux
+
+**Recommendation**: ✅ **MOVE to Dorc.Api/Build/**
+- These handle build artifact retrieval from Azure DevOps and file shares
+- No Windows-specific APIs used
+- Can work on Linux with proper file share access
+
+### Deployment (6 files) - ⚠️ Mixed (some should move, some stay)
+4. **Deployment/PropertiesService.cs** - Property management, cross-platform
+5. **Deployment/PropertyValuesService.cs** - Property values, cross-platform
+6. **Deployment/RequestService.cs** - Request orchestration, cross-platform
+7. **Deployment/EnvironmentMapper.cs** - Environment mapping, cross-platform
+8. **Deployment/FileSystemHelper.cs** - File system operations, cross-platform
+9. **Deployment/ManageUsers.cs** - User management logic, cross-platform
+
+**Recommendation**: ⚠️ **REVIEW DEPENDENCIES FIRST**
+- These appear cross-platform but may depend on Windows-only controllers
+- If they're only used by Windows controllers, keep them in Dorc.Api.Windows
+- If they're general-purpose, move to Dorc.Api/Deployment/
+
+### Orchestration (3 files) - ⚠️ Depends on usage
+10. **Orchestration/EnvironmentOrchestrator.cs** - Environment operations
+11. **Orchestration/ProjectComponentOrchestrator.cs** - Project/component operations
+12. **Orchestration/ServiceStatusOrchestrator.cs** - Windows service status
+
+**Recommendation**: ❌ **KEEP in Dorc.Api.Windows**
+- Created specifically to replace the generic APIServices
+- Used by Windows-specific controllers
+- Orchestrator pattern is specific to this API's architecture
+
+### Model (5 files) - ✅ DTOs are cross-platform
+13. **Model/BuildDetails.cs** - Build information DTO
+14. **Model/DeployRequest.cs** - Deployment request model
+15. **Model/MakeLikeProdRequest.cs** - Environment cloning request
+16. **Model/MakeLikeProdResponse.cs** - Environment cloning response
+17. **Model/AccountGranularity.cs** - Enum for account types
+
+**Recommendation**: ⚠️ **KEEP unless also used in Dorc.Api**
+- Models should be in the API that uses them
+- If both APIs use them, move to shared ApiModel project
+- Current usage is Windows-specific controllers only
+
+### Interfaces (13 files) - ✅ Interfaces are cross-platform
+18. **Interfaces/IBuildInterface.cs**
+19. **Interfaces/IDeployableBuild.cs**
+20. **Interfaces/IPropertiesService.cs**
+21. **Interfaces/IPropertyValuesService.cs**
+22. **Interfaces/IRequestService.cs**
+23. **Interfaces/IEnvironmentMapper.cs**
+24. **Interfaces/IFileSystemHelper.cs**
+25. **Interfaces/IManageUsers.cs**
+26. **Interfaces/IUserGroupReader.cs**
+27. **Interfaces/IUserGroupProvider.cs**
+28. **Interfaces/IDirectorySearchProvider.cs**
+29. **Interfaces/IAuditingManager.cs**
+30. **Interfaces/IRequestService.cs** (duplicate?)
+
+**Recommendation**: ❌ **KEEP in Dorc.Api.Windows**
+- Interfaces should be in the same project as their implementations
+- These define contracts for Windows-specific functionality
+
+### Exceptions (2 files) - ✅ Cross-platform
+31. **Exceptions/NonEnoughRightsException.cs** - Custom exception
+32. **Exceptions/WrongBuildTypeException.cs** - Custom exception
+
+**Recommendation**: ⚠️ **KEEP unless shared**
+- Exceptions should be where they're thrown
+- If only Windows API throws them, keep them there
+
+### Infrastructure (1 file) - ✅ Cross-platform
+33. **Infrastructure/ExceptionJsonConverter.cs** - JSON converter
+
+**Recommendation**: ✅ **MOVE to Dorc.Api/Infrastructure/** if used in both APIs
+- JSON serialization is cross-platform
+- Could be shared infrastructure
+
+### Configuration Files (2 files)
+34. **appsettings.json** - Windows API configuration
+35. **loggerSettings.json** - Logging configuration
+
+**Recommendation**: ✅ **KEEP** - Each API needs its own configuration
+
+### Documentation (1 file)
+36. **README.md** - Windows API documentation
+
+**Recommendation**: ✅ **KEEP** - Documents Windows-specific API
+
+---
+
+## Recommended Actions
+
+### ✅ Immediate Moves (Low Risk) - 3 files
+
+Move these to `Dorc.Api` as they're clearly cross-platform and useful for both APIs:
+
+1. **Build/DeployableBuildFactory.cs** → `Dorc.Api/Build/`
+2. **Build/AzureDevOpsDeployableBuild.cs** → `Dorc.Api/Build/`
+3. **Build/FileShareDeployableBuild.cs** → `Dorc.Api/Build/`
+
+**Rationale:**
+- No Windows-specific APIs
+- Build artifact retrieval works on Linux
+- Useful for the main API deployment functionality
+
+### ⚠️ Conditional Moves (Need Analysis) - 7 files
+
+Move these to `Dorc.Api` ONLY if they're also needed by cross-platform controllers:
+
+4. **Deployment/PropertiesService.cs** → `Dorc.Api/Deployment/` (if used by main API)
+5. **Deployment/PropertyValuesService.cs** → `Dorc.Api/Deployment/` (if used by main API)
+6. **Deployment/RequestService.cs** → `Dorc.Api/Deployment/` (if used by main API)
+7. **Deployment/EnvironmentMapper.cs** → `Dorc.Api/Deployment/` (if used by main API)
+8. **Deployment/FileSystemHelper.cs** → `Dorc.Api/Deployment/` (if used by main API)
+9. **Deployment/ManageUsers.cs** → `Dorc.Api/Deployment/` (if used by main API)
+10. **Infrastructure/ExceptionJsonConverter.cs** → `Dorc.Api/Infrastructure/` (if shared)
+
+**Analysis Required:**
+- Check if the main Dorc.Api uses these services
+- Review dependencies on Windows-only components
+- Verify they don't indirectly depend on Active Directory or Windows auth
+
+### ❌ Do NOT Move (Keep in Windows API) - 25 files
+
+Keep these in `Dorc.Api.Windows`:
+
+- All 6 Controllers (Windows platform-specific)
+- All 4 Identity files (Active Directory dependencies)
+- All 2 Security files (Windows authentication)
+- All 3 Orchestration files (Windows API architecture)
+- All 5 Model files (Windows controller DTOs)
+- All 13 Interface files (Windows implementation contracts)
+- All 2 Exception files (Windows-specific errors)
+- Configuration files (Program.cs, WindowsDependencyRegistry.cs)
+- Settings files (appsettings.json, loggerSettings.json)
+- Documentation (README.md)
+
+---
+
+## Migration Impact Analysis
+
+### If Build Files Are Moved (3 files):
+
+**Benefits:**
+- ✅ Main API can retrieve builds directly (reduces Windows API dependency)
+- ✅ Linux deployment can fetch Azure DevOps builds
+- ✅ Consistent build handling across both APIs
+
+**Risks:**
+- ⚠️ Potential duplicate code if Windows API still needs them
+- ⚠️ Need to update dependency injection in both APIs
+
+**Effort:** 1-2 hours
+
+### If Deployment Files Are Moved (7 files):
+
+**Benefits:**
+- ✅ Reduced duplication if both APIs need deployment logic
+- ✅ Centralized business logic
+
+**Risks:**
+- ❌ May break Windows API if dependencies aren't properly managed
+- ❌ Deployment logic might have hidden Windows dependencies
+- ❌ Could complicate the separation of concerns
+
+**Effort:** 4-8 hours + extensive testing
+
+---
+
+## Current State Assessment
+
+**The current split is actually CORRECT for the stated goal:**
+
+> "second API should be the rest of the code/ bare minimum code thats needed for running on windows"
+
+The Windows API contains:
+- ✅ Windows-specific controllers (Active Directory, Windows Auth)
+- ✅ Supporting services for those controllers
+- ✅ Minimal cross-platform code needed to support Windows operations
+
+**Moving files back would:**
+- ❌ Create dependencies from main API to Windows-only features
+- ❌ Complicate the architecture
+- ❌ Risk introducing Windows dependencies into the cross-platform API
+
+---
+
+## Recommendation
+
+### Final Answer: **Move only Build files (3 files)**
+
+**Safest approach:**
+1. Move the 3 Build files to Dorc.Api
+2. Keep everything else in Dorc.Api.Windows as-is
+3. If both APIs need the same deployment logic, create a **shared library** instead
+
+**Better long-term solution:**
+- Create `Dorc.Core.Deployment` shared project for deployment logic
+- Both APIs reference it
+- Keeps separation clean while reducing duplication
+
+**Current state is actually well-designed** - the split clearly separates:
+- Cross-platform API (Dorc.Api)
+- Windows-only features (Dorc.Api.Windows)
+- Communication via HTTP (IWindowsApiClient)
+
+Most files should **stay where they are** to maintain this clean separation.

--- a/docs/api-split/research/REGISTRY_UPGRADE_EXAMPLE.md
+++ b/docs/api-split/research/REGISTRY_UPGRADE_EXAMPLE.md
@@ -1,0 +1,393 @@
+# Registry Dependency Upgrade Example
+
+This document demonstrates a concrete example of upgrading from Windows-only Registry APIs to cross-platform alternatives.
+
+## Current Implementation (Windows-Only)
+
+### File: `Dorc.Api/Controllers/RefDataServersController.cs`
+
+**Current Code - Lines 130-148:**
+
+```csharp
+using Microsoft.Win32;  // ❌ Windows-only namespace
+
+[HttpGet]
+[SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+[SwaggerResponse(StatusCodes.Status200OK, Type = typeof(ServerOperatingSystemApiModel))]
+[Route("GetServerOperatingFromTarget")]
+public IActionResult GetServerOperatingFromTarget(string serverName)
+{
+    var output = new ServerOperatingSystemApiModel();
+    
+    // ❌ Windows-only Registry API
+    using (var reg = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, serverName))
+    using (var key = reg.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\"))
+    {
+        if (key == null)
+            return BadRequest("Unable to open the target machine");
+
+        output.ProductName = key.GetValue("ProductName").ToString();
+        output.CurrentVersion = key.GetValue("CurrentVersion").ToString();
+    }
+    
+    return Ok(output);
+}
+```
+
+**Issues:**
+- ❌ Uses `Microsoft.Win32` namespace (Windows-only)
+- ❌ `RegistryKey.OpenRemoteBaseKey()` requires Windows
+- ❌ Cannot run on Linux
+- ❌ Tightly coupled to Windows Registry structure
+
+---
+
+## Upgraded Implementation (Cross-Platform)
+
+### Option 1: RuntimeInformation API (Recommended for Local Server)
+
+**For detecting OS information on the server running the API:**
+
+```csharp
+using System.Runtime.InteropServices;  // ✅ Cross-platform
+
+[HttpGet]
+[SwaggerResponse(StatusCodes.Status200OK, Type = typeof(ServerOperatingSystemApiModel))]
+[Route("GetServerOperating")]
+public IActionResult GetServerOperating()
+{
+    var output = new ServerOperatingSystemApiModel
+    {
+        // ✅ Cross-platform - works on Windows, Linux, macOS
+        ProductName = RuntimeInformation.OSDescription,
+        CurrentVersion = Environment.OSVersion.Version.ToString(),
+        Architecture = RuntimeInformation.OSArchitecture.ToString(),
+        Framework = RuntimeInformation.FrameworkDescription
+    };
+    
+    return Ok(output);
+}
+```
+
+**Benefits:**
+- ✅ Works on Windows, Linux, macOS
+- ✅ Built-in to .NET 8 (no extra packages)
+- ✅ No Windows dependencies
+- ✅ More reliable than Registry parsing
+
+**Example Outputs:**
+
+*On Windows Server 2019:*
+```json
+{
+  "ProductName": "Microsoft Windows 10.0.17763",
+  "CurrentVersion": "10.0.17763.0",
+  "Architecture": "X64",
+  "Framework": ".NET 8.0.0"
+}
+```
+
+*On Linux (Ubuntu 22.04):*
+```json
+{
+  "ProductName": "Linux 5.15.0-1052-azure #60-Ubuntu SMP",
+  "CurrentVersion": "5.15.0.1052",
+  "Architecture": "X64",
+  "Framework": ".NET 8.0.0"
+}
+```
+
+---
+
+### Option 2: Remote Server Management (Windows API Proxy)
+
+**For querying remote servers (original use case):**
+
+Since the original code queries *remote* servers, we need a different approach:
+
+#### Step 1: Move to Windows API
+
+Move this functionality to `Dorc.Api.Windows` since it requires Windows-specific remote registry access:
+
+**File: `Dorc.Api.Windows/Controllers/ServerInfoController.cs`** (NEW)
+
+```csharp
+using Microsoft.Win32;
+using Microsoft.AspNetCore.Mvc;
+using System.Runtime.Versioning;
+
+namespace Dorc.Api.Windows.Controllers
+{
+    [SupportedOSPlatform("windows")]
+    [ApiController]
+    [Route("[controller]")]
+    public class ServerInfoController : ControllerBase
+    {
+        [HttpGet]
+        [Route("GetOperatingSystem")]
+        public IActionResult GetOperatingSystem(string serverName)
+        {
+            var output = new ServerOperatingSystemApiModel();
+            
+            try
+            {
+                using (var reg = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, serverName))
+                using (var key = reg.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\"))
+                {
+                    if (key == null)
+                        return BadRequest("Unable to open the target machine");
+
+                    output.ProductName = key.GetValue("ProductName")?.ToString() ?? "Unknown";
+                    output.CurrentVersion = key.GetValue("CurrentVersion")?.ToString() ?? "Unknown";
+                    output.BuildNumber = key.GetValue("CurrentBuildNumber")?.ToString() ?? "Unknown";
+                }
+                
+                return Ok(output);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Failed to query remote registry: {ex.Message}");
+            }
+        }
+    }
+}
+```
+
+#### Step 2: Create Interface in Main API
+
+**File: `Dorc.Api/Interfaces/IWindowsApiClient.cs`** (already exists)
+
+Add method to the interface:
+
+```csharp
+public interface IWindowsApiClient
+{
+    Task<ServerOperatingSystemApiModel> GetServerOperatingSystemAsync(string serverName);
+    // ... other methods
+}
+```
+
+#### Step 3: Update Main API Controller
+
+**File: `Dorc.Api/Controllers/RefDataServersController.cs`** (UPDATED)
+
+```csharp
+using System.Runtime.InteropServices;  // ✅ Cross-platform
+
+public class RefDataServersController : ControllerBase
+{
+    private readonly ISecurityPrivilegesChecker _securityPrivilegesChecker;
+    private readonly IServersPersistentSource _serversPersistentSource;
+    private readonly IEnvironmentsPersistentSource _environmentsPersistentSource;
+    private readonly IWindowsApiClient _windowsApiClient;  // ✅ NEW
+
+    public RefDataServersController(
+        ISecurityPrivilegesChecker securityPrivilegesChecker,
+        IServersPersistentSource serversPersistentSource, 
+        IEnvironmentsPersistentSource environmentsPersistentSource,
+        IWindowsApiClient windowsApiClient)  // ✅ NEW
+    {
+        _environmentsPersistentSource = environmentsPersistentSource;
+        _serversPersistentSource = serversPersistentSource;
+        _securityPrivilegesChecker = securityPrivilegesChecker;
+        _windowsApiClient = windowsApiClient;  // ✅ NEW
+    }
+
+    [HttpGet]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, Type = typeof(string))]
+    [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(ServerOperatingSystemApiModel))]
+    [Route("GetServerOperatingFromTarget")]
+    public async Task<IActionResult> GetServerOperatingFromTarget(string serverName)
+    {
+        try
+        {
+            // ✅ Cross-platform - delegates to Windows API when needed
+            var output = await _windowsApiClient.GetServerOperatingSystemAsync(serverName);
+            return Ok(output);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"Failed to get server info: {ex.Message}");
+        }
+    }
+}
+```
+
+**Remove the using statement:**
+```diff
+- using Microsoft.Win32;  // ❌ Remove Windows-only import
++ using System.Runtime.InteropServices;  // ✅ Cross-platform
+```
+
+---
+
+### Option 3: SSH-Based Remote Query (Fully Cross-Platform)
+
+**For querying remote servers without Windows dependencies:**
+
+Install package:
+```xml
+<PackageReference Include="SSH.NET" Version="2024.0.0" />
+```
+
+**Implementation:**
+
+```csharp
+using Renci.SshNet;
+
+[HttpGet]
+[Route("GetServerOperatingFromTarget")]
+public async Task<IActionResult> GetServerOperatingFromTarget(
+    string serverName, 
+    string username, 
+    string password)
+{
+    try
+    {
+        var output = new ServerOperatingSystemApiModel();
+        
+        // ✅ Cross-platform - works with Windows (via OpenSSH) and Linux
+        using (var client = new SshClient(serverName, username, password))
+        {
+            client.Connect();
+            
+            // Detect OS and run appropriate command
+            var osTypeCommand = client.RunCommand("uname -s 2>/dev/null || echo Windows");
+            var isLinux = !osTypeCommand.Result.Contains("Windows");
+            
+            if (isLinux)
+            {
+                // Linux command
+                var osInfo = client.RunCommand("cat /etc/os-release");
+                // Parse output
+                output.ProductName = ParseLinuxOsRelease(osInfo.Result, "PRETTY_NAME");
+                output.CurrentVersion = ParseLinuxOsRelease(osInfo.Result, "VERSION_ID");
+            }
+            else
+            {
+                // Windows command (requires OpenSSH server on Windows)
+                var winVer = client.RunCommand("systeminfo | findstr /B /C:\"OS Name\" /C:\"OS Version\"");
+                // Parse output
+                var lines = winVer.Result.Split('\n');
+                output.ProductName = lines[0].Split(':')[1].Trim();
+                output.CurrentVersion = lines[1].Split(':')[1].Trim();
+            }
+            
+            client.Disconnect();
+        }
+        
+        return Ok(output);
+    }
+    catch (Exception ex)
+    {
+        return StatusCode(500, $"SSH connection failed: {ex.Message}");
+    }
+}
+
+private string ParseLinuxOsRelease(string content, string key)
+{
+    var line = content.Split('\n').FirstOrDefault(l => l.StartsWith(key));
+    return line?.Split('=')[1].Trim('"') ?? "Unknown";
+}
+```
+
+**Benefits:**
+- ✅ Fully cross-platform
+- ✅ Works with both Windows and Linux targets
+- ✅ No Windows Registry dependency
+- ⚠️ Requires SSH server on target machines
+
+---
+
+## Migration Steps
+
+### Immediate Quick Win (5 minutes)
+
+1. **Remove local Registry usage** - Replace with `RuntimeInformation`:
+
+```diff
+- using Microsoft.Win32;
++ using System.Runtime.InteropServices;
+
+  public IActionResult GetLocalServerInfo()
+  {
+-     using (var key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion"))
+-     {
+-         var productName = key?.GetValue("ProductName")?.ToString();
+-         var version = key?.GetValue("CurrentVersion")?.ToString();
+-     }
++     var productName = RuntimeInformation.OSDescription;
++     var version = Environment.OSVersion.Version.ToString();
+  }
+```
+
+**Time**: 5 minutes per file  
+**Files affected**: 1 file (`RefDataServersController.cs`)
+
+### Short-term (1-2 hours)
+
+2. **Move remote Registry access to Windows API**:
+   - Create new controller in `Dorc.Api.Windows`
+   - Update `IWindowsApiClient` interface
+   - Modify main API to use proxy pattern
+
+**Time**: 1-2 hours  
+**Files affected**: 3 files (1 new, 2 modified)
+
+### Long-term (1 week)
+
+3. **Implement SSH-based alternative**:
+   - Add SSH.NET package
+   - Create cross-platform remote query
+   - Add configuration for SSH credentials
+
+**Time**: 3-5 days  
+**Files affected**: 5-7 files
+
+---
+
+## Comparison Matrix
+
+| Approach | Cross-Platform | Remote Query | Complexity | Windows 7 Support | Linux Support |
+|----------|----------------|--------------|------------|-------------------|---------------|
+| **Registry API (current)** | ❌ No | ✅ Yes | Low | ✅ Yes | ❌ No |
+| **RuntimeInformation** | ✅ Yes | ❌ No (local only) | Very Low | ✅ Yes | ✅ Yes |
+| **Windows API Proxy** | ✅ Yes* | ✅ Yes | Medium | ✅ Yes | ❌ No** |
+| **SSH.NET** | ✅ Yes | ✅ Yes | High | ✅ Yes | ✅ Yes |
+
+*Main API is cross-platform, delegates to Windows API when on Linux  
+**Target servers must be Windows
+
+---
+
+## Recommended Approach
+
+**For the Dorc project**, use a hybrid approach:
+
+1. **Local server info**: Use `RuntimeInformation` (immediate)
+2. **Remote Windows servers**: Use Windows API proxy pattern (current implementation keeps working)
+3. **Future enhancement**: Add SSH support for Linux targets
+
+This approach:
+- ✅ Enables Linux deployment immediately
+- ✅ Maintains backward compatibility
+- ✅ Provides migration path for future
+- ✅ Supports Windows 7+ and Linux
+
+---
+
+## Code Example Summary
+
+### Before (Windows-only)
+```csharp
+using Microsoft.Win32;
+var reg = RegistryKey.OpenRemoteBaseKey(RegistryHive.LocalMachine, server);
+```
+
+### After (Cross-platform)
+```csharp
+using System.Runtime.InteropServices;
+var osInfo = RuntimeInformation.OSDescription;
+```
+
+**Result**: Code runs on Windows, Linux, and macOS with no changes needed.

--- a/docs/api-split/research/WINDOWS_DEPENDENCIES_ANALYSIS.md
+++ b/docs/api-split/research/WINDOWS_DEPENDENCIES_ANALYSIS.md
@@ -1,0 +1,907 @@
+# Windows Dependencies Analysis - Detailed Report
+
+This document provides a comprehensive analysis of all Windows-specific dependencies in the Dorc codebase, their purpose, potential alternatives, and recommendations for cross-platform migration.
+
+## Summary
+
+The Dorc codebase has **4 major categories** of Windows dependencies affecting **30+ files** across multiple projects.
+
+---
+
+## 1. Active Directory (AD) / LDAP Dependencies
+
+### NuGet Packages
+- **System.DirectoryServices** (v9.0.10)
+  - Used in: `Dorc.Core`, `Dorc.PersistentData`, `Dorc.Api.Tests`
+  - **Status**: Windows-only, no Linux support
+  - **Windows OS Support**: Windows Server 2008+ / Windows 7+
+
+- **System.DirectoryServices.AccountManagement** (v9.0.10)
+  - Used in: `Dorc.Core`, `Dorc.PersistentData`
+  - **Status**: Windows-only, no Linux support
+  - **Windows OS Support**: Windows Server 2008+ / Windows 7+
+
+### Specific Files Using Active Directory APIs
+
+**System.DirectoryServices Users (6 files):**
+1. `Dorc.Core/ActiveDirectorySearcher.cs` - Core AD search implementation
+2. `Dorc.Api/Controllers/DirectorySearchController.cs` - User/group search endpoints
+3. `Dorc.Api.Windows/Controllers/DirectorySearchController.cs` - Windows API version
+4. `Dorc.Api/Services/ApiRegistry.cs` - DI registration for AD services
+5. `Dorc.Api.Windows/Configuration/WindowsDependencyRegistry.cs` - Windows DI setup
+6. `Dorc.Api.Tests/Controllers/DirectorySearchControllerTests.cs` - Tests
+
+**System.DirectoryServices.AccountManagement Users (3 files):**
+1. `Dorc.Core/ActiveDirectorySearcher.cs` - User principal, group principal operations
+2. `Dorc.Api/Controllers/DirectorySearchController.cs` - Check group membership
+3. `Dorc.Api.Windows/Controllers/DirectorySearchController.cs` - Windows API version
+
+### Primary Usage
+1. **User/Group Search** (`ActiveDirectorySearcher.cs`)
+   - Search users and groups by name
+   - Get user details by SID
+   - LDAP queries for user attributes (displayName, mail, SAMAccountName, objectSid)
+
+2. **Authentication & Authorization**
+   - Validate group membership
+   - Check if user belongs to specific AD groups
+   - Recursive group membership checks
+
+3. **User Management**
+   - Get all SIDs for a user (including nested groups)
+   - Check account status (enabled/disabled)
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: Azure Entra ID / Microsoft Graph (RECOMMENDED)**
+- **Status**: Already partially implemented in `AzureEntraSearcher.cs`
+- **Packages**: `Microsoft.Graph` (v5.95.0), `Azure.Identity` (v1.17.0)
+- **Cross-platform**: ✅ Yes (works on Linux, macOS, Windows)
+- **Windows OS Compatibility**: All versions (cloud-based, no OS restrictions)
+- **Capabilities**:
+  - User/group search via Microsoft Graph API
+  - Group membership validation
+  - User attribute retrieval
+  - Works with Azure AD / Entra ID (cloud or hybrid deployments)
+- **Migration Path**:
+  1. Extend `AzureEntraSearcher` to replace all `ActiveDirectorySearcher` functionality
+  2. Update `IActiveDirectorySearcher` interface implementations
+  3. Switch DI registration to use Azure Entra by default
+  4. Keep AD as fallback for on-premises deployments
+
+**Compatibility Matrix:**
+| Component | Windows 7 | Win Server 2008 | Win Server 2012+ | Linux | macOS |
+|-----------|-----------|-----------------|------------------|-------|-------|
+| Microsoft.Graph | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Azure.Identity | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+#### ✅ **Option 2: Novell.Directory.Ldap**
+- **Package**: `Novell.Directory.Ldap.NETStandard` (v3.6.0+)
+- **Cross-platform**: ✅ Yes (works on Linux, macOS, Windows)
+- **Windows OS Compatibility**: Windows 7+, Windows Server 2008+
+- **Capabilities**:
+  - Direct LDAP queries (works with AD and other LDAP servers)
+  - User/group search
+  - Attribute retrieval
+- **Pros**: Works with on-premises AD without Azure Entra, no cloud dependency
+- **Cons**: Requires direct LDAP access (port 389/636), more complex setup
+
+**Compatibility Matrix:**
+| Component | Windows 7 | Win Server 2008 | Win Server 2012+ | Linux | macOS |
+|-----------|-----------|-----------------|------------------|-------|-------|
+| Novell.Directory.Ldap | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+**Example Implementation:**
+```csharp
+using Novell.Directory.Ldap;
+
+public class LdapDirectorySearcher : IActiveDirectorySearcher
+{
+    public List<UserElementApiModel> Search(string objectName)
+    {
+        using var conn = new LdapConnection();
+        conn.Connect("ldap.company.com", 389);
+        conn.Bind("cn=admin,dc=company,dc=com", "password");
+        
+        var search = conn.Search(
+            "dc=company,dc=com",
+            LdapConnection.ScopeSub,
+            $"(&(objectClass=user)(cn=*{objectName}*))",
+            new[] { "displayName", "mail", "sAMAccountName" },
+            false);
+        // Process results
+    }
+}
+```
+
+#### ⚠️ **Option 3: Keep Windows-only (Current Implementation)**
+- Windows API runs on Windows server with AD access
+- Linux API forwards AD requests via HTTP to Windows API
+- **Status**: ✅ Already implemented in `Dorc.Api.Windows`
+- **Windows OS Requirements**: Windows Server 2008+, Domain membership required
+
+---
+
+## 2. Windows Authentication & Identity
+
+### Windows-Specific APIs
+- **WindowsIdentity** (9 files)
+- **SecurityIdentifier** / **NTAccount**
+- **Windows Impersonation**
+- **Windows OS Support**: Windows Server 2008+ / Windows 7+
+
+### Specific Files Using Windows Identity APIs
+
+**WindowsIdentity/Impersonation Users (9 files):**
+1. `Dorc.Api/Controllers/ResetAppPasswordController.cs` - Password reset with impersonation
+2. `Dorc.Api.Windows/Controllers/ResetAppPasswordController.cs` - Windows API version
+3. `Dorc.Api/Services/ClaimsTransformer.cs` - Transform Windows identity to claims
+4. `Dorc.Api.Windows/Identity/ClaimsTransformer.cs` - Windows API version
+5. `Dorc.Core/ServiceStatus.cs` - Windows service status checks
+6. `Tools.DeployCopyEnvBuildCLI/Program.cs` - CLI tool
+7. `Tools.PropertyValueCreationCLI/PropertyValueFilterCreation.cs` - CLI tool
+8. `Dorc.Api.Tests/PropertyValuesServiceTests.cs` - Tests
+9. `Dorc.Api.Tests/RequestServiceTests.cs` - Tests
+
+### Primary Usage
+1. **Windows Authentication**
+   - `WinAuthClaimsPrincipalReader.cs` - Read Windows user claims
+   - `ClaimsTransformer.cs` - Transform Windows identity to app claims
+   - Negotiate/Kerberos authentication
+
+2. **Password Reset with Impersonation** (`ResetAppPasswordController.cs`)
+   - Uses `LogonUser` P/Invoke
+   - `WindowsIdentity.RunImpersonated()` for SQL password reset
+   - Requires Windows domain credentials
+
+3. **Security Context**
+   - Convert between SID and NTAccount formats
+   - Get user's group SIDs for authorization
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: OAuth2 / JWT (RECOMMENDED)**
+- **Status**: ✅ Already implemented in `Dorc.Api`
+- **Packages**: `Microsoft.AspNetCore.Authentication.JwtBearer` (v8.0.13)
+- **Cross-platform**: ✅ Yes
+- **Windows OS Compatibility**: All versions
+- **Migration Path**: Already supports OAuth2 as alternative to Windows Auth
+  - Configuration: Set `AuthenticationScheme` to `"OAuth"` or `"Both"`
+
+**Compatibility Matrix:**
+| Component | Windows 7 | Win Server 2008 | Win Server 2012+ | Linux | macOS |
+|-----------|-----------|-----------------|------------------|-------|-------|
+| JWT Bearer Auth | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OAuth2 | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+#### ✅ **Option 2: Azure AD / Entra ID Authentication**
+- Uses OAuth2/OIDC tokens
+- Works cross-platform
+- Integrates with Microsoft Graph for user info
+- **Windows OS Compatibility**: All versions (cloud-based)
+
+#### ⚠️ **Option 3: External Authentication Service**
+- For password reset: Use Azure Key Vault or HashiCorp Vault
+- For impersonation: Replace with service account with proper RBAC
+- **Cross-platform**: Depends on chosen solution
+
+---
+
+## 3. WMI (Windows Management Instrumentation)
+
+### NuGet Packages
+- **System.Management** (v9.0.10)
+  - Used in: `Dorc.Runner`, `Dorc.TerraformRunner`, `Dorc.PowerShell`
+  - **Status**: Windows-only
+  - **Windows OS Support**: Windows Server 2008+ / Windows 7+
+
+### Specific Files Using WMI (9 files)
+
+1. `Dorc.Api/Services/WmiUtil.cs` - Server reboot, WMI operations
+2. `Dorc.Runner/Program.cs` - Runner service WMI usage
+3. `Dorc.TerraformRunner/Program.cs` - Terraform runner WMI
+4. `Dorc.PowerShell/PowerShellScriptRunner.cs` - PowerShell script execution
+5. `Dorc.NetFramework.Runner/Program.cs` - Legacy .NET Framework runner
+6. `Dorc.NetFramework.PowerShell/PowerShellScriptRunner.cs` - Legacy PowerShell
+7. `Dorc.NetFramework.PowerShell/CustomHost.cs` - PowerShell host
+8. `Dorc.NetFramework.PowerShell/CustomHostUserInterface.cs` - PowerShell UI
+9. `Dorc.NetFramework.PowerShell/CustomHostRawUserInterface.cs` - PowerShell raw UI
+
+### Primary Usage
+1. **Server Operations** (`WmiUtil.cs`)
+   - Remote server reboot
+   - Check Windows services status
+   - Query OS version
+
+2. **Service Status Checks** (`ServiceStatus.cs`)
+   - Check if Windows services are running
+   - Get service state
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: SSH / PowerShell Remoting (RECOMMENDED)**
+- **Package**: `SSH.NET` (v2024.0.0) or `System.Management.Automation` (cross-platform)
+- **Cross-platform**: ✅ Yes
+- **Windows OS Compatibility**: Windows Server 2012+ (PowerShell remoting), All versions (SSH)
+- **Capabilities**:
+  - Remote command execution via SSH
+  - PowerShell Core remoting (works on Linux)
+
+**Compatibility Matrix:**
+| Component | Windows 7 | Win Server 2008 | Win Server 2012+ | Linux | macOS |
+|-----------|-----------|-----------------|------------------|-------|-------|
+| SSH.NET | ✅ | ✅ | ✅ | ✅ | ✅ |
+| PowerShell 7+ | ❌ | ⚠️ | ✅ | ✅ | ✅ |
+
+*Note: PowerShell 7+ requires Windows Server 2012+ for full functionality*
+
+**Example Implementation:**
+```csharp
+using Renci.SshNet;
+
+public class SshServerManager
+{
+    public async Task RebootServer(string serverName)
+    {
+        using var client = new SshClient(serverName, "username", "password");
+        client.Connect();
+        var result = client.RunCommand("sudo reboot");
+        client.Disconnect();
+    }
+}
+```
+
+#### ✅ **Option 2: REST API / Agent-Based**
+- Deploy lightweight agent on target servers
+- Expose REST API for operations
+- Works across all platforms
+- **Windows OS Compatibility**: All versions
+
+#### ⚠️ **Option 3: Platform-Specific Implementation**
+- Windows: Use WMI (requires Windows Server 2008+)
+- Linux: Use systemd/systemctl commands
+- Runtime detection with conditional execution
+
+---
+
+## 4. Windows Registry
+
+### Windows-Specific APIs
+- **Microsoft.Win32.Registry** / **RegistryKey**
+- **Windows OS Support**: Windows Server 2008+ / Windows 7+
+
+### Specific Files Using Registry (14 files)
+
+1. `Dorc.Api/Controllers/RefDataServersController.cs` - OS version detection
+2. `Dorc.Api/Controllers/ResetAppPasswordController.cs` - Configuration registry access
+3. `Dorc.Api.Windows/Controllers/ResetAppPasswordController.cs` - Windows API version
+4. `Dorc.Core/ServiceStatus.cs` - Service registry information
+5. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.CreateFile.cs` - Windows interop
+6. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.CreateNamedPipe.cs` - Pipe creation
+7. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.CreatePipe.cs` - Pipe creation
+8. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.DuplicateHandle.cs` - Handle duplication
+9. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.GetStdHandle.cs` - Standard handles
+10. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.STARTUPINFO.cs` - Process startup
+11. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.SetHandleInformation.cs` - Handle info
+12. `Dorc.Monitor/RunnerProcess/Interop/Windows/Kernel32/Interop.TerminateProcess.cs` - Process termination
+13. `Dorc.Monitor/RunnerProcess/ProcessStartupInfoBuilder.cs` - Process startup builder
+14. `Dorc.Monitor/RunnerProcess/RunnerProcess.cs` - Runner process management
+
+### Primary Usage
+1. **OS Version Detection** (`RefDataServersController.cs`)
+   - Read `Software\Microsoft\Windows NT\CurrentVersion`
+   - Get Windows build number and version
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: Runtime Information API (RECOMMENDED)**
+- **Package**: Built-in `System.Runtime.InteropServices.RuntimeInformation`
+- **Cross-platform**: ✅ Yes
+- **Windows OS Compatibility**: All versions
+
+**Compatibility Matrix:**
+| Component | Windows 7 | Win Server 2008 | Win Server 2012+ | Linux | macOS |
+|-----------|-----------|-----------------|------------------|-------|-------|
+| RuntimeInformation | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+**Example Implementation:**
+```csharp
+using System.Runtime.InteropServices;
+
+public string GetOSVersion()
+{
+    return RuntimeInformation.OSDescription;
+    // Returns: "Microsoft Windows 10.0.19044" or "Linux 5.15.0-1"
+}
+
+public string GetOSArchitecture()
+{
+    return RuntimeInformation.OSArchitecture.ToString();
+    // Returns: "X64", "Arm64", etc.
+}
+```
+
+#### ✅ **Option 2: Environment Variables**
+```csharp
+var osVersion = Environment.OSVersion.VersionString;
+var platform = Environment.OSVersion.Platform;
+```
+- **Cross-platform**: ✅ Yes
+- **Windows OS Compatibility**: All versions
+
+---
+
+## 5. PowerShell Dependencies
+
+### NuGet Packages
+- **System.Management.Automation** (v7.4.13 in `Dorc.PowerShell`)
+- **Microsoft.PowerShell.SDK** (v7.5.4 in `Dorc.Core`)
+- **Windows OS Support**: PowerShell 7+ supports Windows 7+, Windows Server 2012+
+
+### Status
+- ✅ **PowerShell 7+ is cross-platform**
+- `Microsoft.PowerShell.SDK` works on Linux/macOS
+- Only `.NetFramework.PowerShell` projects are Windows-only
+
+**Compatibility Matrix:**
+| Component | Windows 7 | Win Server 2008 | Win Server 2012+ | Linux | macOS |
+|-----------|-----------|-----------------|------------------|-------|-------|
+| PowerShell 5.1 | ✅ | ✅ | ✅ | ❌ | ❌ |
+| PowerShell 7+ | ⚠️ | ⚠️ | ✅ | ✅ | ✅ |
+| Microsoft.PowerShell.SDK | ⚠️ | ⚠️ | ✅ | ✅ | ✅ |
+
+*Note: PowerShell 7+ has limited support on Windows 7 and Server 2008. Full support requires Windows Server 2012+*
+
+### Recommendation
+- ✅ **Already cross-platform compatible** via PowerShell 7+
+- Keep using `Microsoft.PowerShell.SDK` (v7.5.4)
+- Deprecate `Dorc.NetFramework.PowerShell` and `Dorc.NetFramework.Runner`
+- **Minimum Windows OS**: Windows Server 2012+ for full PowerShell 7 support
+
+---
+
+## Migration Priority & Roadmap
+
+### Phase 1: Quick Wins (Low Effort, High Impact)
+1. ✅ **Replace Registry API** with `RuntimeInformation` - 1 file affected
+   - **Windows Compatibility**: All versions (Windows 7+)
+    {
+        using var conn = new LdapConnection();
+        conn.Connect("ldap.company.com", 389);
+        conn.Bind("cn=admin,dc=company,dc=com", "password");
+        
+        var search = conn.Search(
+            "dc=company,dc=com",
+            LdapConnection.ScopeSub,
+            $"(&(objectClass=user)(cn=*{objectName}*))",
+            new[] { "displayName", "mail", "sAMAccountName" },
+            false);
+        // Process results
+    }
+}
+```
+
+#### ⚠️ **Option 3: Keep Windows-only (Current Implementation)**
+- Windows API runs on Windows server with AD access
+- Linux API forwards AD requests via HTTP to Windows API
+- **Status**: ✅ Already implemented in `Dorc.Api.Windows`
+
+---
+
+## 2. Windows Authentication & Identity
+
+### Windows-Specific APIs
+- **WindowsIdentity** (15 files)
+- **SecurityIdentifier** / **NTAccount**
+- **Windows Impersonation**
+
+### Primary Usage
+1. **Windows Authentication**
+   - `WinAuthClaimsPrincipalReader.cs` - Read Windows user claims
+   - `ClaimsTransformer.cs` - Transform Windows identity to app claims
+   - Negotiate/Kerberos authentication
+
+2. **Password Reset with Impersonation** (`ResetAppPasswordController.cs`)
+   - Uses `LogonUser` P/Invoke
+   - `WindowsIdentity.RunImpersonated()` for SQL password reset
+   - Requires Windows domain credentials
+
+3. **Security Context**
+   - Convert between SID and NTAccount formats
+   - Get user's group SIDs for authorization
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: OAuth2 / JWT Bearer (RECOMMENDED)**
+- **Status**: ✅ Already implemented in `Dorc.Api`
+- **Packages**: `Microsoft.AspNetCore.Authentication.JwtBearer` (v8.0.13)
+- **Cross-platform**: ✅ Yes
+- **Migration Path**: Already supports OAuth2 as alternative to Windows Auth
+  - Configuration: Set `AuthenticationScheme` to `"OAuth"` or `"Both"`
+
+#### ✅ **Option 2: Azure AD / Entra ID Authentication**
+- Uses OAuth2/OIDC tokens
+- Works cross-platform
+- Integrates with Microsoft Graph for user info
+
+#### ⚠️ **Option 3: External Authentication Service**
+- For password reset: Use Azure Key Vault or HashiCorp Vault
+- For impersonation: Replace with service account with proper RBAC
+
+**Password Reset Alternative:**
+```csharp
+// Instead of Windows impersonation, use service principal
+public class SqlPasswordResetService
+{
+    public async Task<ApiBoolResult> ResetPassword(string username, string serverName)
+    {
+        // Use service account with SQL permissions
+        // Or use Azure Key Vault for credential management
+        var credentials = await _keyVaultClient.GetSecretAsync("sql-admin-credentials");
+        // Reset password without impersonation
+    }
+}
+```
+
+---
+
+## 3. WMI (Windows Management Instrumentation)
+
+### NuGet Packages
+- **System.Management** (v9.0.10)
+  - Used in: `Dorc.Runner`, `Dorc.TerraformRunner`
+  - **Status**: Windows-only
+
+### Primary Usage
+1. **Server Operations** (`WmiUtil.cs`)
+   - Remote server reboot
+   - Check Windows services status
+   - Query OS version
+
+2. **Service Status Checks** (`ServiceStatus.cs`)
+   - Check if Windows services are running
+   - Get service state
+
+### Files Using WMI (4 files)
+```
+Dorc.Api/Services/WmiUtil.cs
+Dorc.Core/ServiceStatus.cs
+Dorc.Runner/Program.cs
+Dorc.TerraformRunner/Program.cs
+```
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: SSH / PowerShell Remoting (RECOMMENDED)**
+- **Package**: `SSH.NET` or `System.Management.Automation` (cross-platform version)
+- **Cross-platform**: ✅ Yes
+- **Capabilities**:
+  - Remote command execution via SSH
+  - PowerShell Core remoting (works on Linux)
+
+**Example Implementation:**
+```csharp
+using Renci.SshNet;
+
+public class SshServerManager
+{
+    public async Task RebootServer(string serverName)
+    {
+        using var client = new SshClient(serverName, "username", "password");
+        client.Connect();
+        var result = client.RunCommand("sudo reboot");
+        client.Disconnect();
+    }
+}
+```
+
+#### ✅ **Option 2: REST API / Agent-Based**
+- Deploy lightweight agent on target servers
+- Expose REST API for operations
+- Works across all platforms
+
+#### ⚠️ **Option 3: Platform-Specific Implementation**
+- Windows: Use WMI
+- Linux: Use systemd/systemctl commands
+- Runtime detection with conditional execution
+
+---
+
+## 4. Windows Registry
+
+### Windows-Specific APIs
+- **Microsoft.Win32.Registry** / **RegistryKey**
+
+### Primary Usage
+1. **OS Version Detection** (`RefDataServersController.cs`)
+   - Read `Software\Microsoft\Windows NT\CurrentVersion`
+   - Get Windows build number and version
+
+### Files Using Registry (21 files - mostly tests and references)
+```
+Dorc.Api/Controllers/RefDataServersController.cs
+[+ 20 files in tests]
+```
+
+### **Alternatives & Recommendations**
+
+#### ✅ **Option 1: Runtime Information API (RECOMMENDED)**
+- **Package**: Built-in `System.Runtime.InteropServices.RuntimeInformation`
+- **Cross-platform**: ✅ Yes
+
+**Example Implementation:**
+```csharp
+using System.Runtime.InteropServices;
+
+public string GetOSVersion()
+{
+    return RuntimeInformation.OSDescription;
+    // Returns: "Microsoft Windows 10.0.19044" or "Linux 5.15.0-1"
+}
+
+public string GetOSArchitecture()
+{
+    return RuntimeInformation.OSArchitecture.ToString();
+    // Returns: "X64", "Arm64", etc.
+}
+```
+
+#### ✅ **Option 2: Environment Variables**
+```csharp
+var osVersion = Environment.OSVersion.VersionString;
+var platform = Environment.OSVersion.Platform;
+```
+
+---
+
+## 5. PowerShell Dependencies
+
+### NuGet Packages
+- **System.Management.Automation** (v7.4.13 in `Dorc.PowerShell`)
+- **Microsoft.PowerShell.SDK** (v7.5.4 in `Dorc.Core`)
+
+### Status
+- ✅ **PowerShell 7+ is cross-platform**
+- `Microsoft.PowerShell.SDK` works on Linux/macOS
+- Only `.NetFramework.PowerShell` projects are Windows-only
+
+### Recommendation
+- ✅ **Already cross-platform compatible** via PowerShell 7+
+- Keep using `Microsoft.PowerShell.SDK` (v7.5.4)
+- Deprecate `Dorc.NetFramework.PowerShell` and `Dorc.NetFramework.Runner`
+
+---
+
+## Migration Priority & Roadmap
+
+### Phase 1: Quick Wins (Low Effort, High Impact)
+1. ✅ **Replace Registry API** with `RuntimeInformation` - 1 file
+2. ✅ **Standardize on OAuth2** instead of Windows Auth - Already supported
+3. ✅ **Document Azure Entra** as AD alternative - Partially implemented
+
+### Phase 2: Medium Effort
+4. **Expand AzureEntraSearcher** to full AD replacement
+   - Implement all `IActiveDirectorySearcher` methods
+   - Add configuration option to choose AD provider
+   - Files affected: ~10
+
+5. **Replace WMI with SSH/REST**
+   - Implement cross-platform server management
+   - Files affected: ~4
+
+### Phase 3: Long-term (Complex Migration)
+6. **Refactor password reset** to use service accounts
+   - Remove Windows impersonation dependency
+   - Use Azure Key Vault or similar
+   - Files affected: 1-2
+
+7. **Implement LDAP alternative** for on-premises without Azure
+   - Use `Novell.Directory.Ldap`
+   - Provide configuration-based switching
+   - Files affected: ~10
+
+---
+
+## Cross-Platform Compatibility Matrix
+
+| Component | Current Status | Linux Compatible? | Recommended Alternative |
+|-----------|----------------|-------------------|------------------------|
+| **Active Directory** | System.DirectoryServices | ❌ No | ✅ Microsoft Graph (Azure Entra) or Novell.Directory.Ldap |
+| **Windows Auth** | Negotiate/NTLM | ❌ No | ✅ OAuth2/JWT (already implemented) |
+| **WMI** | System.Management | ❌ No | ✅ SSH.NET or REST API |
+| **Registry** | Microsoft.Win32 | ❌ No | ✅ RuntimeInformation (built-in) |
+| **PowerShell** | PowerShell 7+ | ✅ Yes | ✅ Keep current (already compatible) |
+| **Impersonation** | WindowsIdentity | ❌ No | ⚠️ Service accounts with RBAC |
+
+---
+
+## Dependency Removal Impact
+
+### Projects Affected by Full Windows Dependency Removal:
+1. **Dorc.Core** - Contains `ActiveDirectorySearcher` (can be replaced)
+2. **Dorc.PersistentData** - Uses AD for user lookups (can be abstracted)
+3. **Dorc.Api** - Windows-specific controllers (✅ already moved to Dorc.Api.Windows)
+4. **Dorc.Runner** - WMI for service management (needs SSH alternative)
+
+### Projects That Can Be Deprecated:
+1. **Dorc.NetFramework.PowerShell** - Replaced by PowerShell 7+
+2. **Dorc.NetFramework.Runner** - Can be migrated to .NET 8
+
+---
+
+## Recommended Action Items
+
+### Immediate (Next Sprint)
+1. ✅ Document current Windows dependencies (this document)
+2. Replace `Registry` usage with `RuntimeInformation` in `RefDataServersController`
+3. Add configuration option to choose AD provider (ActiveDirectory vs AzureEntra vs LDAP)
+
+### Short-term (1-2 Sprints)
+4. Complete `AzureEntraSearcher` implementation for all AD operations
+5. Create abstraction layer for server management (WMI vs SSH)
+6. Add feature flags for gradual migration
+
+### Long-term (3-6 months)
+7. Implement `Novell.Directory.Ldap` as fallback for on-premises
+8. Deprecate .NET Framework projects
+9. Migrate all authentication to OAuth2/JWT
+10. Replace Windows impersonation with service principal pattern
+
+---
+
+## Configuration Example for Flexible AD Provider
+
+```json
+{
+  "AppSettings": {
+    "DirectoryProvider": "AzureEntra",  // Options: "ActiveDirectory", "AzureEntra", "Ldap"
+    "AzureEntra": {
+      "TenantId": "...",
+      "ClientId": "...",
+      "ClientSecret": "..."
+    },
+    "Ldap": {
+      "Server": "ldap.company.com",
+      "Port": 389,
+      "BaseDn": "dc=company,dc=com",
+      "Username": "cn=admin,dc=company,dc=com"
+    }
+  }
+}
+```
+
+---
+
+## Conclusion
+
+The Dorc codebase has **significant but manageable** Windows dependencies. Key findings:
+
+1. **23 files** use Active Directory APIs - Can be replaced with Microsoft Graph or LDAP
+2. **15 files** use Windows Identity - OAuth2 already available as alternative  
+3. **4 files** use WMI - Can be replaced with SSH or REST APIs
+4. **PowerShell is already cross-platform** via PowerShell 7+
+
+**Current Split Architecture** (Dorc.Api + Dorc.Api.Windows) is a good interim solution that:
+- ✅ Enables immediate Linux deployment of core functionality
+- ✅ Keeps Windows-specific features working
+- ✅ Provides path for gradual migration
+
+**Recommended Next Steps:**
+1. Replace Registry API usage (1 hour)
+2. Expand Azure Entra implementation (2-3 days)
+3. Create configuration-based provider switching (1-2 days)
+4. Implement SSH-based server management (3-5 days)
+
+Total effort for full cross-platform migration: **2-4 weeks** of focused development.
+2. ✅ **Standardize on OAuth2** instead of Windows Auth - Already supported
+   - **Windows Compatibility**: All versions
+
+3. ✅ **Document Azure Entra** as AD alternative - Partially implemented
+   - **Windows Compatibility**: All versions (cloud-based)
+
+### Phase 2: Medium Effort (2-4 weeks)
+4. **Expand AzureEntraSearcher** to full AD replacement
+   - Implement all `IActiveDirectorySearcher` methods
+   - Add configuration option to choose AD provider
+   - Files affected: ~10
+   - **Windows Compatibility**: All versions (cloud-based)
+
+5. **Replace WMI with SSH/REST**
+   - Implement cross-platform server management
+   - Files affected: ~9
+   - **Windows Compatibility**: SSH.NET supports all Windows versions
+   - **PowerShell Remoting**: Requires Windows Server 2012+
+
+### Phase 3: Long-term (3-6 months)
+6. **Refactor password reset** to use service accounts
+   - Remove Windows impersonation dependency
+   - Use Azure Key Vault or similar
+   - Files affected: 2-3
+   - **Windows Compatibility**: All versions (service-based)
+
+7. **Implement LDAP alternative** for on-premises without Azure
+   - Use `Novell.Directory.Ldap`
+   - Provide configuration-based switching
+   - Files affected: ~10
+   - **Windows Compatibility**: Windows 7+, Windows Server 2008+
+
+---
+
+## Windows OS Compatibility Summary
+
+### Current Windows Dependencies - Minimum Requirements
+
+| Dependency | Minimum Windows Version | Recommended | Notes |
+|------------|------------------------|-------------|-------|
+| **System.DirectoryServices** | Windows 7 / Server 2008 | Server 2012+ | Requires domain membership |
+| **System.DirectoryServices.AccountManagement** | Windows 7 / Server 2008 | Server 2012+ | Requires domain membership |
+| **System.Management (WMI)** | Windows 7 / Server 2008 | Server 2012+ | Works on all Windows versions |
+| **Windows Registry** | Windows 7 / Server 2008 | Any | Universal Windows support |
+| **WindowsIdentity/Impersonation** | Windows 7 / Server 2008 | Server 2012+ | Domain authentication required |
+| **PowerShell 5.1** | Windows 7 / Server 2008 | N/A | Legacy only |
+| **PowerShell 7+** | Server 2012+ | Server 2016+ | Limited support on Win 7/2008 |
+
+### Proposed Cross-Platform Alternatives - Windows Compatibility
+
+| Alternative | Windows 7 | Server 2008 | Server 2012+ | Linux | macOS | Notes |
+|-------------|-----------|-------------|--------------|-------|-------|-------|
+| **Microsoft Graph** | ✅ | ✅ | ✅ | ✅ | ✅ | Cloud-based, no OS restrictions |
+| **Azure.Identity** | ✅ | ✅ | ✅ | ✅ | ✅ | Cloud-based authentication |
+| **Novell.Directory.Ldap** | ✅ | ✅ | ✅ | ✅ | ✅ | LDAP access required |
+| **OAuth2/JWT** | ✅ | ✅ | ✅ | ✅ | ✅ | Modern authentication |
+| **SSH.NET** | ✅ | ✅ | ✅ | ✅ | ✅ | SSH server required on target |
+| **PowerShell 7+** | ⚠️ | ⚠️ | ✅ | ✅ | ✅ | Limited on Win7/2008R2 |
+| **RuntimeInformation** | ✅ | ✅ | ✅ | ✅ | ✅ | Built-in .NET 8 |
+
+**Legend:**
+- ✅ Fully supported
+- ⚠️ Limited support or requires updates
+- ❌ Not supported
+
+### Historic Windows OS Support Notes
+
+**Windows 7 / Server 2008:**
+- ✅ Can use Microsoft Graph (cloud-based, no OS dependency)
+- ✅ Can use Novell.Directory.Ldap for LDAP
+- ✅ Can use OAuth2/JWT authentication
+- ✅ Can use SSH.NET for remote management
+- ⚠️ PowerShell 7+ has limited functionality (recommend PowerShell 5.1 fallback)
+- ✅ RuntimeInformation works perfectly
+
+**Windows Server 2012+:**
+- ✅ All proposed alternatives fully supported
+- ✅ Full PowerShell 7+ support
+- ✅ Recommended minimum for modern deployments
+
+**Recommendation for Legacy Windows Support:**
+- For organizations running Windows 7 or Server 2008, use Microsoft Graph or Novell.Directory.Ldap
+- Both provide full functionality on legacy Windows versions
+- Consider upgrading to Windows Server 2012+ for PowerShell 7+ features
+
+---
+
+## Cross-Platform Compatibility Matrix
+
+### Summary by Dependency Category
+
+| Category | Windows-Only Files | Cross-Platform Alternative | Effort | Windows 7 Support | Server 2008 Support |
+|----------|-------------------|---------------------------|--------|-------------------|---------------------|
+| **Active Directory** | 9 core files | Microsoft Graph / LDAP | 2-3 weeks | ✅ Full | ✅ Full |
+| **Windows Auth** | 9 files | OAuth2/JWT | 1 week | ✅ Full | ✅ Full |
+| **WMI** | 9 files | SSH.NET / REST | 1-2 weeks | ✅ Full | ✅ Full |
+| **Registry** | 14 files | RuntimeInformation | 1-2 hours | ✅ Full | ✅ Full |
+| **PowerShell** | Legacy only | PowerShell 7+ | 0 (already done) | ⚠️ Limited | ⚠️ Limited |
+
+### Detailed File Inventory
+
+**Total Files Requiring Changes: ~40 files**
+
+#### By Project:
+- **Dorc.Api**: 6 controllers, 4 services, ~10 files total
+- **Dorc.Api.Windows**: 6 controllers, 8 service files, ~14 files total
+- **Dorc.Core**: 2 core files (ActiveDirectorySearcher, ServiceStatus)
+- **Dorc.Monitor**: 8 interop files (all Windows P/Invoke)
+- **Dorc.Runner**: 1 file (Program.cs)
+- **Dorc.TerraformRunner**: 1 file (Program.cs)
+- **Dorc.PowerShell**: 1 file (PowerShellScriptRunner.cs)
+- **Tools**: 2 CLI tools
+- **Tests**: 2 test files
+
+#### Priority Grouping:
+
+**High Priority (Linux blockers):**
+1. Registry API in `RefDataServersController.cs` - 1 file
+2. WMI in `WmiUtil.cs` - 1 file
+3. Service-based authentication setup - 2 files
+
+**Medium Priority (Can use Windows API fallback):**
+4. Active Directory search operations - 9 files
+5. Windows Authentication - 9 files
+
+**Low Priority (Can defer or deprecate):**
+6. .NET Framework projects - 5 files
+7. Monitor interop (Windows-specific by design) - 8 files
+
+---
+
+## Implementation Strategy
+
+### Recommended Approach: Phased Migration
+
+**Phase 1: Enable Linux Deployment (Week 1-2)**
+1. Replace Registry API (1 hour)
+2. Configure OAuth2 as primary authentication (already done)
+3. Deploy Windows API on Windows server
+4. Configure Linux API to proxy Windows-specific calls
+5. **Result**: Linux deployment enabled, full backward compatibility
+
+**Phase 2: Reduce Windows Dependencies (Week 3-6)**
+6. Implement Microsoft Graph for AD operations
+7. Implement SSH.NET for WMI replacement
+8. Add configuration switches for provider selection
+9. **Result**: 80% Windows-independent, optional Windows API
+
+**Phase 3: Full Cross-Platform (Month 2-3)**
+10. Complete LDAP alternative implementation
+11. Migrate all authentication to OAuth2
+12. Deprecate .NET Framework projects
+13. **Result**: 100% cross-platform capable
+
+### Configuration-Based Provider Selection
+
+```json
+{
+  "AppSettings": {
+    "DirectoryProvider": "MicrosoftGraph",  // Options: "ActiveDirectory", "MicrosoftGraph", "Ldap", "WindowsApi"
+    "ServerManagementProvider": "SSH",      // Options: "WMI", "SSH", "REST"
+    "MinimumWindowsVersion": "Server2012",  // For validation
+    "MicrosoftGraph": {
+      "TenantId": "...",
+      "ClientId": "...",
+      "ClientSecret": "..."
+    },
+    "Ldap": {
+      "Server": "ldap.company.com",
+      "Port": 389,
+      "BaseDn": "dc=company,dc=com"
+    },
+    "WindowsApi": {
+      "Url": "https://windows-server:5002"
+    }
+  }
+}
+```
+
+---
+
+## Conclusion
+
+The Dorc codebase has **manageable** Windows dependencies affecting ~40 files. Key findings:
+
+1. **All alternatives support Windows 7 and Server 2008+** - No compatibility concerns for legacy Windows
+2. **9 files** use Active Directory - Replaceable with Microsoft Graph (fully backward compatible) or LDAP
+3. **9 files** use Windows Identity - OAuth2 already available (works on all Windows versions)
+4. **9 files** use WMI - Replaceable with SSH.NET (supports all Windows versions)
+5. **PowerShell is already cross-platform** via PowerShell 7+ (Server 2012+ recommended)
+
+**Current Split Architecture** (Dorc.Api + Dorc.Api.Windows) is a good solution that:
+- ✅ Enables immediate Linux deployment
+- ✅ Maintains full Windows compatibility (Windows 7+)
+- ✅ Keeps Windows-specific features working
+- ✅ Provides clear migration path
+- ✅ No breaking changes for existing Windows deployments
+
+**For organizations with Windows 7 or Server 2008:**
+- All proposed alternatives (Microsoft Graph, Novell.Directory.Ldap, OAuth2, SSH.NET) work perfectly
+- Only limitation: PowerShell 7+ has reduced functionality (use PowerShell 5.1 fallback)
+- **Recommendation**: All alternatives are production-ready for legacy Windows
+
+**Recommended Next Steps:**
+1. Replace Registry API usage (1 hour) - Works on all Windows versions
+2. Expand Microsoft Graph implementation (2-3 days) - Cloud-based, version-independent
+3. Create configuration-based provider switching (1-2 days)
+4. Implement SSH-based server management (3-5 days) - Supports all Windows versions
+
+**Total effort for full cross-platform migration: 2-4 weeks**
+
+**Windows compatibility guarantee: All proposed solutions support Windows 7+ and Windows Server 2008+**


### PR DESCRIPTION
## Summary

First of a five-PR stack replacing #706, which had grown from an HLPS draft into planning docs *plus* production code, tests and a CI workflow in 15 commits — too large to review as one unit, and conflicting with `main`.

This PR is the **HLPS planning checkpoint only**: `docs/api-split/HLPS-api-split.md` plus the five analysis documents carried over from the superseded #424 so the investigation isn't lost.

Documentation-only. No code, no build, no installer changes.

## The stack

| PR | Content | Base |
|----|---------|------|
| **1/5 (this)** | HLPS + research docs | `main` |
| 2/5 | Implementation Sequence | 1/5 |
| 3/5 | SPEC-S-001 (Graph migration) | 2/5 |
| 4/5 | AD→Graph production code + tests | 3/5 |
| 5/5 | Linux build CI gate | 4/5 |

The split follows the CLAUDE.md planning checkpoints (HLPS → IS → JIT Spec), each independently approvable by the review panel. PR 5 must land after PR 4 — the gate can only pass once the Windows-only refs are gone.

## Why this exists

#424 was closed unmerged because it bundled the structural split with a bulk class-rename pass that misread CLAUDE.md's naming rule as a banned-words blacklist, wide drift after daemons-modernisation (#649), and three unresolved architectural decisions baked into code without sign-off. This HLPS unwinds those and asks the architecture owner to resolve the unknowns first.

## Review focus

Per CLAUDE.md, plans are evaluated on clarity, ordering and completeness — not syntactic correctness. The Unknowns Register (§7) is the part that needs architecture-owner input.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4oyf4T5zBgSWiztdzMBmy)_