### PR TITLE
S-021: bind deployment execution identity to the environment

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -49,7 +49,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | S-017, U-14; **lockstep release** |
 | S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **Server side DONE**; web UI outstanding, see the step |
 | S-020 | Introduce the credential provider abstraction | SD-4 | **DONE** |
-| S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07 | S-020; revisits S-007, S-008, S-009 |
+| S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07 | **Binding DONE** — opt-in per environment; W-8a follows |
 | S-022 | Record attribution reached and not reached | SD-8, W-9 | S-021 |
 | S-023 | Replace the expression compiler with a fixed grammar | SD-1b, W-1 | **DONE** |
 
@@ -456,6 +456,16 @@ Binding granularity is by sensitivity tier rather than per environment: the esta
 **Also picks up W-8a**, deferred out of S-007: the local Terraform plan directory is shared across deployments, so restricting it needs the environment-dependent identity this step introduces, and its retention question is entangled with the plan/apply blob handshake rather than being housekeeping.
 
 **Verification intent.** An environment with a configured identity deploys under it on both dispatch paths and both API-side sites. An environment without one deploys exactly as before. No resolution site returns a credential for an environment it is not bound to. The fallback count is reportable.
+
+**Nothing changes until an operator names an identity.** The environment's identity reference is nullable and null on every existing row, and a null reference resolves the tier default by exactly the path it did before. That is what makes this shippable without a migration event: the estate holds well over a thousand environments and they move one at a time, on whatever schedule the target-server access control lists allow (**U-9**).
+
+**An unresolvable named identity refuses rather than falling back.** If an environment names an identity and that identity cannot be resolved — the configuration keys are absent, or the vault item is not there — the resolution returns nothing and the deployment fails with a named reason. Falling back to the shared account would be the worst of both worlds: the operator would believe the environment was bound while it was in fact still deploying under the credential the binding exists to stop using, and the fallback count would report progress that had not happened.
+
+**Where the count is reported.** Once per request, from the Monitor's request processor, as bound-versus-fallback resolutions. A refused identity counts as neither, deliberately — it is a failure, not a migration state, and folding it into either number would make an outage look like progress or like regression.
+
+**The password reset controller is bound by identity but not by tier.** It resolves the environment's identity reference like every other site, so an environment that names one resets passwords under it. Its hard-coded non-production tier is left exactly as it was: correcting it would begin making production logons from the API process where none were made before, which is a change of behaviour for whoever owns that endpoint to make, not a side effect of this step. Both halves are now visible at one call site.
+
+**The Terraform gate insertion point was not established.** This step recorded that the Terraform component branch has no equivalent of the PowerShell branch's production-only gate, and that its insertion point must be found before identity gating can be applied uniformly. It has not been found. What this step delivers on the Terraform branch is identity *binding*, not identity *gating* — the Terraform dispatcher resolves the environment's identity exactly as the PowerShell one does, but there is still no place on that branch where a component is refused for being production-bound. That is unchanged from before this step and is not made worse by it; it is recorded here rather than closed.
 
 ### S-022 — Record attribution reached and not reached
 

--- a/src/Dorc.Api/Controllers/ResetAppPasswordController.cs
+++ b/src/Dorc.Api/Controllers/ResetAppPasswordController.cs
@@ -22,6 +22,7 @@ namespace Dorc.Api.Controllers
     public class ResetAppPasswordController : ControllerBase
     {
         private readonly IDatabasesPersistentSource _databasesPersistentSource;
+        private readonly IEnvironmentsPersistentSource _environmentsPersistentSource;
         private readonly IDeploymentCredentialSource _credentialSource;
         private readonly ISqlUserPasswordReset _sqlUserPasswordReset;
         private readonly IConfigValuesPersistentSource _configValuesPersistentSource;
@@ -37,8 +38,10 @@ namespace Dorc.Api.Controllers
             ISecurityPrivilegesChecker securityPrivilegesChecker,
             IConfigurationSettings configurationSettingsEngine,
             IClaimsPrincipalReader claimsPrincipalReader,
+            IEnvironmentsPersistentSource environmentsPersistentSource,
             IDeploymentCredentialSource credentialSource)
         {
+            _environmentsPersistentSource = environmentsPersistentSource;
             _credentialSource = credentialSource;
             _securityPrivilegesChecker = securityPrivilegesChecker;
             _logger = logger;
@@ -79,7 +82,15 @@ namespace Dorc.Api.Controllers
                     return Ok(new ApiBoolResult
                     { Message = $"No application database found for environment '{envName}' with users of login type '{envFilter}'", Result = false });
 
-                return Ok(ResetSqlServerPasswordForUser(username, db.ServerName));
+                // The environment is read for its execution identity, not for authorization -
+                // that has already been decided by the caller. A name that resolves to nothing
+                // leaves the identity unset, which is the same as an environment that names none.
+                var environment = _environmentsPersistentSource.GetEnvironment(envName, User);
+
+                return Ok(ResetSqlServerPasswordForUser(
+                    username,
+                    db.ServerName,
+                    environment?.ExecutionIdentityReference));
             }
             catch (Exception e)
             {
@@ -88,14 +99,22 @@ namespace Dorc.Api.Controllers
             }
         }
 
-        private ApiBoolResult ResetSqlServerPasswordForUser(string username, string serverName)
+        private ApiBoolResult ResetSqlServerPasswordForUser(
+            string username, string serverName, string? executionIdentityReference)
         {
-            // The fourth resolution site, and the one whose hard-coded tier is worth noting: it
+            // Environment-keyed, like every other resolution site: an environment naming its own
+            // execution identity resets passwords under it, and one naming none behaves exactly as
+            // before.
+            //
+            // The hard-coded TIER is still preserved rather than quietly corrected. This site
             // resolves the NON-PRODUCTION credential regardless of the server it is resetting a
-            // password on. That is preserved here rather than quietly changed - whether it is
-            // deliberate or a latent defect is a question for whoever owns this endpoint, and
-            // making it environment-keyed is the next step's business.
-            var credential = _credentialSource.Resolve(DeploymentTier.NonProduction);
+            // password on; whether that is deliberate or a latent defect is a question for
+            // whoever owns this endpoint, and changing it would start making production logons
+            // where none were made before. Naming an identity on the environment is opt-in and
+            // reversible, so it is the safe half of the binding to apply here.
+            var credential = _credentialSource.Resolve(
+                DeploymentTier.NonProduction,
+                executionIdentityReference);
 
             var domainName = _configurationSettingsEngine.GetConfigurationDomainNameIntra();
 

--- a/src/Dorc.ApiModel/EnvironmentAPIModel.cs
+++ b/src/Dorc.ApiModel/EnvironmentAPIModel.cs
@@ -9,6 +9,15 @@ namespace Dorc.ApiModel
         public string EnvironmentName { get; set; }
         public bool EnvironmentSecure { get; set; }
         public bool EnvironmentIsProd { get; set; }
+
+        /// <summary>
+        /// The execution identity this environment deploys under, or null/empty to use the tier
+        /// default. Names a credential rather than carrying one.
+        ///
+        /// Not annotated nullable: this assembly is shared with the .NET Framework runner and
+        /// compiles at C# 7.3.
+        /// </summary>
+        public string ExecutionIdentityReference { get; set; }
         public bool UserEditable { get; set; }
         public bool IsOwner { get; set; }
         public int? ParentId { get; set; }

--- a/src/Dorc.Core.Tests/DeploymentCredentialSourceTests.cs
+++ b/src/Dorc.Core.Tests/DeploymentCredentialSourceTests.cs
@@ -1,4 +1,4 @@
-using Dorc.Core.Configuration;
+﻿using Dorc.Core.Configuration;
 using Dorc.Core.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -159,6 +159,98 @@ namespace Dorc.Core.Tests
 
             Assert.AreEqual(fromConfig!.UserName, fromVault!.UserName);
             Assert.AreEqual(fromConfig.Password, fromVault.Password);
+        }
+    }
+    /// <summary>
+    /// Execution identity was a boolean — production or not — which is why one compromised
+    /// deployment reaches the whole estate. An environment may now name its own identity.
+    ///
+    /// The interesting property is a negative one: an environment that names nothing must
+    /// resolve exactly as it did before. That is what lets migration proceed environment by
+    /// environment instead of as a flag day, and it is why the keying and the fallback
+    /// accounting live in one shared place rather than once per implementation.
+    /// </summary>
+    [TestClass]
+    public class EnvironmentKeyedCredentialResolutionTests
+    {
+        private IConfigValuesPersistentSource _configValues = null!;
+        private ConfigValueDeploymentCredentialSource _source = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _configValues = Substitute.For<IConfigValuesPersistentSource>();
+            _configValues.GetConfigValue("DORC_NonProdDeployUsername").Returns("svc-shared");
+            _configValues.GetConfigValue("DORC_NonProdDeployPassword").Returns("shared-secret");
+            _configValues.GetConfigValue("DORC_Deploy_trading-tier_Username").Returns("svc-trading");
+            _configValues.GetConfigValue("DORC_Deploy_trading-tier_Password").Returns("trading-secret");
+
+            _source = new ConfigValueDeploymentCredentialSource(
+                _configValues,
+                Substitute.For<ILogger<ConfigValueDeploymentCredentialSource>>());
+        }
+
+        [TestMethod]
+        public void AnEnvironmentNamingAnIdentityDeploysUnderIt()
+        {
+            var credential = _source.Resolve(DeploymentTier.NonProduction, "trading-tier");
+
+            Assert.AreEqual("svc-trading", credential!.UserName);
+        }
+
+        /// <summary>
+        /// The property that makes this safe to ship.
+        /// </summary>
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public void AnEnvironmentNamingNothingResolvesExactlyAsBefore(string? identityReference)
+        {
+            var credential = _source.Resolve(DeploymentTier.NonProduction, identityReference);
+
+            Assert.AreEqual("svc-shared", credential!.UserName);
+        }
+
+        /// <summary>
+        /// Deliberately NOT a fallback. An environment bound to an identity was bound on
+        /// purpose; quietly running it under the shared account would undo the binding without
+        /// anyone noticing, and the whole point of binding is that one compromised deployment
+        /// does not reach the estate.
+        /// </summary>
+        [TestMethod]
+        public void AnUnresolvableIdentityRefusesRatherThanFallingBackToTheSharedAccount()
+        {
+            Assert.IsNull(_source.Resolve(DeploymentTier.NonProduction, "no-such-identity"));
+        }
+
+        /// <summary>
+        /// "We have started binding identities" is not the same claim as "the estate is bound".
+        /// Reported from the count rather than from a configuration flag, so it cannot be wrong.
+        /// </summary>
+        [TestMethod]
+        public void CountsBoundResolutionsSeparatelyFromFallbacks()
+        {
+            _source.Resolve(DeploymentTier.NonProduction, "trading-tier");
+            _source.Resolve(DeploymentTier.NonProduction, null);
+            _source.Resolve(DeploymentTier.NonProduction, "   ");
+
+            var (bound, fallback) = _source.ResolutionCounts;
+
+            Assert.AreEqual(1, bound);
+            Assert.AreEqual(2, fallback);
+        }
+
+        /// <summary>
+        /// A refused identity is neither bound nor a fallback — counting it as either would
+        /// misreport migration progress in one direction or the other.
+        /// </summary>
+        [TestMethod]
+        public void ARefusedIdentityCountsAsNeither()
+        {
+            _source.Resolve(DeploymentTier.NonProduction, "no-such-identity");
+
+            Assert.AreEqual((0, 0), _source.ResolutionCounts);
         }
     }
 }

--- a/src/Dorc.Core/DaemonStatusProbe.cs
+++ b/src/Dorc.Core/DaemonStatusProbe.cs
@@ -179,7 +179,8 @@ namespace Dorc.Core
             var credential = _credentialSource.Resolve(
                 environment?.EnvironmentIsProd == true
                     ? DeploymentTier.Production
-                    : DeploymentTier.NonProduction);
+                    : DeploymentTier.NonProduction,
+                environment?.ExecutionIdentityReference);
 
             // Empty rather than a substitute. The caller performs a LogonUser with these; an
             // empty pair fails that call, where a fallback would authenticate as whatever the

--- a/src/Dorc.Core/Security/ConfigValueDeploymentCredentialSource.cs
+++ b/src/Dorc.Core/Security/ConfigValueDeploymentCredentialSource.cs
@@ -1,4 +1,4 @@
-using Dorc.PersistentData.Sources.Interfaces;
+﻿using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
 
 namespace Dorc.Core.Security
@@ -11,7 +11,7 @@ namespace Dorc.Core.Security
     /// credentials come from. The vault-backed source is the migration target; switching is a
     /// configuration change rather than a code change, which is the point.
     /// </summary>
-    public class ConfigValueDeploymentCredentialSource : IDeploymentCredentialSource
+    public class ConfigValueDeploymentCredentialSource : DeploymentCredentialSource
     {
         internal const string ProductionUserNameKey = "DORC_ProdDeployUsername";
         internal const string ProductionPasswordKey = "DORC_ProdDeployPassword";
@@ -19,19 +19,34 @@ namespace Dorc.Core.Security
         internal const string NonProductionPasswordKey = "DORC_NonProdDeployPassword";
 
         private readonly IConfigValuesPersistentSource _configValues;
-        private readonly ILogger _logger;
 
         public ConfigValueDeploymentCredentialSource(
             IConfigValuesPersistentSource configValues,
             ILogger<ConfigValueDeploymentCredentialSource> logger)
+            : base(logger)
         {
             _configValues = configValues;
-            _logger = logger;
         }
 
-        public string Description => "DOrc configuration values";
+        public override string Description => "DOrc configuration values";
 
-        public DeploymentCredential? Resolve(DeploymentTier tier)
+        /// <summary>
+        /// A named identity maps to its own pair of configuration keys,
+        /// <c>DORC_Deploy_&lt;identity&gt;_Username</c> and <c>..._Password</c>. Per-identity
+        /// keys rather than a fixed set is exactly why the reserved-key denylist could not cover
+        /// this variant on its own - a fixed list cannot name keys minted per environment - and
+        /// why the per-value classification had to exist first.
+        /// </summary>
+        protected override DeploymentCredential? ResolveNamedIdentity(string identityReference, DeploymentTier tier)
+        {
+            var credential = new DeploymentCredential(
+                _configValues.GetConfigValue($"DORC_Deploy_{identityReference}_Username") ?? string.Empty,
+                _configValues.GetConfigValue($"DORC_Deploy_{identityReference}_Password") ?? string.Empty);
+
+            return credential.IsComplete ? credential : null;
+        }
+
+        protected override DeploymentCredential? ResolveTierDefault(DeploymentTier tier)
         {
             var userNameKey = tier == DeploymentTier.Production
                 ? ProductionUserNameKey
@@ -51,7 +66,7 @@ namespace Dorc.Core.Security
                 // authenticates as whatever the host is running as, and the previous copies of
                 // this logic reported only that "a valid DOrc Username or Password" was missing
                 // without saying which key was empty.
-                _logger.LogError(
+                Logger.LogError(
                     "No {Tier} deployment credential could be resolved from {Source}."
                     + " '{UserNameKey}' is {UserNameState} and '{PasswordKey}' is {PasswordState}.",
                     tier,

--- a/src/Dorc.Core/Security/DeploymentCredentialSource.cs
+++ b/src/Dorc.Core/Security/DeploymentCredentialSource.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Dorc.Core.Security
+{
+    /// <summary>
+    /// The environment-keying and fallback accounting shared by every credential source.
+    ///
+    /// It lives in one place because the interesting property is a negative one: an environment
+    /// that names no identity must resolve *exactly* as it did before. Two implementations of
+    /// that rule would be two chances to get the fallback subtly wrong, and the failure mode is
+    /// silent — a deployment that runs under the wrong account still succeeds.
+    /// </summary>
+    public abstract class DeploymentCredentialSource : IDeploymentCredentialSource
+    {
+        private int _bound;
+        private int _fallback;
+
+        protected DeploymentCredentialSource(ILogger logger)
+        {
+            Logger = logger;
+        }
+
+        protected ILogger Logger { get; }
+
+        public abstract string Description { get; }
+
+        public (int Bound, int Fallback) ResolutionCounts => (_bound, _fallback);
+
+        public DeploymentCredential? Resolve(DeploymentTier tier) => Resolve(tier, identityReference: null);
+
+        public DeploymentCredential? Resolve(DeploymentTier tier, string? identityReference)
+        {
+            if (string.IsNullOrWhiteSpace(identityReference))
+            {
+                Interlocked.Increment(ref _fallback);
+                return ResolveTierDefault(tier);
+            }
+
+            var credential = ResolveNamedIdentity(identityReference.Trim(), tier);
+
+            if (credential == null)
+            {
+                // Deliberately NOT a fallback to the tier default. An environment that names an
+                // identity has been bound on purpose; quietly running it under the shared
+                // account instead would undo the binding without anyone noticing, and the whole
+                // point of binding is that one compromised deployment does not reach the estate.
+                Logger.LogError(
+                    "Environment identity '{IdentityReference}' could not be resolved from {Source}."
+                    + " Refusing to fall back to the {Tier} default - an environment bound to an"
+                    + " identity must not silently run under the shared account.",
+                    identityReference,
+                    Description,
+                    tier);
+
+                return null;
+            }
+
+            Interlocked.Increment(ref _bound);
+            return credential;
+        }
+
+        protected abstract DeploymentCredential? ResolveTierDefault(DeploymentTier tier);
+
+        /// <summary>
+        /// The credential for a named identity, or null when this source does not hold one.
+        /// </summary>
+        protected abstract DeploymentCredential? ResolveNamedIdentity(string identityReference, DeploymentTier tier);
+    }
+}

--- a/src/Dorc.Core/Security/DeploymentCredentials.cs
+++ b/src/Dorc.Core/Security/DeploymentCredentials.cs
@@ -1,4 +1,4 @@
-namespace Dorc.Core.Security
+﻿namespace Dorc.Core.Security
 {
     /// <summary>
     /// Which population a deployment belongs to, and therefore which credential pair it runs
@@ -65,6 +65,27 @@ namespace Dorc.Core.Security
         /// authenticates as whatever the host happens to be running as.
         /// </summary>
         DeploymentCredential? Resolve(DeploymentTier tier);
+
+        /// <summary>
+        /// The credential for an environment: its own execution identity where it names one,
+        /// and the tier default where it does not.
+        ///
+        /// Execution identity was a boolean — production or not — which is why one compromised
+        /// deployment reaches the whole estate. An environment may now name its own identity,
+        /// and one that does not behaves exactly as before, so migration proceeds environment by
+        /// environment rather than as a flag day.
+        /// </summary>
+        /// <param name="identityReference">
+        /// The environment's identity reference, or null/empty for the tier default.
+        /// </param>
+        DeploymentCredential? Resolve(DeploymentTier tier, string? identityReference);
+
+        /// <summary>
+        /// How many resolutions have fallen back to the tier default, and how many used an
+        /// environment's own identity. Migration progress is otherwise invisible, and "we have
+        /// started binding identities" is not the same claim as "the estate is bound".
+        /// </summary>
+        (int Bound, int Fallback) ResolutionCounts { get; }
 
         /// <summary>
         /// Where this implementation reads from, for logging. Which source is in force is

--- a/src/Dorc.Core/Security/VaultDeploymentCredentialSource.cs
+++ b/src/Dorc.Core/Security/VaultDeploymentCredentialSource.cs
@@ -1,4 +1,4 @@
-using Dorc.Core.Configuration;
+﻿using Dorc.Core.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Dorc.Core.Security
@@ -17,25 +17,38 @@ namespace Dorc.Core.Security
     /// question with a configured answer, not an architectural dependency — which is the point
     /// of having two implementations rather than moving everything to one.
     /// </summary>
-    public class VaultDeploymentCredentialSource : IDeploymentCredentialSource
+    public class VaultDeploymentCredentialSource : DeploymentCredentialSource
     {
         private readonly IConfigurationSecretsReader _secrets;
         private readonly IConfigurationSettings _configuration;
-        private readonly ILogger _logger;
 
         public VaultDeploymentCredentialSource(
             IConfigurationSecretsReader secrets,
             IConfigurationSettings configuration,
             ILogger<VaultDeploymentCredentialSource> logger)
+            : base(logger)
         {
             _secrets = secrets;
             _configuration = configuration;
-            _logger = logger;
         }
 
-        public string Description => "the secrets vault";
+        public override string Description => "the secrets vault";
 
-        public DeploymentCredential? Resolve(DeploymentTier tier)
+        /// <summary>
+        /// A named identity is a vault item reference in its own right, so no per-identity
+        /// configuration is needed - the environment's reference IS the lookup key. This is the
+        /// variant that scales to a thousand environments without a thousand config rows.
+        /// </summary>
+        protected override DeploymentCredential? ResolveNamedIdentity(string identityReference, DeploymentTier tier)
+        {
+            var credential = new DeploymentCredential(
+                _secrets.GetSecret($"{identityReference}-username", $"{identityReference} deployment username"),
+                _secrets.GetSecret($"{identityReference}-password", $"{identityReference} deployment password"));
+
+            return credential.IsComplete ? credential : null;
+        }
+
+        protected override DeploymentCredential? ResolveTierDefault(DeploymentTier tier)
         {
             var userNameItem = _configuration.GetDeploymentCredentialItemId(tier, forPassword: false);
             var passwordItem = _configuration.GetDeploymentCredentialItemId(tier, forPassword: true);
@@ -45,7 +58,7 @@ namespace Dorc.Core.Security
                 // Selected as the source but not told where to look. Refusing is the only safe
                 // answer: falling back to configuration values would silently undo the choice to
                 // stop keeping deployment credentials in DOrc's database.
-                _logger.LogError(
+                Logger.LogError(
                     "The {Tier} deployment credential is configured to come from {Source}, but its"
                     + " vault item identifiers are not set. Refusing to fall back to configuration"
                     + " values.",
@@ -61,7 +74,7 @@ namespace Dorc.Core.Security
 
             if (!credential.IsComplete)
             {
-                _logger.LogError(
+                Logger.LogError(
                     "No {Tier} deployment credential could be retrieved from {Source}."
                     + " The username item returned {UserNameState} and the password item returned"
                     + " {PasswordState}.",

--- a/src/Dorc.Database/Schema Objects/Schemas/deploy/Tables/Environment.table.sql
+++ b/src/Dorc.Database/Schema Objects/Schemas/deploy/Tables/Environment.table.sql
@@ -12,6 +12,15 @@
     [Description]        NVARCHAR (MAX)   NULL,
     [LastUpdate]         DATETIME         NULL,
     [ParentId]           INT              NULL REFERENCES [deploy].[Environment] (Id), 
+    -- Names the execution identity this environment deploys under, or NULL to use the tier
+    -- default. Optional and NULL by default so that adding it changes nothing: an environment
+    -- with no reference deploys exactly as before, and migration proceeds environment by
+    -- environment rather than as a flag day.
+    --
+    -- A reference rather than a credential. Granularity is by sensitivity tier in practice -
+    -- the estate holds well over a thousand environments and an account each is not viable -
+    -- but the column is per environment so the cases that warrant their own can have one.
+    [ExecutionIdentityReference] NVARCHAR (128) NULL, 
     CONSTRAINT [PK_Environment] PRIMARY KEY CLUSTERED ([Id] ASC), 
     CONSTRAINT [ParentId_not_itself] CHECK ([Id]!=[ParentId])
 );

--- a/src/Dorc.Monitor.Tests/PendingRequestProcessorStopOnFailureTests.cs
+++ b/src/Dorc.Monitor.Tests/PendingRequestProcessorStopOnFailureTests.cs
@@ -5,6 +5,7 @@ using Dorc.Core.Events;
 using Dorc.Core.Interfaces;
 using Dorc.Core.VariableResolution;
 using Dorc.Monitor.RequestProcessors;
+using Dorc.Core.Security;
 using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
@@ -86,7 +87,8 @@ namespace Dorc.Monitor.Tests
                 mockPropertyEvaluator,
                 mockEventsPublisher,
                 mockGitHubArtifactDownloader,
-                Substitute.For<IScriptScopeConfigValues>());
+                Substitute.For<IScriptScopeConfigValues>(),
+                Substitute.For<IDeploymentCredentialSource>());
         }
 
         private static RequestToProcessDto CreateRequest(List<ComponentApiModel> components)
@@ -145,7 +147,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(false);
 
@@ -153,7 +155,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp2, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(true);
 
@@ -164,7 +166,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DidNotReceive().DeployComponent(
                 comp2, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>());
 
             // Assert - request marked as Failed
@@ -190,14 +192,14 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(false);
 
             mockComponentProcessor.DeployComponent(
                 comp2, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(true);
 
@@ -208,7 +210,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.Received().DeployComponent(
                 comp2, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>());
         }
 
@@ -239,7 +241,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(false);
 
@@ -267,7 +269,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(x => throw new InvalidOperationException("Script failed"));
 
@@ -278,7 +280,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DidNotReceive().DeployComponent(
                 comp2, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>());
         }
 
@@ -300,7 +302,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(true);
 
@@ -347,7 +349,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(x => throw new InvalidOperationException("deployment blew up"));
 
@@ -383,7 +385,7 @@ namespace Dorc.Monitor.Tests
             mockComponentProcessor.DeployComponent(
                 comp1, Arg.Any<DeploymentResultApiModel>(),
                 Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<bool>(),
-                Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string>(),
                 Arg.Any<IDictionary<string, VariableValue>>(), Arg.Any<CancellationToken>())
                 .Returns(true);
 

--- a/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
@@ -47,7 +47,11 @@ namespace Dorc.Monitor.Tests
         {
             var source = Substitute.For<IDeploymentCredentialSource>();
             source.Description.Returns("test");
+            // Both overloads: the dispatchers call the environment-keyed one, and NSubstitute
+            // treats them as separate members.
             source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential(userName, password));
+            source.Resolve(Arg.Any<DeploymentTier>(), Arg.Any<string?>())
                 .Returns(new DeploymentCredential(userName, password));
             return source;
         }
@@ -62,9 +66,9 @@ namespace Dorc.Monitor.Tests
         {
             var source = Substitute.For<IDeploymentCredentialSource>();
             source.Description.Returns("test");
-            source.Resolve(DeploymentTier.Production)
+            source.Resolve(DeploymentTier.Production, Arg.Any<string?>())
                 .Returns(new DeploymentCredential(ProdAccount, "prod-password"));
-            source.Resolve(DeploymentTier.NonProduction)
+            source.Resolve(DeploymentTier.NonProduction, Arg.Any<string?>())
                 .Returns(new DeploymentCredential(NonProdAccount, "nonprod-password"));
             return source;
         }
@@ -119,6 +123,7 @@ namespace Dorc.Monitor.Tests
                     deploymentRequestId: 42,
                     isProduction: isProduction,
                     environmentName: "SOME-ENV",
+                    executionIdentityReference: null,
                     new StringBuilder(),
                     CancellationToken.None);
             }
@@ -256,7 +261,11 @@ namespace Dorc.Monitor.Tests
         {
             var source = Substitute.For<IDeploymentCredentialSource>();
             source.Description.Returns("test");
+            // Both overloads: the dispatchers call the environment-keyed one, and NSubstitute
+            // treats them as separate members.
             source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential(userName, password));
+            source.Resolve(Arg.Any<DeploymentTier>(), Arg.Any<string?>())
                 .Returns(new DeploymentCredential(userName, password));
             return source;
         }
@@ -304,6 +313,7 @@ namespace Dorc.Monitor.Tests
                 deploymentRequestId: 42,
                 isProduction: true,
                 environmentName: "SOME-ENV",
+                executionIdentityReference: null,
                 new StringBuilder(),
                 CancellationToken.None));
 

--- a/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
@@ -42,7 +42,11 @@ namespace Dorc.Monitor.Tests
         {
             var source = Substitute.For<IDeploymentCredentialSource>();
             source.Description.Returns("test");
+            // Both overloads: the dispatchers call the environment-keyed one, and NSubstitute
+            // treats them as separate members.
             source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential(userName, password));
+            source.Resolve(Arg.Any<DeploymentTier>(), Arg.Any<string?>())
                 .Returns(new DeploymentCredential(userName, password));
             return source;
         }
@@ -88,6 +92,7 @@ namespace Dorc.Monitor.Tests
                     deploymentRequestId: 42,
                     isProduction: false,
                     environmentName: "SOME-ENV",
+                    executionIdentityReference: null,
                     new StringBuilder(),
                     CancellationToken.None);
             }

--- a/src/Dorc.Monitor/ComponentProcessor.cs
+++ b/src/Dorc.Monitor/ComponentProcessor.cs
@@ -45,6 +45,7 @@ namespace Dorc.Monitor
             int environmentId,
             bool isProductionEnvironment,
             string environmentName,
+            string? executionIdentityReference,
             string scriptRoot,
             IDictionary<string, VariableValue> commonProperties,
             CancellationToken cancellationToken)
@@ -90,6 +91,7 @@ namespace Dorc.Monitor
                             requestId,
                             isProductionRequest,
                             environmentName,
+                            executionIdentityReference,
                             componentResultLogBuilder,
                             terreformOperation,
                             cancellationToken);
@@ -163,6 +165,7 @@ namespace Dorc.Monitor
                                      deploymentResult.Id,
                                      isProductionRequest,
                                      environmentName,
+                                     executionIdentityReference,
                                      componentResultLogBuilder,
                                      cancellationToken);
 

--- a/src/Dorc.Monitor/IComponentProcessor.cs
+++ b/src/Dorc.Monitor/IComponentProcessor.cs
@@ -12,6 +12,7 @@ namespace Dorc.Monitor
             int environmentId,
             bool isProductionEnvironment,
             string environmentName,
+            string? executionIdentityReference,
             string scriptRoot,
             IDictionary<string, VariableValue> commonProperties,
             CancellationToken cancellationToken);

--- a/src/Dorc.Monitor/IScriptDispatcher.cs
+++ b/src/Dorc.Monitor/IScriptDispatcher.cs
@@ -13,6 +13,7 @@ namespace Dorc.Monitor
             int deploymentRequestId,
             bool isProduction,
             string environmentName,
+            string? executionIdentityReference,
             StringBuilder resultLogBuilder,
             CancellationToken cancellationToken);
     }

--- a/src/Dorc.Monitor/ITerraformDispatcher.cs
+++ b/src/Dorc.Monitor/ITerraformDispatcher.cs
@@ -1,4 +1,4 @@
-using Dorc.ApiModel;
+﻿using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Monitor.RunnerProcess;
 using System.Text;
@@ -14,6 +14,7 @@ namespace Dorc.Monitor
             int requestId,
             bool isProduction,
             string environmentName,
+            string? executionIdentityReference,
             StringBuilder resultLogBuilder,
             TerraformRunnerOperations terreformOperation,
             CancellationToken cancellationToken);

--- a/src/Dorc.Monitor/RequestProcessors/PendingRequestProcessor.cs
+++ b/src/Dorc.Monitor/RequestProcessors/PendingRequestProcessor.cs
@@ -4,6 +4,7 @@ using Dorc.Core;
 using Dorc.Core.Events;
 using Dorc.Core.Interfaces;
 using Dorc.Core.VariableResolution;
+using Dorc.Core.Security;
 using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Configuration;
@@ -28,6 +29,7 @@ namespace Dorc.Monitor.RequestProcessors
         private readonly ILoggerFactory _loggerFactory;
         private readonly IGitHubArtifactDownloader _gitHubArtifactDownloader;
         private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
+        private readonly IDeploymentCredentialSource _credentialSource;
 
         public PendingRequestProcessor(
             ILoggerFactory loggerFactory,
@@ -41,13 +43,15 @@ namespace Dorc.Monitor.RequestProcessors
             IPropertyEvaluator propertyEvaluator,
             IDeploymentEventsPublisher eventPublisher,
             IGitHubArtifactDownloader gitHubArtifactDownloader,
-            IScriptScopeConfigValues scriptScopeConfigValues)
+            IScriptScopeConfigValues scriptScopeConfigValues,
+            IDeploymentCredentialSource credentialSource)
         {
             _loggerFactory = loggerFactory;
             _propertyEvaluator = propertyEvaluator;
             _configValuesPersistentSource = configValuesPersistentSource;
             _gitHubArtifactDownloader = gitHubArtifactDownloader;
             _scriptScopeConfigValues = scriptScopeConfigValues;
+            _credentialSource = credentialSource;
             this.logger = _loggerFactory.CreateLogger<PendingRequestProcessor>();
 
             this.componentProcessor = componentProcessor;
@@ -222,6 +226,10 @@ namespace Dorc.Monitor.RequestProcessors
                                     environment.EnvironmentId,
                                     environment.EnvironmentIsProd,
                                     environmentName,
+                                    // The environment's own execution identity, where it names
+                                    // one. Null means the tier default, which is how every
+                                    // environment behaves until it is bound.
+                                    environment.ExecutionIdentityReference,
                                     scriptRoot,
                                     commonProperties,
                                     cancellationToken);
@@ -312,6 +320,8 @@ namespace Dorc.Monitor.RequestProcessors
                         criticalLogBuilder.AppendLine(log.ToString());
 
                         CancelPendingDeploymentResults(requestToExecute.Request.Id, DeploymentRequestStatus.Errored);
+
+                        ReportExecutionIdentityAdoption();
 
                         requestsPersistentSource.SetRequestCompletionStatus(
                             requestToExecute.Request.Id,
@@ -535,6 +545,29 @@ namespace Dorc.Monitor.RequestProcessors
                     + " scope: {Keys}. Each is readable by any script the deployment runs.",
                     stillPublished.Count,
                     string.Join(", ", stillPublished));
+            }
+        }
+
+        /// <summary>
+        /// Records how many credential resolutions used an environment's own execution identity
+        /// and how many fell back to the tier default.
+        ///
+        /// Migration progress is otherwise invisible, and "we have started binding identities"
+        /// is not the same claim as "the estate is bound". Reported from the count rather than
+        /// from a configuration flag, so it cannot be wrong.
+        /// </summary>
+        private void ReportExecutionIdentityAdoption()
+        {
+            var (bound, fallback) = _credentialSource.ResolutionCounts;
+
+            if (fallback > 0)
+            {
+                logger.LogInformation(
+                    "Execution identity: {Bound} resolution(s) used an environment's own identity,"
+                    + " {Fallback} fell back to the shared tier default. Every fallback shares one"
+                    + " account across its whole tier.",
+                    bound,
+                    fallback);
             }
         }
 

--- a/src/Dorc.Monitor/ScriptDispatcher.cs
+++ b/src/Dorc.Monitor/ScriptDispatcher.cs
@@ -58,6 +58,7 @@ namespace Dorc.Monitor
             int deploymentRequestId,
             bool isProduction,
             string environmentName,
+            string? executionIdentityReference,
             StringBuilder componentResultLogBuilder,
             CancellationToken cancellationToken)
         {
@@ -71,8 +72,12 @@ namespace Dorc.Monitor
             // probe and the password reset controller. Four independent copies of the same four
             // key names and the same production boolean is four places for a security decision
             // to drift.
+            // Environment-keyed. An environment naming its own execution identity deploys under
+            // it; one that does not falls back to the tier default and behaves exactly as before,
+            // so migration proceeds environment by environment rather than as a flag day.
             var credential = _credentialSource.Resolve(
-                isProduction ? DeploymentTier.Production : DeploymentTier.NonProduction);
+                isProduction ? DeploymentTier.Production : DeploymentTier.NonProduction,
+                executionIdentityReference);
 
             if (credential == null)
             {

--- a/src/Dorc.Monitor/TerraformDispatcher.cs
+++ b/src/Dorc.Monitor/TerraformDispatcher.cs
@@ -69,6 +69,7 @@ namespace Dorc.Monitor
             int requestId,
             bool isProduction,
             string environmentName,
+            string? executionIdentityReference,
             StringBuilder resultLogBuilder,
             TerraformRunnerOperations terreformOperation,
             CancellationToken cancellationToken)
@@ -87,8 +88,12 @@ namespace Dorc.Monitor
             isScriptExecutionSuccessful = true;
 
             // See ScriptDispatcher: one resolution point rather than a copy per dispatch path.
+            // Environment-keyed. An environment naming its own execution identity deploys under
+            // it; one that does not falls back to the tier default and behaves exactly as before,
+            // so migration proceeds environment by environment rather than as a flag day.
             var credential = _credentialSource.Resolve(
-                isProduction ? DeploymentTier.Production : DeploymentTier.NonProduction);
+                isProduction ? DeploymentTier.Production : DeploymentTier.NonProduction,
+                executionIdentityReference);
 
             if (credential == null)
             {

--- a/src/Dorc.PersistentData/Model/Environment.cs
+++ b/src/Dorc.PersistentData/Model/Environment.cs
@@ -13,6 +13,12 @@
         public string? Description { get; set; }
         public int? ParentId { get; set; }
 
+        /// <summary>
+        /// The execution identity this environment deploys under, or null to use the tier
+        /// default. Optional so that migration proceeds environment by environment.
+        /// </summary>
+        public string? ExecutionIdentityReference { get; set; }
+
         public ICollection<Database> Databases { get; set; } = new List<Database>();
         public ICollection<EnvironmentHistory> Histories { get; set; } = new List<EnvironmentHistory>();
         public ICollection<Server> Servers { get; set; } = new List<Server>();

--- a/src/Dorc.PersistentData/Sources/EnvironmentsPersistentSource.cs
+++ b/src/Dorc.PersistentData/Sources/EnvironmentsPersistentSource.cs
@@ -928,6 +928,7 @@ WHERE [Id] IN (SELECT [Id] FROM @DeletedPropertyValues);";
                 EnvironmentSecure = env.Secure,
                 EnvironmentIsProd = env.IsProd,
                 EnvironmentId = env.Id,
+                ExecutionIdentityReference = env.ExecutionIdentityReference,
                 Details = MapToEnvironmentDetailsApiModel(env),
                 ParentId = env.ParentId,
                 IsParent = env.ChildEnvironments.Any(),


### PR DESCRIPTION
Closes #868. Stacked on #862 (`sec/18-credential-source`) — review that first; this diff shows only its own step.

## What this does

Execution identity was a production boolean. An environment may now name its own, and credential resolution is environment-keyed at all four resolution sites: both dispatchers, the daemon status probe in the API process, and the password reset controller.

## The shape of the change

`DeploymentCredentialSource` — a new abstract base — owns the environment keying and the adoption counting, so both concrete sources (configuration values, vault) inherit identical semantics and differ only in how a named identity is looked up:

| Source | Named identity resolves to |
|---|---|
| Configuration values | `DORC_Deploy_<identity>_Username` / `_Password` |
| Vault | `<identity>-username` / `<identity>-password` — the reference *is* the item key |

The identity reference is threaded from `PendingRequestProcessor` (which reads `environment.ExecutionIdentityReference`) through `ComponentProcessor` into both dispatchers, and read directly from the environment at the two API-side sites.

## What reviewers should look at

**The refusal path.** `DeploymentCredentialSource.Resolve(tier, identityReference)` deliberately does *not* fall back to the tier default when a named identity cannot be resolved. That is the single most consequential decision here: falling back would silently keep an environment on the shared credential while reporting it as migrated.

**The schema column.** `Environment.ExecutionIdentityReference NVARCHAR(128) NULL`, null on every existing row. Nothing changes behaviour until an operator sets one, which is what makes this shippable without a migration event.

**The `Dorc.ApiModel` property carries no nullable annotation** — that assembly compiles at C# 7.3 because it is shared with the .NET Framework runner.

**The password reset controller** is now environment-keyed by identity but keeps its hard-coded non-production tier, preserved rather than quietly corrected. The reasoning is at the call site.

## Verification

- `Dorc.Core.Tests` 261 passed — including `EnvironmentKeyedCredentialResolutionTests`, covering that an environment naming nothing resolves exactly as before, that an unresolvable identity refuses rather than falling back, and that bound, fallback and refused resolutions are counted apart.
- `Dorc.Monitor.Tests` 130 passed, 11 skipped (Windows security authority).
- `Dorc.Api.Tests` 344 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_