### PR TITLE
S-019: surface the script-visibility classification in the web UI

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -47,7 +47,7 @@ Four rules determine the order below. They are stated up front because several a
 | ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | **Worklist queries delivered** (`S-016-off-share-script-paths.sql`); operator-executed |
 | S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | **DONE** — reports by default, enforce after S-016 |
 | S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | S-017, U-14; **lockstep release** |
-| S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **Server side DONE**; web UI outstanding, see the step |
+| S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **DONE** — server and web UI |
 | S-020 | Introduce the credential provider abstraction | SD-4 | **DONE** |
 | S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07, W-8a | **DONE** — opt-in per environment; W-8a closed here |
 | S-022 | Record attribution reached and not reached | SD-8, W-9 | **DONE** — `S-022-attribution-reached-and-not-reached.md` |
@@ -412,9 +412,17 @@ Everything in it is read-only except a remediation template that is commented ou
 
 **Verification intent.** An existing value's behaviour is unchanged until an administrator changes its classification. A newly created secure value is hidden by default. A hidden value does not appear in the serialized script group. The administrative surface is reachable only by administrators.
 
-**Delivered server side; the web UI is not done.** Schema, entity, API model, persistence and enforcement are complete, and the classification is maintainable through the existing `RefDataConfig` endpoints — which already gate every write on `IsAdmin`, so the "reachable only by administrators" criterion needed no new code. What is missing is the *convenient* surface: a column on the config values page and a control on the create form.
+**Delivered server side first; the web UI followed.** Schema, entity, API model, persistence and enforcement are complete, and the classification is maintainable through the existing `RefDataConfig` endpoints — which already gate every write on `IsAdmin`, so the "reachable only by administrators" criterion needed no new code. What is missing is the *convenient* surface: a column on the config values page and a control on the create form.
 
-That half needs the generated TypeScript API client regenerated from the OpenAPI document — `dorc-web/src/apis/dorc-api/models/ConfigValueApiModel.ts` carries a "do not edit manually" banner, and hand-editing generated output is how a client and a contract drift apart. The step is usable without it: an administrator can set the classification over the API today.
+That half needed the generated TypeScript API client regenerated from the OpenAPI document — `dorc-web/src/apis/dorc-api/models/ConfigValueApiModel.ts` carries a "do not edit manually" banner, and hand-editing generated output is how a client and a contract drift apart. It was regenerated rather than hand-edited, and only the one changed model taken from the output: the checked-in `swagger.json` is behind the checked-in client in other places, so regenerating the whole client from it would have silently *removed* properties the UI depends on. That drift is pre-existing and is left recorded rather than repaired here — repairing it means re-exporting the OpenAPI document from a running API, which is a separate piece of work with its own review.
+
+**The UI half.** A "Visible To Scripts" column on the config values page and a control on the create form, both administrator-gated like the existing classifications. Two decisions worth stating.
+
+The checkbox is readable on every row but changeable only on secure ones. A non-secure value is ordinary configuration, visible to scripts by definition, and the server forces the flag true when one is created — an editable control there would suggest a restriction that does not exist.
+
+The create form defaults it **off**, matching the server's asymmetry: a new secure value is hidden from script scope unless its creator says otherwise, while existing values default the other way in the column default. Defaulting the form the other way would make every newly-added credential readable by every deployment script the moment it was created.
+
+**The reserved-key list is not duplicated into the UI.** A value on that list is withheld from script scope whatever the checkbox says, and the server is where that is decided. Showing it per row would need either an endpoint exposing the list or a second copy of it in the client — and a second copy of a security decision is a second place for it to drift. The residual is that an administrator can tick "visible" on a reserved key and see it stay ticked while the value remains withheld; the display misleads, the enforcement does not. Recorded rather than closed.
 
 **The asymmetric default is what makes this shippable.** Existing values default to visible, in the column default, so adding the column changes no deployment's behaviour on upgrade. New *secure* values are created hidden. A symmetric default would force a choice between breaking deployments on day one and shipping a control that protects nothing new.
 

--- a/src/dorc-web/src/apis/dorc-api/models/ConfigValueApiModel.ts
+++ b/src/dorc-web/src/apis/dorc-api/models/ConfigValueApiModel.ts
@@ -41,4 +41,9 @@ export interface ConfigValueApiModel {
      * @memberof ConfigValueApiModel
      */
     IsForProd?: boolean | null;
+    /**
+     * @type {boolean}
+     * @memberof ConfigValueApiModel
+     */
+    VisibleToScripts?: boolean;
 }

--- a/src/dorc-web/src/apis/dorc-api/swagger.json
+++ b/src/dorc-web/src/apis/dorc-api/swagger.json
@@ -8660,6 +8660,9 @@
           "IsForProd": {
             "type": "boolean",
             "nullable": true
+          },
+          "VisibleToScripts": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false

--- a/src/dorc-web/src/components/add-config-value.ts
+++ b/src/dorc-web/src/components/add-config-value.ts
@@ -26,6 +26,13 @@ export class AddConfigValue extends LitElement {
 
   @property({type: Boolean }) private isForProd: boolean = false;
 
+  // Unticked by default, and only meaningful for a secure value: the server hides a new
+  // secure value from script scope unless its creator says otherwise, while a non-secure
+  // value is ordinary configuration and stays visible whatever this says. Defaulting the
+  // other way would make every newly-added credential readable by every deployment
+  // script the moment it was created.
+  @property({type: Boolean }) private visibleToScripts: boolean = false;
+
   @property({ type: Boolean }) private valid = false;
 
   @property({ type: Object })
@@ -101,6 +108,17 @@ export class AddConfigValue extends LitElement {
             }}"
             tabindex="3"
           ></vaadin-checkbox>
+          <vaadin-checkbox
+            id="visible-to-scripts"
+            label="Visible To Scripts"
+            title="Whether deployment scripts may read this value. Only applies to secure values; some values are withheld from script scope regardless."
+            .disabled="${!this.isSecure}"
+            .checked="${this.visibleToScripts}"
+            @change="${(e: Event) => {
+              this.visibleToScripts = (e.target as HTMLInputElement).checked;
+            }}"
+            tabindex="3"
+          ></vaadin-checkbox>
           </vaadin-text-field>
         </vaadin-vertical-layout>
         <div>
@@ -138,6 +156,7 @@ export class AddConfigValue extends LitElement {
 
     this.configValue.Secure = this.isSecure;
     this.configValue.IsForProd = this.isForProd;
+    this.configValue.VisibleToScripts = this.visibleToScripts;
     this.configValue.Key = this.key;
     this.configValue.Value = this.value;
 
@@ -184,6 +203,7 @@ export class AddConfigValue extends LitElement {
     this.clearTextField('value');
 
     this.configValue = this.getEmptyConfigValue();
+    this.visibleToScripts = false;
     this.keyValid = false;
     this.valueValid = false;
 
@@ -196,7 +216,8 @@ export class AddConfigValue extends LitElement {
       Key: '',
       Value: '',
       Secure: false,
-      IsForProd: undefined
+      IsForProd: undefined,
+      VisibleToScripts: false
     };
   }
 }

--- a/src/dorc-web/src/pages/page-config-values-list.ts
+++ b/src/dorc-web/src/pages/page-config-values-list.ts
@@ -39,6 +39,7 @@ export class PageConfigValuesList extends ResponsiveMixin(PageElement) {
     this.getConfigValuesList();
     this.isSecuredRenderer = this.isSecuredRenderer.bind(this);
     this.isForProdRenderer = this.isForProdRenderer.bind(this);
+    this.isVisibleToScriptsRenderer = this.isVisibleToScriptsRenderer.bind(this);
   }
 
   private getConfigValuesList() {
@@ -207,6 +208,16 @@ export class PageConfigValuesList extends ResponsiveMixin(PageElement) {
                 .renderer=${this.isForProdRenderer}
                 ?hidden="${this._narrowScreen}"
               ></vaadin-grid-sort-column>
+              <vaadin-grid-sort-column
+                path="VisibleToScripts"
+                header="Visible To Scripts"
+                title="Whether deployment scripts may read this value. Some values are withheld from script scope regardless of this setting."
+                resizable
+                width="140px"
+                flex-grow="0"
+                .renderer=${this.isVisibleToScriptsRenderer}
+                ?hidden="${this._narrowScreen}"
+              ></vaadin-grid-sort-column>
               <vaadin-grid-column
                 header="Config Value"
                 .renderer=${this.variableValueControlsRenderer}
@@ -288,6 +299,41 @@ export class PageConfigValuesList extends ResponsiveMixin(PageElement) {
 
     checkbox.addEventListener('change', async () => {
       await this.updateConfigItem({...configValueApiModel, IsForProd: checkbox.checked
+      });
+    });
+
+    render(checkbox, root);
+  }
+
+  /**
+   * Whether deployment scripts may read this value.
+   *
+   * The classification is only meaningful for secure values — a non-secure value is
+   * ordinary configuration and is visible to scripts by definition, which is why the
+   * server forces it true on creation. The checkbox follows that: readable for every
+   * row, changeable only on the secure ones.
+   *
+   * Ticking this box is not the same as publishing the value. Values on the reserved-key
+   * list are withheld from script scope whatever this says, and the server is where that
+   * is decided — the list is not duplicated here, because a second copy of a security
+   * decision is a second place for it to drift.
+   */
+  isVisibleToScriptsRenderer(
+    root: HTMLElement,
+    _column: GridColumn,
+    model: GridItemModel<ConfigValueApiModel>
+  ) {
+    const configValueApiModel = model.item as ConfigValueApiModel;
+
+    const checkbox = new Checkbox();
+
+    checkbox.checked = configValueApiModel.VisibleToScripts as boolean;
+    checkbox.disabled = !this.isAdmin || !configValueApiModel.Secure;
+
+    checkbox.addEventListener('change', async () => {
+      await this.updateConfigItem({
+        ...configValueApiModel,
+        VisibleToScripts: checkbox.checked
       });
     });
 

--- a/src/dorc-web/tests/pages/page-config-values-list.test.ts
+++ b/src/dorc-web/tests/pages/page-config-values-list.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// --- Hoisted mock values (available before vi.mock factories run) ---
+const { mockConfigGet, mockConfigPut, mockRolesGet } = vi.hoisted(() => ({
+  mockConfigGet: vi.fn(),
+  mockConfigPut: vi.fn(),
+  mockRolesGet: vi.fn()
+}));
+
+// Vaadin web component side-effect registrations. The checkbox is NOT mocked —
+// these tests assert on a real Checkbox instance's checked and disabled state.
+vi.mock('@vaadin/grid/vaadin-grid', () => ({}));
+vi.mock('@vaadin/grid/vaadin-grid-sort-column', () => ({}));
+vi.mock('@vaadin/grid', () => ({}));
+vi.mock('@vaadin/icons/vaadin-icons', () => ({}));
+vi.mock('@vaadin/icon', () => ({}));
+vi.mock('@vaadin/text-field', () => ({}));
+vi.mock('@vaadin/button', () => ({}));
+vi.mock('@polymer/paper-dialog', () => ({}));
+
+vi.mock('../../src/components/dorc-spinner', () => ({}));
+vi.mock('../../src/components/grid-button-groups/config-value-controls', () => ({}));
+vi.mock('../../src/components/add-config-value', () => ({}));
+vi.mock('../../src/helpers/html-meta-manager', () => ({ updateMetadata: vi.fn() }));
+vi.mock('../../src/router/routes.ts', () => ({}));
+vi.mock('@vaadin/router', () => ({}));
+
+vi.mock('../../src/apis/dorc-api', () => ({
+  RefDataConfigApi: class {
+    refDataConfigGet = mockConfigGet;
+    refDataConfigPut = mockConfigPut;
+  },
+  RefDataRolesApi: class {
+    refDataRolesGet = mockRolesGet;
+  }
+}));
+
+import { PageConfigValuesList } from '../../src/pages/page-config-values-list';
+import { Checkbox } from '@vaadin/checkbox';
+import type { ConfigValueApiModel } from '../../src/apis/dorc-api';
+
+/** A subscribe() that hands the supplied payload straight to the next handler. */
+const emitting = (payload: unknown) => ({
+  subscribe: (handlers: any) => {
+    handlers.next?.(payload);
+    handlers.complete?.();
+  }
+});
+
+async function flushAsync(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+/**
+ * A config value's script visibility is the only classification on this page that is not
+ * simply a property of the value — it decides whether a deployment script can read it,
+ * so who may change it and when it means anything both matter.
+ *
+ * The classification applies to secure values only. A non-secure value is ordinary
+ * configuration and is visible by definition; the server forces it true on creation, and
+ * a checkbox that let an administrator appear to un-publish one would be lying.
+ */
+describe('PageConfigValuesList script visibility', () => {
+  let el: PageConfigValuesList;
+
+  const secure: ConfigValueApiModel = {
+    Id: 1,
+    Key: 'SomeAccountPassword',
+    Value: 'enc:x',
+    Secure: true,
+    IsForProd: true,
+    VisibleToScripts: false
+  };
+
+  const nonSecure: ConfigValueApiModel = {
+    Id: 2,
+    Key: 'ArtefactsUrl',
+    Value: 'https://example.invalid',
+    Secure: false,
+    IsForProd: false,
+    VisibleToScripts: true
+  };
+
+  /** Runs the renderer for one row and returns the checkbox it produced. */
+  function renderVisibility(item: ConfigValueApiModel): Checkbox {
+    const root = document.createElement('div');
+    el.isVisibleToScriptsRenderer(root, {} as any, { item } as any);
+    return root.firstElementChild as Checkbox;
+  }
+
+  async function mount(roles: string[]): Promise<void> {
+    mockConfigGet.mockImplementation(() => emitting([secure, nonSecure]));
+    mockRolesGet.mockImplementation(() => emitting(roles));
+    mockConfigPut.mockImplementation(() => emitting({}));
+
+    el = new PageConfigValuesList();
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await flushAsync();
+  }
+
+  beforeEach(() => {
+    mockConfigGet.mockClear();
+    mockConfigPut.mockClear();
+    mockRolesGet.mockClear();
+  });
+
+  afterEach(() => {
+    el?.remove();
+    document.body.innerHTML = '';
+  });
+
+  it('shows the stored classification', async () => {
+    await mount(['Admin']);
+
+    expect(renderVisibility(secure).checked).toBe(false);
+    expect(renderVisibility(nonSecure).checked).toBe(true);
+  });
+
+  it('lets an administrator change it on a secure value', async () => {
+    await mount(['Admin']);
+
+    expect(renderVisibility(secure).disabled).toBe(false);
+  });
+
+  it('does not offer it on a non-secure value', async () => {
+    await mount(['Admin']);
+
+    // Not a permissions question: a non-secure value is visible to scripts by
+    // definition and the server forces it true, so an editable checkbox here would
+    // suggest a restriction that does not exist.
+    expect(renderVisibility(nonSecure).disabled).toBe(true);
+  });
+
+  it('does not offer it to a non-administrator', async () => {
+    await mount([]);
+
+    expect(renderVisibility(secure).disabled).toBe(true);
+  });
+
+  it('sends the changed classification and nothing else', async () => {
+    await mount(['Admin']);
+
+    const checkbox = renderVisibility(secure);
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    await flushAsync();
+
+    expect(mockConfigPut).toHaveBeenCalledTimes(1);
+    const sent = mockConfigPut.mock.calls[0][0] as any;
+    expect(sent.id).toBe(secure.Id);
+    expect(sent.configValueApiModel.VisibleToScripts).toBe(true);
+    // The server applies one change per request, so the rest of the value has to
+    // arrive unchanged or a visibility toggle would be read as an edit of something
+    // else — the encrypted value, most damagingly.
+    expect(sent.configValueApiModel.Value).toBe(secure.Value);
+    expect(sent.configValueApiModel.Secure).toBe(secure.Secure);
+    expect(sent.configValueApiModel.IsForProd).toBe(secure.IsForProd);
+  });
+});


### PR DESCRIPTION
Closes #874. Stacked on #873 (`sec/21-attribution-record`) — review that first; this diff shows only its own step. Completes S-019, whose server half is #846.

## What this does

Adds a **Visible To Scripts** column to the config values page and a control to the create form, both administrator-gated like `Is Secure` and `Is For Prod`.

## What reviewers should look at

**The checkbox is disabled on non-secure rows, and that is not a permissions decision.** A non-secure value is ordinary configuration and the server forces `VisibleToScripts = true` when one is created; an editable control there would suggest a restriction that does not exist. `checkbox.disabled = !this.isAdmin || !configValueApiModel.Secure`.

**The create form defaults it off.** The server hides a new *secure* value from script scope unless its creator says otherwise, while existing values default the other way in the column default. The form matches the server, not the column.

**The update sends the whole model with one field changed.** `ConfigValuesPersistentSource.Update` applies one change per request in an if/else chain, so a visibility toggle that dropped fields would be read as an edit of something else — the encrypted value, most damagingly. There is a test for exactly this.

## How the generated model was produced

`ConfigValueApiModel.ts` carries a do-not-edit banner, so it was regenerated with `openapi-generator-cli` after adding the property to `swagger.json` — **and only that one file taken from the output.**

That last part is deliberate and worth a reviewer's attention. The checked-in `swagger.json` is behind the checked-in client in other places (`ApiBoolResult.RequiresConfirmation` is in the client and not in the document), so regenerating the whole client from it would silently *remove* properties the UI depends on. The generated `ConfigValueApiModel.ts` was diffed against the checked-in one first: the only difference is the five added lines. That pre-existing drift is recorded in the IS rather than repaired here — repairing it means re-exporting the OpenAPI document from a running API.

`openapitools.json` pins generator 6.6.0 while the checked-in `.openapi-generator/VERSION` says 7.13.0; both produce byte-identical output for this model, which is how the file was verified. Neither file is touched by this PR.

## Verification

- `npx vitest run` (chromium) — 14 files, 127 tests passed, including 5 new in `tests/pages/page-config-values-list.test.ts` covering the stored classification, administrator gating, the non-secure case, and that a toggle sends the changed field and leaves the rest of the value intact.
- `tsc --noEmit` and `tsc -p tsconfig.test.json --noEmit` clean.
- `eslint` clean.
- `lit-analyzer --strict` reports no new findings; the four `no-incompatible-type-binding` entries on `.renderer` bindings are pre-existing and apply equally to the existing `Is Secure` and `Is For Prod` columns.

Firefox and WebKit instances were not run — those Playwright browsers are not available in this environment. The suite was run on chromium only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_