### PR TITLE
W-8a: confine and expire the local Terraform plan artefacts

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -34,7 +34,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-004 | Contain expression evaluation by provenance | SD-1a, W-1, SC-01, SC-02 | **DONE** |
 | S-005 | Confine the build drop location | W-14, SC-05 | **DONE** |
 | S-006 | Remove resolved property values from runner logging | SD-6, W-7, SC-06 | **DONE** |
-| S-007 | Expire execution artefacts | SD-7, W-8, W-12, SC-08, SC-08a | **DONE** (W-8a deferred to S-021) |
+| S-007 | Expire execution artefacts | SD-7, W-8, W-12, SC-08, SC-08a | **DONE** (W-8a deferred to S-021, closed there) |
 | S-008 | Replace the null process security descriptor | SD-2, W-2, SC-04 | **DONE** — see the W-2 correction |
 | S-009 | Authenticate the script-group transport | SD-2, W-3, SC-04 | **DONE** — must ship in lockstep, see the step |
 | S-010 | Validate script paths at the write path | SD-5, W-5 | **DONE** (W-5a recorded, deferred to S-011) |
@@ -49,7 +49,7 @@ Four rules determine the order below. They are stated up front because several a
 | S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | S-017, U-14; **lockstep release** |
 | S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **Server side DONE**; web UI outstanding, see the step |
 | S-020 | Introduce the credential provider abstraction | SD-4 | **DONE** |
-| S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07 | **Binding DONE** — opt-in per environment; W-8a follows |
+| S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07, W-8a | **DONE** — opt-in per environment; W-8a closed here |
 | S-022 | Record attribution reached and not reached | SD-8, W-9 | S-021 |
 | S-023 | Replace the expression compiler with a fixed grammar | SD-1b, W-1 | **DONE** |
 
@@ -466,6 +466,18 @@ Binding granularity is by sensitivity tier rather than per environment: the esta
 **The password reset controller is bound by identity but not by tier.** It resolves the environment's identity reference like every other site, so an environment that names one resets passwords under it. Its hard-coded non-production tier is left exactly as it was: correcting it would begin making production logons from the API process where none were made before, which is a change of behaviour for whoever owns that endpoint to make, not a side effect of this step. Both halves are now visible at one call site.
 
 **The Terraform gate insertion point was not established.** This step recorded that the Terraform component branch has no equivalent of the PowerShell branch's production-only gate, and that its insertion point must be found before identity gating can be applied uniformly. It has not been found. What this step delivers on the Terraform branch is identity *binding*, not identity *gating* — the Terraform dispatcher resolves the environment's identity exactly as the PowerShell one does, but there is still no place on that branch where a component is refused for being production-bound. That is unchanged from before this step and is not made worse by it; it is recorded here rather than closed.
+
+#### W-8a, picked up here
+
+The local Terraform plan directory is now one directory per deployment result under `%ProgramData%\dorc\terraform-plans`, with a protected access control list admitting the Monitor, SYSTEM, Administrators, and that deployment's own identity. The shared directory is what made restriction impossible before: an access control list over a folder every deployment writes into would have to admit every identity that deploys on the host, which is no restriction at all. Splitting the layout is what lets a single identity be named, and that identity only became environment-dependent in this step.
+
+The grant is on the directory rather than on the files because the files do not exist yet — `terraform plan -out` creates the binary plan and the Runner writes the rendered content, both as the deployment account. That is the difference from the script-group bundle, which the Monitor writes and can therefore grant per file.
+
+**Retention resolves the entanglement rather than ignoring it.** The plan path expires its local artefacts only after both blob uploads have returned, so a failed upload leaves the local copy in place — it is the only copy, and deleting it would turn a recoverable failure into a lost plan. The apply path expires unconditionally, on success and failure alike, because there the local file is a cache of the blob that was downloaded into it. A sweep on each reservation clears what an earlier deployment left behind, including artefacts written directly into the root before this layout existed — on a long-lived deployment host that backlog is every plan it has ever produced.
+
+Two things the sweep deliberately does not do: it never removes the directory being reserved, however old that directory looks, because an apply confirmed after the retention window has passed reserves a directory older than the cutoff; and it judges a directory's age by the newest artefact inside it rather than by the directory's own write time, which does not move when a file within it is written.
+
+**What is not covered by test.** The access control list itself. Applying one needs a Windows security authority, and these tests run wherever the build does — the same boundary the runner process descriptor tests draw. What is covered is the layout and the lifetime, which is what decides who *could* be admitted. The dispatcher's half of the lifetime is not reachable either: dispatch builds a Windows process security context from a real account before it ever touches the plan store.
 
 ### S-022 — Record attribution reached and not reached
 

--- a/src/Dorc.Monitor.Tests/TerraformPlanLifetimeTests.cs
+++ b/src/Dorc.Monitor.Tests/TerraformPlanLifetimeTests.cs
@@ -1,0 +1,247 @@
+using Dorc.Monitor.Pipes;
+using Dorc.Monitor.Terraform;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Dorc.Monitor.Tests
+{
+    /// <summary>
+    /// Terraform plan artefacts embed the variable values the plan was made with — the binary plan
+    /// carries them and the rendered content lists them in plain text. They used to be written
+    /// into one shared directory created with inherited permissions and were never removed, so a
+    /// long-lived deployment host accumulated every plan it had ever produced, readable by any
+    /// authenticated user on it.
+    ///
+    /// What is covered here is the layout and the lifetime: a directory per deployment result, and
+    /// removal once the artefacts have a durable copy elsewhere. The access control list itself is
+    /// not — applying one needs a Windows security authority, and these tests run wherever the
+    /// build does. That is the same boundary the Runner process descriptor tests draw, and it is
+    /// why the store keeps the two concerns separable: the layout decides WHO could be admitted,
+    /// and the layout is what is testable here.
+    ///
+    /// The dispatcher's half of the lifetime — expire after upload on the plan path, expire
+    /// unconditionally on the apply path — is not reachable from a test host either: dispatch
+    /// builds a Windows process security context from a real account before it ever touches the
+    /// plan store. The asymmetry is stated at both call sites rather than asserted.
+    /// </summary>
+    [TestClass]
+    public class TerraformPlanLifetimeTests
+    {
+        private string _root = null!;
+        private ILogger _logger = null!;
+
+        private static readonly ScriptGroupReaderIdentity DeploymentIdentity =
+            new("CORP", "svc-dorc-prod");
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _root = Path.Join(Path.GetTempPath(), "dorc-plan-test-" + Guid.NewGuid().ToString("N"));
+            _logger = Substitute.For<ILogger>();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+
+        private TerraformPlanStore Reserve(int deploymentResultId) =>
+            TerraformPlanStore.Reserve(_logger, _root, deploymentResultId, DeploymentIdentity);
+
+        /// <summary>
+        /// The shared directory is what made restriction impossible: an access control list over it
+        /// would have to admit every identity that deploys on the host. One directory per
+        /// deployment result is what lets a single identity be admitted, which is the whole reason
+        /// this waited for the execution identity to become environment-dependent.
+        /// </summary>
+        [TestMethod]
+        public void TwoDeploymentsDoNotShareAPlanDirectory()
+        {
+            var first = Reserve(4001);
+            var second = Reserve(4002);
+
+            Assert.AreNotEqual(first.Directory, second.Directory);
+            Assert.IsTrue(Directory.Exists(first.Directory));
+            Assert.IsTrue(Directory.Exists(second.Directory));
+        }
+
+        /// <summary>
+        /// The plan and the apply that confirms it are separate dispatches, minutes or days apart,
+        /// and the apply downloads the plan blob by a name derived from the same identifier. If
+        /// they did not agree on the directory the apply would download into a place the Runner was
+        /// not told to look.
+        /// </summary>
+        [TestMethod]
+        public void ThePlanAndTheApplyOfOneDeploymentShareADirectory()
+        {
+            Assert.AreEqual(Reserve(4003).Directory, Reserve(4003).Directory);
+        }
+
+        [TestMethod]
+        public void ArtefactsAreNamedInsideTheDeploymentsOwnDirectory()
+        {
+            var store = Reserve(4004);
+
+            Assert.AreEqual(
+                Path.Combine(store.Directory, "4004.tfplan"),
+                store.PathOf("4004.tfplan"));
+        }
+
+        /// <summary>
+        /// Plan file names are derived from the deployment result identifier rather than supplied,
+        /// so this is a guard rather than a live defence — but a name that escaped the directory
+        /// would escape its access control list with it, which is exactly the confinement being
+        /// bought.
+        /// </summary>
+        [TestMethod]
+        [DataRow("../4005.tfplan")]
+        [DataRow("nested/4005.tfplan")]
+        [DataRow("")]
+        [DataRow("   ")]
+        public void AnArtefactNameThatIsNotABareFileNameIsRefused(string planFileName)
+        {
+            var store = Reserve(4005);
+
+            Assert.ThrowsExactly<ArgumentException>(() => store.PathOf(planFileName));
+        }
+
+        [TestMethod]
+        public void ExpiryRemovesTheArtefactsAndTheDirectoryTheyLiveIn()
+        {
+            var store = Reserve(4006);
+            File.WriteAllText(store.PathOf("4006.tfplan"), "binary-plan");
+            File.WriteAllText(store.PathOf("4006-content.txt"), "instance_password = \"secret\"");
+
+            store.Expire();
+
+            Assert.IsFalse(Directory.Exists(store.Directory));
+        }
+
+        [TestMethod]
+        public void ExpiringTwiceIsNotAFailure()
+        {
+            var store = Reserve(4007);
+
+            store.Expire();
+            store.Expire();
+
+            Assert.IsFalse(Directory.Exists(store.Directory));
+        }
+
+        /// <summary>
+        /// This is the asymmetry the plan path depends on. If the blob upload failed, the local
+        /// copy is the only copy of that plan — so a later deployment reserving the same directory
+        /// must re-apply its access control list without touching what is inside it.
+        /// </summary>
+        [TestMethod]
+        public void ReservingADirectoryThatAlreadyHoldsAPlanLeavesItAlone()
+        {
+            var first = Reserve(4008);
+            var retained = first.PathOf("4008.tfplan");
+            File.WriteAllText(retained, "the-only-copy");
+
+            Reserve(4008);
+
+            Assert.IsTrue(File.Exists(retained));
+            Assert.AreEqual("the-only-copy", File.ReadAllText(retained));
+        }
+
+        /// <summary>
+        /// The accumulated backlog. Before this change plan artefacts sat directly in the shared
+        /// root, so on every existing host that is where the history is; sweeping only the new
+        /// per-deployment shape would leave every plan the host had ever produced exactly where it
+        /// was.
+        /// </summary>
+        [TestMethod]
+        public void TheBacklogOfPlansWrittenBeforeThisLayoutExistedIsSwept()
+        {
+            Directory.CreateDirectory(_root);
+            var legacy = Path.Combine(_root, "1234.tfplan");
+            File.WriteAllText(legacy, "an-old-plan");
+            File.SetLastWriteTimeUtc(legacy, DateTime.UtcNow.AddDays(-30));
+
+            Reserve(4009);
+
+            Assert.IsFalse(File.Exists(legacy));
+        }
+
+        [TestMethod]
+        public void AnAbandonedDeploymentsPlanDirectoryIsSwept()
+        {
+            var abandoned = Reserve(4010);
+            var artefact = abandoned.PathOf("4010.tfplan");
+            File.WriteAllText(artefact, "abandoned");
+            Age(abandoned.Directory, TimeSpan.FromDays(30));
+
+            Reserve(4011);
+
+            Assert.IsFalse(Directory.Exists(abandoned.Directory));
+        }
+
+        /// <summary>
+        /// A plan awaiting confirmation is live. Retention exists to clear what a deployment left
+        /// behind, not to sweep what another deployment is still using.
+        /// </summary>
+        [TestMethod]
+        public void ARecentDeploymentsPlanDirectoryIsLeftWhereItIs()
+        {
+            var recent = Reserve(4012);
+            File.WriteAllText(recent.PathOf("4012.tfplan"), "in-flight");
+
+            Reserve(4013);
+
+            Assert.IsTrue(Directory.Exists(recent.Directory));
+        }
+
+        /// <summary>
+        /// The directory being reserved is never swept, however old it looks. An apply confirmed
+        /// after the retention window has passed reserves a directory older than the cutoff, and
+        /// removing it would delete the plan the apply is about to read back into it.
+        /// </summary>
+        [TestMethod]
+        public void TheDirectoryThisDeploymentIsReservingSurvivesItsOwnRetention()
+        {
+            var store = Reserve(4014);
+            var retained = store.PathOf("4014.tfplan");
+            File.WriteAllText(retained, "confirmed-late");
+            Age(store.Directory, TimeSpan.FromDays(30));
+
+            var reReserved = Reserve(4014);
+
+            Assert.AreEqual(store.Directory, reReserved.Directory);
+            Assert.IsTrue(File.Exists(retained));
+        }
+
+        /// <summary>
+        /// A directory's own write time does not move when a file inside it is written, so age has
+        /// to be judged by the newest artefact rather than by the container.
+        /// </summary>
+        [TestMethod]
+        public void ADirectoryHoldingARecentlyWrittenArtefactIsNotSwept()
+        {
+            var store = Reserve(4015);
+            File.WriteAllText(store.PathOf("4015.tfplan"), "written-just-now");
+            Directory.SetLastWriteTimeUtc(store.Directory, DateTime.UtcNow.AddDays(-30));
+
+            Reserve(4016);
+
+            Assert.IsTrue(Directory.Exists(store.Directory));
+        }
+
+        private static void Age(string directory, TimeSpan by)
+        {
+            var when = DateTime.UtcNow - by;
+
+            foreach (var file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                File.SetLastWriteTimeUtc(file, when);
+            }
+
+            Directory.SetLastWriteTimeUtc(directory, when);
+        }
+    }
+}

--- a/src/Dorc.Monitor/Pipes/ScriptGroupFileWriter.cs
+++ b/src/Dorc.Monitor/Pipes/ScriptGroupFileWriter.cs
@@ -118,9 +118,11 @@ namespace Dorc.Monitor.Pipes
         /// otherwise make the bundle unreadable. Access is granted on the file rather than the
         /// directory so that the deployment account can reach the bundle it is meant to consume
         /// and not those of concurrent deployments — the isolation that buys is per-deployment,
-        /// but the principal is not: it is one shared account per production/non-production
-        /// tier, so any process already running as it can still read that tier's in-flight
-        /// bundles. Narrowing the principal itself is S-021's job, not this one's.
+        /// but the principal need not be: an environment that names no execution identity of its
+        /// own still resolves to one shared account per production/non-production tier, so any
+        /// process already running as it can still read that tier's in-flight bundles. What
+        /// narrows the principal is the environment naming its own identity; that is a migration
+        /// per environment, not a property of this code.
         ///
         /// Reaching a file by path also needs traverse rights on its parents. Those come from
         /// the "Bypass traverse checking" right, which Windows grants to Everyone by default;
@@ -139,23 +141,21 @@ namespace Dorc.Monitor.Pipes
         {
             var account = readerIdentity.QualifiedAccountName;
 
+            // A misconfigured account name that resolves to a broad group would publish the
+            // bundle to it. The deployment will fail moments later when the logon is attempted
+            // with the same name, and the bundle is expired on that path - but not granting it
+            // in the first place is free.
+            if (!readerIdentity.TryResolveSecurityIdentifier(out var reader, out var refusal))
+            {
+                logger.LogError(
+                    $"{refusal} No access to the script group bundle '{filename}' has been granted, so the" +
+                    " Runner will be unable to read it unless it runs as an account the directory already" +
+                    " admits.");
+                return;
+            }
+
             try
             {
-                var reader = (SecurityIdentifier)new NTAccount(account).Translate(typeof(SecurityIdentifier));
-
-                if (IsTooBroadToHoldASecret(reader))
-                {
-                    // A misconfigured account name that resolves to a broad group would
-                    // publish the bundle to it. The deployment will fail moments later when
-                    // the logon is attempted with the same name, and the bundle is expired on
-                    // that path - but not granting it in the first place is free.
-                    logger.LogError(
-                        $"The configured deployment account '{account}' resolves to '{reader}', which is a" +
-                        " group broad enough that granting it access to the script group bundle would" +
-                        " disclose it. No access has been granted.");
-                    return;
-                }
-
                 var fileInfo = new FileInfo(filename);
                 var security = fileInfo.GetAccessControl();
                 security.AddAccessRule(new FileSystemAccessRule(
@@ -171,24 +171,6 @@ namespace Dorc.Monitor.Pipes
                     $" bundle '{filename}'. The Runner will be unable to read it unless it runs as an" +
                     $" account the directory already admits. Exception: {ex}");
             }
-        }
-
-        /// <summary>
-        /// Refuses the principals whose membership is effectively "anyone on the host". This is
-        /// a denylist of the catastrophic cases, not a general test for whether a SID names a
-        /// group — that needs the account's SID_NAME_USE, which has no managed API. A narrower
-        /// group slipping through still only reaches one bundle, for the seconds before the
-        /// logon fails on the same misconfigured name and the bundle is expired.
-        /// </summary>
-        private static bool IsTooBroadToHoldASecret(SecurityIdentifier sid)
-        {
-            return sid.IsWellKnown(WellKnownSidType.WorldSid)
-                || sid.IsWellKnown(WellKnownSidType.AuthenticatedUserSid)
-                || sid.IsWellKnown(WellKnownSidType.BuiltinUsersSid)
-                || sid.IsWellKnown(WellKnownSidType.BuiltinGuestsSid)
-                || sid.IsWellKnown(WellKnownSidType.InteractiveSid)
-                || sid.IsWellKnown(WellKnownSidType.NetworkSid)
-                || sid.IsWellKnown(WellKnownSidType.AnonymousSid);
         }
 
         /// <summary>

--- a/src/Dorc.Monitor/Pipes/ScriptGroupReaderIdentity.cs
+++ b/src/Dorc.Monitor/Pipes/ScriptGroupReaderIdentity.cs
@@ -1,3 +1,6 @@
+using System.Runtime.Versioning;
+using System.Security.Principal;
+
 namespace Dorc.Monitor.Pipes
 {
     /// <summary>
@@ -37,5 +40,72 @@ namespace Dorc.Monitor.Pipes
             UserName.Contains('\\') || UserName.Contains('@') || Domain.Length == 0
                 ? UserName
                 : $@"{Domain}\{UserName}";
+
+        /// <summary>
+        /// Resolves this account to a security identifier, refusing one that names a principal
+        /// too broad to be trusted with a deployment artefact.
+        ///
+        /// Both callers — the script-group bundle and the Terraform plan directory — grant this
+        /// principal access to something that carries resolved deployment properties, so both
+        /// need the same refusal. A misconfigured account name that happens to resolve to
+        /// Authenticated Users would otherwise publish the artefact to the whole host.
+        /// </summary>
+        /// <param name="refusal">
+        /// Why the identity was refused, when this returns false. Suitable for logging: it names
+        /// the configured account but nothing from the artefact being protected.
+        /// </param>
+        [SupportedOSPlatform("windows")]
+        public bool TryResolveSecurityIdentifier(
+            out SecurityIdentifier? securityIdentifier,
+            out string? refusal)
+        {
+            securityIdentifier = null;
+            refusal = null;
+
+            var account = QualifiedAccountName;
+
+            try
+            {
+                var resolved = (SecurityIdentifier)new NTAccount(account).Translate(typeof(SecurityIdentifier));
+
+                if (IsTooBroadToHoldASecret(resolved))
+                {
+                    refusal =
+                        $"The configured deployment account '{account}' resolves to '{resolved}', which is a"
+                        + " group broad enough that granting it access to a deployment artefact would"
+                        + " disclose it.";
+                    return false;
+                }
+
+                securityIdentifier = resolved;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                refusal =
+                    $"The configured deployment account '{account}' could not be resolved to a security"
+                    + $" identifier. Exception: {ex}";
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Refuses the principals whose membership is effectively "anyone on the host". This is
+        /// a denylist of the catastrophic cases, not a general test for whether a SID names a
+        /// group — that needs the account's SID_NAME_USE, which has no managed API. A narrower
+        /// group slipping through still only reaches one deployment's artefacts, for the seconds
+        /// before the logon fails on the same misconfigured name.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        private static bool IsTooBroadToHoldASecret(SecurityIdentifier sid)
+        {
+            return sid.IsWellKnown(WellKnownSidType.WorldSid)
+                || sid.IsWellKnown(WellKnownSidType.AuthenticatedUserSid)
+                || sid.IsWellKnown(WellKnownSidType.BuiltinUsersSid)
+                || sid.IsWellKnown(WellKnownSidType.BuiltinGuestsSid)
+                || sid.IsWellKnown(WellKnownSidType.InteractiveSid)
+                || sid.IsWellKnown(WellKnownSidType.NetworkSid)
+                || sid.IsWellKnown(WellKnownSidType.AnonymousSid);
+        }
     }
 }

--- a/src/Dorc.Monitor/Terraform/TerraformPlanStore.cs
+++ b/src/Dorc.Monitor/Terraform/TerraformPlanStore.cs
@@ -1,0 +1,360 @@
+using Dorc.Monitor.Pipes;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using System.Security.Principal;
+
+namespace Dorc.Monitor.Terraform
+{
+    /// <summary>
+    /// The local home of one deployment's Terraform plan artefacts, for as long as they are
+    /// needed and no longer.
+    ///
+    /// Two artefacts land here: the binary plan, which embeds the variable values it was planned
+    /// with, and the rendered plan content, which lists them in plain text. Both were previously
+    /// written straight into a single shared <c>%ProgramData%\dorc\terraform-plans</c> directory
+    /// created with inherited permissions — readable by any authenticated user on the deployment
+    /// host — and neither was ever removed. Every plan of every deployment the host had ever run
+    /// accumulated there.
+    ///
+    /// Restricting a shared directory is not possible without knowing who to admit, which is why
+    /// this could not be done alongside the other artefact hardening: the deployment identity was
+    /// a production boolean at the time. It is now the environment's own, so the layout changes
+    /// with it — one directory per deployment result, its access control list protected from
+    /// inheritance and naming that deployment's identity alone. A concurrent deployment running
+    /// under a different environment's identity cannot read this one's plan.
+    ///
+    /// The directory rather than the files must admit the deployment identity, because the plan
+    /// files do not exist yet: <c>terraform plan -out</c> creates the binary plan and the Runner
+    /// writes the rendered content, both as the deployment account. That is the difference from
+    /// the script-group bundle, which the Monitor writes and grants on the file.
+    /// </summary>
+    internal sealed class TerraformPlanStore
+    {
+        /// <summary>
+        /// How long plan artefacts left behind by an earlier deployment may survive before a
+        /// later one removes them.
+        ///
+        /// Longer than the bundle's retention, deliberately. A bundle is read once within seconds;
+        /// a plan is the durable half of a human-gated handshake, and while the uploaded blob is
+        /// what the apply reads back, a local survivor means the upload did not happen. That is
+        /// the one copy an operator has, so it is kept long enough to be noticed rather than
+        /// swept away by the next deployment on the host.
+        /// </summary>
+        private static readonly TimeSpan OrphanedPlanRetention = TimeSpan.FromDays(7);
+
+        private readonly ILogger _logger;
+
+        private TerraformPlanStore(ILogger logger, string directory)
+        {
+            _logger = logger;
+            Directory = directory;
+        }
+
+        /// <summary>The per-deployment directory the plan artefacts live in.</summary>
+        public string Directory { get; }
+
+        /// <summary>
+        /// Prepares this deployment's plan directory and returns a store over it.
+        /// </summary>
+        /// <param name="root">
+        /// The shared plan root, normally <c>%ProgramData%\dorc\terraform-plans</c>. Injected so
+        /// that the layout and lifetime are exercisable without writing under ProgramData.
+        /// </param>
+        /// <param name="deploymentResultId">
+        /// Names the directory. The same identifier is used for the plan and for the apply that
+        /// follows it, so both operations of one handshake share a directory — which is what makes
+        /// the apply able to find the plan it downloads.
+        /// </param>
+        /// <param name="deploymentIdentity">
+        /// The account the Runner will be started as, carried from the credential resolution
+        /// point rather than assumed to be the Monitor's own.
+        /// </param>
+        public static TerraformPlanStore Reserve(
+            ILogger logger,
+            string root,
+            int deploymentResultId,
+            ScriptGroupReaderIdentity deploymentIdentity)
+        {
+            var directory = Path.Join(
+                root,
+                deploymentResultId.ToString(CultureInfo.InvariantCulture));
+
+            var store = new TerraformPlanStore(logger, directory);
+
+            store.EnsureRoot(root);
+            store.RemoveOrphanedPlans(root);
+            store.EnsureDeploymentDirectory(deploymentIdentity);
+
+            return store;
+        }
+
+        /// <summary>
+        /// Where a named plan artefact belongs. Plan file names are derived from the deployment
+        /// result identifier and are the blob names too, so they are not attacker-chosen — but a
+        /// name that escaped this directory would escape its access control list as well, so the
+        /// join refuses anything that is not a bare file name.
+        /// </summary>
+        public string PathOf(string planFileName)
+        {
+            if (string.IsNullOrWhiteSpace(planFileName)
+                || planFileName != Path.GetFileName(planFileName))
+            {
+                throw new ArgumentException(
+                    "A Terraform plan artefact must be named by a bare file name.",
+                    nameof(planFileName));
+            }
+
+            return Path.Combine(Directory, planFileName);
+        }
+
+        /// <summary>
+        /// Removes this deployment's plan artefacts.
+        ///
+        /// Called once the artefacts have a durable copy elsewhere — after the plan blobs are
+        /// uploaded, or after an apply that read its plan back from one. Deliberately NOT called
+        /// on the failure path of a plan: if the upload is what failed, the local copy is the only
+        /// copy there is, and deleting it would turn a recoverable failure into a lost plan.
+        /// </summary>
+        public void Expire()
+        {
+            try
+            {
+                if (System.IO.Directory.Exists(Directory))
+                {
+                    System.IO.Directory.Delete(Directory, recursive: true);
+                    _logger.LogDebug($"Local Terraform plan artefacts in '{Directory}' have been removed.");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Called from the deployment path. Failing to delete is worth knowing about but
+                // must not replace the deployment's own outcome.
+                _logger.LogError(
+                    $"Failed to remove local Terraform plan artefacts in '{Directory}'. Exception: {ex}");
+            }
+        }
+
+        private void EnsureRoot(string root)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                System.IO.Directory.CreateDirectory(root);
+                return;
+            }
+
+            EnsureRestrictedRoot(root);
+        }
+
+        private void EnsureDeploymentDirectory(ScriptGroupReaderIdentity deploymentIdentity)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                // DOrc deploys on Windows; this branch exists so the layout and lifetime are
+                // exercisable off it. No restriction is applied here, so it must never be the
+                // production path.
+                System.IO.Directory.CreateDirectory(Directory);
+                return;
+            }
+
+            CreateRestrictedDeploymentDirectory(deploymentIdentity);
+        }
+
+        [SupportedOSPlatform("windows")]
+        private void EnsureRestrictedRoot(string root)
+        {
+            var security = RestrictedSecurity(admitting: null);
+
+            if (!System.IO.Directory.Exists(root))
+            {
+                // Created with the supplied access control list atomically, so the root never
+                // exists with the permissions it would have inherited from ProgramData.
+                security.CreateDirectory(root);
+                return;
+            }
+
+            // Re-asserted on every deployment, as the bundle directory is. The root predates this
+            // change on every existing host, so the first deployment after the release is what
+            // corrects the permissions it was created with.
+            new DirectoryInfo(root).SetAccessControl(security);
+        }
+
+        [SupportedOSPlatform("windows")]
+        private void CreateRestrictedDeploymentDirectory(ScriptGroupReaderIdentity deploymentIdentity)
+        {
+            // Failure to resolve the identity is logged, not thrown. The confinement is the
+            // protected access control list, which is applied either way; what an unresolvable
+            // identity costs is the deployment's ability to write its plan, and that surfaces as
+            // an access denial from Terraform moments later. Throwing here would turn a transient
+            // directory-service blip into a failed production deployment, and would do it before
+            // the deployment had any chance to report why.
+            SecurityIdentifier? deploymentAccount = null;
+            if (!deploymentIdentity.TryResolveSecurityIdentifier(out deploymentAccount, out var refusal))
+            {
+                _logger.LogError(
+                    $"{refusal} The Terraform plan directory '{Directory}' has been created without it, so"
+                    + " the Runner will be unable to write its plan unless it runs as an account the"
+                    + " directory already admits.");
+            }
+
+            var security = RestrictedSecurity(deploymentAccount);
+
+            if (!System.IO.Directory.Exists(Directory))
+            {
+                security.CreateDirectory(Directory);
+                return;
+            }
+
+            // A surviving directory belongs to an earlier attempt at the same deployment result,
+            // or to the plan half of this handshake. Its contents are left alone — they may be the
+            // only copy of a plan whose upload failed — but the access control list is re-applied,
+            // because the identity admitted may have changed since it was created.
+            //
+            // Overwriting a file preserves that file's own access control list, which would matter
+            // if a permissively-created file could end up in here. None can: this directory layout
+            // is introduced by this change, so nothing inside one was created before the
+            // restriction existed.
+            new DirectoryInfo(Directory).SetAccessControl(security);
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static DirectorySecurity RestrictedSecurity(SecurityIdentifier? admitting)
+        {
+            var security = new DirectorySecurity();
+            security.SetAccessRuleProtection(isProtected: true, preserveInheritance: false);
+
+            foreach (var identity in PrivilegedIdentities(admitting))
+            {
+                security.AddAccessRule(new FileSystemAccessRule(
+                    identity,
+                    FileSystemRights.FullControl,
+                    InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                    PropagationFlags.None,
+                    AccessControlType.Allow));
+            }
+
+            return security;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static IEnumerable<IdentityReference> PrivilegedIdentities(SecurityIdentifier? admitting)
+        {
+            // The Monitor writes here on the apply path, downloading the plan blob for the Runner
+            // to read, so its own identity is needed on both the root and the per-deployment
+            // directory. SYSTEM and Administrators keep the host administrable.
+            yield return WindowsIdentity.GetCurrent().User!;
+            yield return new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+            yield return new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+
+            if (admitting != null)
+            {
+                // Only on the per-deployment directory. Admitting the deployment identity to the
+                // root would let it enumerate — and read — every other deployment's plan, which is
+                // the disclosure this layout exists to prevent.
+                yield return admitting;
+            }
+        }
+
+        /// <summary>
+        /// Removes plan artefacts that outlived the deployment that produced them.
+        ///
+        /// Expiry on the deployment path covers the artefacts of a deployment that reached its
+        /// upload; this covers the ones whose Monitor did not survive to run it, the ones whose
+        /// upload failed, and — importantly — the entire backlog accumulated before any of this
+        /// existed, which on a long-lived deployment host is every plan it has ever run.
+        ///
+        /// That backlog sits directly in the root rather than in a per-deployment directory, so
+        /// both shapes are swept.
+        /// </summary>
+        private void RemoveOrphanedPlans(string root)
+        {
+            try
+            {
+                var cutoff = DateTime.UtcNow - OrphanedPlanRetention;
+                var removed = 0;
+
+                foreach (var entry in System.IO.Directory.EnumerateFileSystemEntries(root))
+                {
+                    try
+                    {
+                        // Never the directory this deployment is about to use, whatever its age
+                        // says. An apply confirmed after the retention window would otherwise
+                        // sweep the plan it is running.
+                        if (string.Equals(
+                                Path.GetFullPath(entry),
+                                Path.GetFullPath(Directory),
+                                StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        if (System.IO.Directory.Exists(entry))
+                        {
+                            // The write time of a directory does not move when a file inside it is
+                            // written, so the newest artefact decides whether the directory is
+                            // spent - not the moment it was created.
+                            if (LastWriteWithin(entry, cutoff))
+                            {
+                                continue;
+                            }
+
+                            System.IO.Directory.Delete(entry, recursive: true);
+                        }
+                        else
+                        {
+                            if (File.GetLastWriteTimeUtc(entry) >= cutoff)
+                            {
+                                continue;
+                            }
+
+                            File.Delete(entry);
+                        }
+
+                        removed++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            $"Failed to remove orphaned Terraform plan artefacts at '{entry}'. Exception: {ex}");
+                    }
+                }
+
+                if (removed > 0)
+                {
+                    _logger.LogInformation(
+                        $"Removed {removed} orphaned Terraform plan artefact(s) from '{root}'.");
+                }
+            }
+            catch (Exception ex)
+            {
+                // Housekeeping. Never let it stop a deployment.
+                _logger.LogWarning(
+                    $"Failed to enumerate Terraform plan artefacts in '{root}'. Exception: {ex}");
+            }
+        }
+
+        private static bool LastWriteWithin(string directory, DateTime cutoff)
+        {
+            if (System.IO.Directory.GetLastWriteTimeUtc(directory) >= cutoff)
+            {
+                return true;
+            }
+
+            foreach (var entry in System.IO.Directory.EnumerateFileSystemEntries(
+                directory, "*", SearchOption.AllDirectories))
+            {
+                var lastWrite = System.IO.Directory.Exists(entry)
+                    ? System.IO.Directory.GetLastWriteTimeUtc(entry)
+                    : File.GetLastWriteTimeUtc(entry);
+
+                if (lastWrite >= cutoff)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Dorc.Monitor/TerraformDispatcher.cs
+++ b/src/Dorc.Monitor/TerraformDispatcher.cs
@@ -151,6 +151,8 @@ namespace Dorc.Monitor
                 // context rather than assumed to be the Monitor's own identity.
                 var readerIdentity = new ScriptGroupReaderIdentity(domainName, processAccountName);
 
+                Terraform.TerraformPlanStore? planStore = null;
+
                 try
                 {
                     Task scriptGroupPipeTask = _scriptGroupPipeServer.Start(
@@ -167,13 +169,20 @@ namespace Dorc.Monitor
 
                     _requestsPersistentSource.UpdateUncLogPath(requestId, uncLogPath);
 
-                    var planStorageDir = Path.Join(DorcProgramData.Root, "terraform-plans");
-                    if (!Directory.Exists(planStorageDir))
-                        Directory.CreateDirectory(planStorageDir);
+                    // The plan and its rendered content carry the variable values they were planned
+                    // with, so they get a directory of their own, restricted to this deployment's
+                    // identity, rather than the shared inherited-permission folder they used to
+                    // share with every plan the host had ever produced.
+                    planStore = Terraform.TerraformPlanStore.Reserve(
+                        logger,
+                        Path.Join(DorcProgramData.Root, "terraform-plans"),
+                        deploymentResult.Id,
+                        readerIdentity);
+
                     var terraformPlanFileName = deploymentResult.Id.CreateTerraformPlanBlobName();
-                    var terraformPlanFilePath = Path.Combine(planStorageDir, terraformPlanFileName);
+                    var terraformPlanFilePath = planStore.PathOf(terraformPlanFileName);
                     var terraformPlanContentFileName = deploymentResult.Id.CreateTerraformPlanContentBlobName();
-                    var terraformPlanContentFilePath = Path.Combine(planStorageDir, terraformPlanContentFileName);
+                    var terraformPlanContentFilePath = planStore.PathOf(terraformPlanContentFileName);
                     if (terreformOperation == TerraformRunnerOperations.ApplyPlan)
                     {
                         _azureStorageAccountWorker.DownloadFileFromBlobs(terraformPlanFileName, terraformPlanFilePath);
@@ -271,6 +280,13 @@ namespace Dorc.Monitor
                             // save Terraform human-readable plan file to Azure Storage Account
                             _azureStorageAccountWorker.SaveFileToBlobs(terraformPlanContentFilePath);
 
+                            // Both artefacts now have a durable copy in blob storage, which is
+                            // where the apply reads the plan back from - so the local ones, which
+                            // list the variable values the plan was made with, are withdrawn.
+                            // Reached only if both uploads returned: if either threw, the local
+                            // copy is the only copy and is deliberately left in place.
+                            planStore.Expire();
+
                             // Update status to WaitingConfirmation
                             _requestsPersistentSource.UpdateResultStatus(
                                 deploymentResult,
@@ -296,6 +312,15 @@ namespace Dorc.Monitor
                     // withdrawn as soon as that process is gone - on the failure and
                     // cancellation paths as much as the successful one.
                     _scriptGroupPipeServer.Expire(startedScriptGroupPipeName);
+
+                    if (terreformOperation == TerraformRunnerOperations.ApplyPlan)
+                    {
+                        // On the apply path the local plan is a cache of the blob that was
+                        // downloaded into it, so nothing is lost by withdrawing it whatever the
+                        // outcome. The plan path is the asymmetric one: there the local copy is
+                        // the original, and it is expired only once the upload has succeeded.
+                        planStore?.Expire();
+                    }
                 }
 
             }


### PR DESCRIPTION
Closes #870. Stacked on #869 (`sec/19-environment-identity`) — review that first; this diff shows only its own step.

## What this does

`%ProgramData%\dorc\terraform-plans` was one shared directory created with inherited permissions, holding every plan the host had ever produced. It becomes one directory per deployment result, with a protected access control list naming the Monitor, SYSTEM, Administrators and that deployment's own identity — the identity #869 made environment-dependent.

## What reviewers should look at

**The expiry asymmetry**, which is the part that carries risk. `TerraformDispatcher` expires the plan directory:

- on the **plan** path, only after *both* `SaveFileToBlobs` calls return — so a throwing upload leaves the local copy, because it is then the only copy;
- on the **apply** path, in `finally`, on success and failure alike — there the local file is a cache of the blob downloaded into it.

**Why the grant is on the directory, not the files.** The plan files do not exist when the directory is prepared: `terraform plan -out=<path>` creates the binary plan and the Runner's `File.WriteAllText` creates the rendered content, both running as the deployment account. This is the difference from the script-group bundle, which the Monitor writes and can grant per file.

**Two sweep decisions that are easy to get wrong.** The directory being reserved is never swept however old it looks — an apply confirmed after the retention window reserves a directory older than the cutoff, and sweeping it would delete the plan the apply is about to read back. And a directory's age is judged by the newest artefact inside it, because a directory's own write time does not move when a file within it is written.

**The SID resolution moved.** `IsTooBroadToHoldASecret` and the `NTAccount` translation move from `ScriptGroupFileWriter` onto `ScriptGroupReaderIdentity.TryResolveSecurityIdentifier`, so both consumers refuse an over-broad principal identically rather than one of them carrying a private copy. `ScriptGroupFileWriter`'s behaviour is unchanged apart from the two error messages collapsing into one.

**Failure to resolve the identity is logged, not thrown.** The confinement is the protected access control list, which is applied either way; what an unresolvable identity costs is the deployment's ability to write its plan, which surfaces as an access denial moments later. Throwing would turn a transient directory-service blip into a failed production deployment before the deployment could report why.

## Verification

`Dorc.Monitor.Tests` 145 passed, 11 skipped — 15 new in `TerraformPlanLifetimeTests` covering the per-deployment layout, that plan and apply of one deployment share a directory, that reserving a directory holding a retained plan leaves it alone, that the pre-existing flat backlog is swept, and both sweep exemptions above. `Dorc.Core.Tests` 261 and `Dorc.Api.Tests` 344 unchanged and passing.

The access control list itself is not asserted: applying one needs a Windows security authority. That is the same boundary the runner process descriptor tests draw, and it is stated in the test class rather than left implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_