### PR TITLE
S-018a: record what a script's content is allowed to be

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -46,7 +46,7 @@ Four rules determine the order below. They are stated up front because several a
 | ⚙ S-015 | Rotate the deployment credentials | SD-3, W-4 | **Runbook delivered**; gate satisfied, operator-executed |
 | ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | **Worklist queries delivered** (`S-016-off-share-script-paths.sql`); operator-executed |
 | S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | **DONE** — reports by default, enforce after S-016 |
-| S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | S-017, U-14; **lockstep release** |
+| S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | **U-14 resolved**, see `SPEC-S-018-*`; a) record **DONE**, b) verify **lockstep** |
 | S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **DONE** — server and web UI |
 | S-020 | Introduce the credential provider abstraction | SD-4 | **DONE** |
 | S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07, W-8a | **DONE** — opt-in per environment; W-8a closed here |
@@ -397,6 +397,20 @@ Everything in it is read-only except a remediation template that is commented ou
 **Release constraint.** **Lockstep, not additive.** The script group is deserialized by a serializer that ignores unknown members, so a runner that has not been upgraded would silently ignore an added hash and execute unverified — the criterion unmet with no signal. All three runners and both dispatchers ship together; they are packaged in a single installer, so this is achievable. The Monitor must also define its behaviour when it cannot confirm the runner performed verification.
 
 **Verification intent.** A script whose content changed after its hash was recorded fails verification and does not execute, with the outcome recorded against the deployment result. An unmodified script executes normally. An unrecorded hash follows the adopted tolerance mode rather than failing arbitrarily.
+
+**U-14 is resolved in `SPEC-S-018-script-content-verification.md`.** Four decisions, summarised here because they change what this step is.
+
+**DOrc records the hash on first execution — trust on first use.** Not an operator by hand: there are hundreds of registered scripts and a control needing hundreds of manual acts is never adopted. Not the promotion pipeline as a precondition: that is the correct end state and the spec makes it reachable, but requiring pipeline work outside this repository first means the step delivers nothing until that work happens. What trust on first use is worth, stated plainly: it does not establish that a script was legitimate when first seen — if the share was already compromised, the compromised bytes become the baseline. What it detects is **change after recording**, which is the actual attack, and it converts a silent indefinite compromise into a refusal at the next deployment.
+
+**Re-recording on promotion is an administrator-gated endpoint**, which a pipeline calls after publishing a new version. Clearing a hash means "re-record on next execution", not "stop verifying this one" — there is deliberately no per-script opt-out, because a per-script opt-out is a per-script hole.
+
+**Three modes, defaulting to report**: `Off`, `Report`, `Enforce`, from `ScriptContentVerification` in AppSettings. Same shape as script path confinement and for the same reason — the population that would be refused on release day is unknown until something reports it. An unrecorded hash is **never** a refusal in any mode.
+
+**The Monitor does not attempt to confirm that verification happened.** The IS asks for that behaviour to be defined, and this is the definition. The runner reports its outcome, the Monitor records what was reported, and records when nothing was. Anything stronger would be a false claim: the Monitor cannot distinguish "verified silently" from "old build" without a protocol version, and an old build ignores a protocol version too. The real guard against a stale runner is the lockstep release, not a runtime check.
+
+**Delivered in two parts.** **S-018a** — schema column, entity, API model, the hash computation in the shared assembly, the mode setting, and the recording endpoint. Nothing reads the column, so it changes no behaviour and ships on its own. **S-018b** — the hash travels in the script group, both PowerShell runners verify before execution, first use records, outcome reported. That half carries the lockstep constraint.
+
+**Two residuals, recorded not closed.** Trust on first use does not authenticate the first read. And verification covers the entry script, not what it dot-sources — a verified script that dot-sources an unverified file from the same share executes unverified code, and no check placed at a single point of read closes that.
 
 ---
 

--- a/docs/deployment-privilege-containment/SPEC-S-018-script-content-verification.md
+++ b/docs/deployment-privilege-containment/SPEC-S-018-script-content-verification.md
@@ -1,0 +1,122 @@
+# SPEC S-018 — Verify script content at the point of read
+
+| Field       | Value                                                        |
+|-------------|--------------------------------------------------------------|
+| **Status**  | DRAFT                                                        |
+| **Step**    | S-018                                                        |
+| **IS**      | IS-deployment-privilege-containment.md                       |
+| **Address** | W-5 (execution half), SD-5, SC-05                            |
+| **Depends** | S-017 (delivered), **U-14 (resolved below)**                 |
+
+---
+
+## 1. What this step is for
+
+W-5 has two halves. The write path — which paths a component may register — is closed by S-010 and S-017. This is the other half: **the bytes actually executed are never checked against anything.**
+
+The share is protected by a gated promotion pipeline, so the threat is not "anyone can write a script". It is that anyone who *does* obtain write access to the share, by any route, gets arbitrary code execution as the deployment account on every deployment that runs that script — with nothing in DOrc that would notice.
+
+Verification cannot be done at dispatch. Dispatch happens in the Monitor; the executed bytes are read later, in a different process, from a network share. Anything checked at dispatch can be swapped in the window between the check and the read, by exactly the actor this exists to stop. **The check has to happen where the bytes are read**, which is `PowerShellScriptRunner.Run`, immediately before `AddScript`.
+
+---
+
+## 2. U-14, resolved
+
+> *Nothing yet specifies who records the hash or how it is re-recorded when the gated pipeline promotes a new version.*
+
+### 2.1 Who records it
+
+**DOrc records it, on first execution of a script whose hash is unrecorded — trust on first use.**
+
+Rejected alternatives, and why:
+
+- **An operator records it by hand.** There are hundreds of registered scripts. A control whose adoption requires hundreds of manual acts is a control that is never adopted, and one whose records go stale the first time anyone forgets.
+- **The promotion pipeline records it at promotion.** This is the correct end state and this spec makes it possible — but it is work in a pipeline outside this repository, and making it a *precondition* means S-018 delivers nothing until that work happens. It becomes the migration target, not the entry condition.
+
+**What trust on first use is worth, stated honestly.** It does not establish that a script was legitimate when first seen. If the share was already compromised, the compromised bytes are what get recorded. What it detects is **change after recording** — which is the actual attack: the share is written to at some point, and every subsequent deployment executes the altered script. It converts a silent, indefinite compromise into a refusal at the next deployment.
+
+It is also what makes the control adoptable at all, because it needs no inventory of what every script currently is.
+
+### 2.2 How it is re-recorded on promotion
+
+Two routes, and both must exist.
+
+**An API endpoint** on the script record that sets or clears the recorded hash. The gated pipeline calls it after promoting a new version; an administrator can call it to clear a hash and let the next execution re-record. Writes are administrator-gated like every other `RefData` write.
+
+**Clearing is not the same as disabling.** A cleared hash means "re-record on next execution". There is no per-script switch that means "never verify this one" — a per-script opt-out is a per-script hole, and the mode configuration below already provides the only opt-out that should exist, at the estate level.
+
+### 2.3 The tolerance mode
+
+Three states, one setting, `ScriptContentVerification` in AppSettings:
+
+| Value | Unrecorded hash | Mismatch |
+|---|---|---|
+| `Off` | ignored | ignored — no verification at all |
+| `Report` *(default)* | recorded | logged against the deployment result; **script executes** |
+| `Enforce` | recorded | **script does not execute**; deployment result fails |
+
+`Report` is the default, for the same reason S-017 reports by default: shipping straight to `Enforce` would fail every deployment whose script had legitimately changed since its hash was recorded, on the day the release lands, across the whole estate. `Report` produces the population of mismatches; `Enforce` is turned on once that population is understood and the pipeline records hashes on promotion.
+
+`Off` exists so that an operator can withdraw the control without a rollback if it misbehaves in an unforeseen way. It is not the default and should not be a resting state.
+
+**An unrecorded hash is never a refusal, in any mode.** It is recorded and execution proceeds. A script executed for the first time after this ships has no recorded hash through no fault of anyone's; refusing it would be arbitrary, and it is the exact case the IS names.
+
+---
+
+## 3. Requirements
+
+### R-1 — The hash
+
+SHA-256 over the **exact bytes read**, not over decoded text. Hashing decoded text would make the answer depend on how each runner decodes it — and the two PowerShell runners are separate assemblies on separate frameworks (.NET 8 and .NET Framework 4.8), so a text-based hash would eventually disagree with itself across the two. The bytes are what execute; the bytes are what is hashed.
+
+Recorded as lower-case hexadecimal. A string rather than a binary column, because it is compared, displayed and set over an API far more often than it is stored.
+
+### R-2 — Where verification happens
+
+Immediately before the script content is handed to PowerShell, in both `Dorc.PowerShell.PowerShellScriptRunner` and `Dorc.NetFramework.PowerShell.PowerShellScriptRunner`. Not earlier: any gap between the read and the execution is the window the check exists to close. The content is read once and both hashed and executed from that single read.
+
+### R-3 — What the runner is told
+
+The expected hash travels in the script group, per script, alongside the path it applies to. A script the Monitor has no hash for carries none, which is the unrecorded case.
+
+### R-4 — The Monitor's behaviour when it cannot confirm verification happened
+
+The IS requires this to be defined. **It is defined as: the Monitor does not attempt to confirm it.**
+
+The runner reports the verification outcome in its result, and the Monitor records it against the deployment result. A runner that performed no verification reports none, and the Monitor records that no verification was reported. It does not refuse, and it does not infer that verification passed.
+
+Anything stronger is a false claim. The Monitor cannot distinguish "the runner verified and said nothing" from "the runner is an old build" without a protocol version, and a protocol version that an old build also ignores establishes nothing. The genuine guard against a stale runner is the release constraint below, not a runtime check.
+
+### R-5 — Release constraint
+
+**Lockstep, not additive.** The script group is deserialized by a serializer that ignores unknown members, so an un-upgraded runner would silently ignore the added hash and execute unverified — the criterion unmet, with no signal. All three runners and both dispatchers ship together. They are packaged in a single installer, so this is achievable; it must not be assumed.
+
+### R-6 — Recording is administrator-gated
+
+Setting or clearing a recorded hash is a write to the script record and follows the existing `RefData` authorization, which already requires `IsAdmin`. Trust-on-first-use recording is performed by the deployment path itself, not by a user.
+
+---
+
+## 4. Delivery
+
+Two changes, in order, because one is safe to ship alone and the other is not.
+
+**S-018a — the record and its API.** Schema column, entity, API model, the hash computation, the mode setting, and the endpoint that sets or clears a recorded hash. **No behaviour change to dispatch or execution**: nothing reads the column yet. Ships independently and is reversible by ignoring the column.
+
+**S-018b — carry and verify.** The hash travels in the script group; both PowerShell runners verify before execution; first-use recording; outcome reported and recorded. **This is the lockstep half** and carries the release constraint of R-5.
+
+---
+
+## 5. Verification intent
+
+- A script whose content changed after its hash was recorded fails verification. Under `Enforce` it does not execute and the deployment result records why; under `Report` it executes and the mismatch is recorded.
+- An unmodified script executes normally in every mode.
+- A script with no recorded hash executes and has its hash recorded, in every mode except `Off`.
+- The hash is computed over bytes, and the two runner implementations agree on the same file.
+- Clearing a recorded hash causes the next execution to re-record it.
+
+## 6. Residual
+
+**Trust on first use does not authenticate the first read.** Stated in 2.1 and worth restating: if the share is already compromised when this ships, the compromised bytes become the baseline. Closing that needs hashes recorded by the promotion pipeline from the artefact it promoted — which this spec makes possible and does not itself deliver.
+
+**Verification covers the entry script, not what it dot-sources.** A verified script that dot-sources an unverified file from the same share executes unverified code. The estate's script conventions decide how much this matters; it is not closed here, and it is not closed by any check placed at a single point of read.

--- a/src/Dorc.Api.Tests/Sources/ScriptContentHashRecordingTests.cs
+++ b/src/Dorc.Api.Tests/Sources/ScriptContentHashRecordingTests.cs
@@ -1,0 +1,238 @@
+using Dorc.Api.Tests.Mocks;
+using Dorc.ApiModel;
+using Dorc.PersistentData;
+using Dorc.PersistentData.Contexts;
+using Dorc.PersistentData.Model;
+using Dorc.PersistentData.Sources;
+using Dorc.PersistentData.Sources.Interfaces;
+using NSubstitute;
+using System.Security.Principal;
+using System.Text;
+
+namespace Dorc.Api.Tests.Sources
+{
+    /// <summary>
+    /// The recorded content hash is what a script is permitted to be. Three properties follow
+    /// from that and are the reason this is not folded into the ordinary script edit.
+    ///
+    /// It must be settable on its own, by a promotion pipeline that has just published a new
+    /// version — otherwise every legitimate promotion looks like tampering at the next
+    /// deployment. It must be clearable, so a script whose new hash nobody knows can be
+    /// re-baselined by the next execution. And it must be audited, because a baseline that
+    /// changes without a promotion behind it is exactly what an investigation would look for.
+    /// </summary>
+    [TestClass]
+    public class ScriptContentHashRecordingTests
+    {
+        private const string ValidHash =
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+        private List<Script> _stored = null!;
+        private IScriptsAuditPersistentSource _audit = null!;
+        private ScriptsPersistentSource _source = null!;
+        private IPrincipal _user = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _stored = new List<Script>
+            {
+                new()
+                {
+                    Id = 1,
+                    Name = "Deploy.ps1",
+                    Path = "Deploy.ps1",
+                    Components = new List<Component>()
+                }
+            };
+
+            // Built into a local first: GetQueryableMockDbSet configures another substitute
+            // internally, and NSubstitute cannot have that happen inside a Returns() argument.
+            var scripts = DbContextMock.GetQueryableMockDbSet(_stored);
+
+            var context = Substitute.For<IDeploymentContext>();
+            context.Scripts.Returns(scripts);
+
+            var contextFactory = Substitute.For<IDeploymentContextFactory>();
+            contextFactory.GetContext().Returns(context);
+
+            var claimsReader = Substitute.For<IClaimsPrincipalReader>();
+            claimsReader.GetUserFullDomainName(Arg.Any<IPrincipal>()).Returns(@"CORP\promoter");
+
+            _audit = Substitute.For<IScriptsAuditPersistentSource>();
+            _user = Substitute.For<IPrincipal>();
+
+            _source = new ScriptsPersistentSource(contextFactory, claimsReader, _audit);
+        }
+
+        [TestMethod]
+        public void RecordsAHashAgainstTheScript()
+        {
+            Assert.IsTrue(_source.RecordContentHash(1, ValidHash, _user));
+
+            Assert.AreEqual(ValidHash, _stored.Single().ContentHash);
+        }
+
+        /// <summary>
+        /// A pipeline handing over an upper-case hash is not making a mistake, and a stored
+        /// baseline that differed only in case from the one the runner computes would refuse a
+        /// script that had never changed.
+        /// </summary>
+        [TestMethod]
+        public void StoresAHashInOneCaseWhateverCaseItArrivesIn()
+        {
+            _source.RecordContentHash(1, ValidHash.ToUpperInvariant(), _user);
+
+            Assert.AreEqual(ValidHash, _stored.Single().ContentHash);
+        }
+
+        /// <summary>
+        /// Refused where it is recorded rather than discovered as a mismatch on the next
+        /// deployment, when the report would say the script had changed and it had not.
+        /// </summary>
+        [TestMethod]
+        [DataRow("not-a-hash")]
+        [DataRow("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a0")]
+        [DataRow("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08a")]
+        [DataRow("zf86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")]
+        public void RefusesAValueThatIsNotShapedLikeASha256Hash(string candidate)
+        {
+            Assert.IsFalse(_source.RecordContentHash(1, candidate, _user));
+
+            Assert.IsNull(_stored.Single().ContentHash);
+        }
+
+        [TestMethod]
+        public void RefusesAScriptThatDoesNotExist()
+        {
+            Assert.IsFalse(_source.RecordContentHash(99, ValidHash, _user));
+        }
+
+        /// <summary>
+        /// Clearing means "re-record on next execution", not "stop verifying this one". There is
+        /// no per-script opt-out, because a per-script opt-out is a per-script hole.
+        /// </summary>
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("   ")]
+        public void ClearsTheRecordedHash(string? cleared)
+        {
+            _source.RecordContentHash(1, ValidHash, _user);
+
+            Assert.IsTrue(_source.RecordContentHash(1, cleared, _user));
+            Assert.IsNull(_stored.Single().ContentHash);
+        }
+
+        [TestMethod]
+        public void AuditsTheChangeWithBothTheOldAndTheNewBaseline()
+        {
+            _source.RecordContentHash(1, ValidHash, _user);
+
+            _audit.Received(1).AddRecord(
+                1,
+                "Deploy.ps1",
+                Arg.Is<string>(from => from.Contains("(unrecorded)")),
+                Arg.Is<string>(to => to.Contains(ValidHash)),
+                @"CORP\promoter",
+                "RecordContentHash",
+                Arg.Any<string>());
+        }
+
+        /// <summary>
+        /// A pipeline that re-promotes an unchanged artefact would otherwise fill the audit trail
+        /// with entries saying nothing happened, which is how a trail stops being read.
+        /// </summary>
+        [TestMethod]
+        public void RecordingTheSameHashAgainIsNotAudited()
+        {
+            _source.RecordContentHash(1, ValidHash, _user);
+            _audit.ClearReceivedCalls();
+
+            Assert.IsTrue(_source.RecordContentHash(1, ValidHash, _user));
+
+            _audit.DidNotReceiveWithAnyArgs().AddRecord(
+                default, default!, default!, default!, default!, default!, default!);
+        }
+
+        /// <summary>
+        /// The general script edit changes what a script is called and how it runs. If it also
+        /// re-baselined what the script is allowed to BE, an unrelated edit would silently
+        /// approve whatever is on the share — which is the state an attacker with script-edit
+        /// rights would want to reach.
+        /// </summary>
+        [TestMethod]
+        public void AnOrdinaryScriptEditLeavesTheBaselineAlone()
+        {
+            _source.RecordContentHash(1, ValidHash, _user);
+
+            _source.UpdateScript(new ScriptApiModel
+            {
+                Id = 1,
+                Name = "Renamed.ps1",
+                Path = "Renamed.ps1",
+                PowerShellVersionNumber = "7.4",
+                ContentHash = null
+            }, _user);
+
+            Assert.AreEqual(ValidHash, _stored.Single().ContentHash);
+        }
+    }
+
+    /// <summary>
+    /// The hash is computed in the shared model assembly precisely so that the API that records
+    /// one and the two PowerShell runners that verify against it cannot disagree — they share no
+    /// other code, and they compile for different frameworks.
+    /// </summary>
+    [TestClass]
+    public class ScriptContentHashTests
+    {
+        [TestMethod]
+        public void HashesTheKnownVectorForTheBytesOfAbc()
+        {
+            // SHA-256("abc"), the published test vector. Pinned so that a change of algorithm or
+            // of hex formatting cannot pass unnoticed - every recorded baseline in the estate
+            // would silently stop matching.
+            Assert.AreEqual(
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                ScriptContentHash.Of(Encoding.ASCII.GetBytes("abc")));
+        }
+
+        /// <summary>
+        /// Over bytes, never over decoded text. A file that differs only by a byte-order mark is
+        /// a different file to PowerShell as well, and a text-based hash would call the two the
+        /// same — while also making the answer depend on which framework decoded it.
+        /// </summary>
+        [TestMethod]
+        public void ADifferenceOfOneByteIsADifferentHash()
+        {
+            var withoutMark = Encoding.UTF8.GetBytes("Write-Host 'x'");
+            var withMark = Encoding.UTF8.GetPreamble()
+                .Concat(withoutMark)
+                .ToArray();
+
+            Assert.AreNotEqual(ScriptContentHash.Of(withoutMark), ScriptContentHash.Of(withMark));
+        }
+
+        [TestMethod]
+        public void MatchesIgnoringCaseAndSurroundingSpace()
+        {
+            var hash = ScriptContentHash.Of(Encoding.ASCII.GetBytes("abc"));
+
+            Assert.IsTrue(ScriptContentHash.Matches($"  {hash.ToUpperInvariant()} ", hash));
+        }
+
+        /// <summary>
+        /// An absent baseline is not a match. It is the unrecorded case, which the caller has to
+        /// handle as its own outcome rather than as a passed or failed verification.
+        /// </summary>
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        public void AnAbsentBaselineNeverMatches(string? recorded)
+        {
+            Assert.IsFalse(ScriptContentHash.Matches(
+                recorded!, ScriptContentHash.Of(Encoding.ASCII.GetBytes("abc"))));
+        }
+    }
+}

--- a/src/Dorc.Api/Controllers/RefDataScriptsController.cs
+++ b/src/Dorc.Api/Controllers/RefDataScriptsController.cs
@@ -57,5 +57,33 @@ namespace Dorc.Api.Controllers
                 ? StatusCode(StatusCodes.Status400BadRequest, "Script must already exist in DOrc!")
                 : StatusCode(StatusCodes.Status200OK, _scriptsPersistentSource.UpdateScript(script, User));
         }
+
+        /// <summary>
+        /// Record, or clear, the content hash a script's bytes are verified against.
+        ///
+        /// This is the route a gated promotion pipeline calls after promoting a new version of a
+        /// script: without it, every legitimate promotion would look like tampering at the next
+        /// deployment. Sending no hash clears the recorded one, which means the next execution
+        /// records what it finds — the way to re-baseline a script whose new hash the caller does
+        /// not know.
+        ///
+        /// Administrators only, rather than PowerUsers as for the general script edit. The
+        /// recorded hash decides what a script is permitted to be; the general edit decides what
+        /// it is called and how it runs. Those are not the same authority.
+        /// </summary>
+        [SwaggerResponse(StatusCodes.Status200OK, Type = typeof(bool))]
+        [HttpPut("{id}/content-hash")]
+        public IActionResult PutContentHash(int id, [FromBody] ScriptContentHashApiModel? contentHash)
+        {
+            if (!_rolePrivilegesChecker.IsAdmin(User))
+                return StatusCode(StatusCodes.Status403Forbidden,
+                    "The script content hash can only be recorded by Admins!");
+
+            return _scriptsPersistentSource.RecordContentHash(id, contentHash?.ContentHash, User)
+                ? StatusCode(StatusCodes.Status200OK, true)
+                : StatusCode(StatusCodes.Status400BadRequest,
+                    "The script must exist in DOrc and the hash, if given, must be 64 hexadecimal"
+                    + " characters (SHA-256).");
+        }
     }
 }

--- a/src/Dorc.ApiModel/ScriptApiModel.cs
+++ b/src/Dorc.ApiModel/ScriptApiModel.cs
@@ -12,6 +12,19 @@ namespace Dorc.ApiModel
         public string InstallScriptName { get; set; }
         public bool IsEnabled { set; get; }
         public string PowerShellVersionNumber { set; get; }
+
+        /// <summary>
+        /// SHA-256, lower-case hex, of the bytes the runner is expected to execute, or null when
+        /// no hash has been recorded.
+        /// </summary>
+        /// <remarks>
+        /// Not settable through the ordinary script edit. It is recorded by the deployment path
+        /// on first use and set deliberately by a promotion pipeline, so folding it into the
+        /// general update would let an edit of a script's NAME silently re-baseline what that
+        /// script is allowed to be.
+        /// </remarks>
+        public string ContentHash { set; get; }
+
         public IList<string> ProjectNames { get; set; }
     }
 }

--- a/src/Dorc.ApiModel/ScriptContentHash.cs
+++ b/src/Dorc.ApiModel/ScriptContentHash.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Dorc.ApiModel
+{
+    /// <summary>
+    /// The identity of a script's content, as recorded and as verified.
+    ///
+    /// This lives in the shared model assembly because both ends need it and they do not share
+    /// anything else: the API records a hash, and two PowerShell runners on two different
+    /// frameworks - .NET 8 and .NET Framework 4.8 - verify one. Two implementations of "the
+    /// hash of this file" is two answers waiting to disagree, and the failure mode of a
+    /// disagreement is a refusal to run a script that was never modified.
+    ///
+    /// Computed over the exact bytes, never over decoded text. Decoding introduces the runner's
+    /// encoding assumptions into the answer, and those are precisely what differs between the
+    /// two frameworks. The bytes are what execute, so the bytes are what is hashed.
+    /// </summary>
+    public static class ScriptContentHash
+    {
+        /// <summary>
+        /// The hash of the content that is about to be executed.
+        /// </summary>
+        /// <param name="content">
+        /// The bytes as read. The caller must hash and execute the SAME read - re-reading the
+        /// file to hash it reopens the window this check exists to close.
+        /// </param>
+        public static string Of(byte[] content)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            using (var sha256 = SHA256.Create())
+            {
+                return ToHex(sha256.ComputeHash(content));
+            }
+        }
+
+        /// <summary>
+        /// Whether a recorded hash and a computed one name the same content.
+        ///
+        /// Case-insensitive: a hash recorded by a pipeline is as likely to arrive upper-case as
+        /// lower, and a comparison that refused a script because someone's tool shouted its hex
+        /// would be a self-inflicted outage rather than a security property.
+        /// </summary>
+        public static bool Matches(string recorded, string computed)
+        {
+            if (string.IsNullOrWhiteSpace(recorded) || string.IsNullOrWhiteSpace(computed))
+            {
+                return false;
+            }
+
+            return string.Equals(recorded.Trim(), computed.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Whether a value is shaped like a SHA-256 hash. Used at the write path so that a
+        /// mistyped or truncated hash is refused when it is recorded rather than discovered as a
+        /// mismatch on the next deployment, when the report says the script changed and it did
+        /// not.
+        /// </summary>
+        public static bool IsWellFormed(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var candidate = value.Trim();
+
+            if (candidate.Length != 64)
+            {
+                return false;
+            }
+
+            foreach (var character in candidate)
+            {
+                var isHex = (character >= '0' && character <= '9')
+                    || (character >= 'a' && character <= 'f')
+                    || (character >= 'A' && character <= 'F');
+
+                if (!isHex)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string ToHex(byte[] hash)
+        {
+            // Written out rather than using Convert.ToHexString, which does not exist on .NET
+            // Framework 4.8 - and this assembly compiles for it.
+            var text = new StringBuilder(hash.Length * 2);
+
+            foreach (var b in hash)
+            {
+                text.Append(b.ToString("x2"));
+            }
+
+            return text.ToString();
+        }
+    }
+}

--- a/src/Dorc.ApiModel/ScriptContentHashApiModel.cs
+++ b/src/Dorc.ApiModel/ScriptContentHashApiModel.cs
@@ -1,0 +1,19 @@
+namespace Dorc.ApiModel
+{
+    /// <summary>
+    /// What a caller sends to record a script's content hash.
+    ///
+    /// A wrapper rather than a bare string body so that the property is named on the wire. A
+    /// promotion pipeline posting a 64-character string with no field name around it is a
+    /// message whose meaning depends entirely on which endpoint it was sent to, and the cost of
+    /// getting that wrong is a script baselined to the wrong content.
+    /// </summary>
+    public class ScriptContentHashApiModel
+    {
+        /// <summary>
+        /// SHA-256, hexadecimal. Null or empty clears the recorded hash, which means the next
+        /// execution records what it finds.
+        /// </summary>
+        public string ContentHash { get; set; }
+    }
+}

--- a/src/Dorc.ApiModel/ScriptContentVerificationMode.cs
+++ b/src/Dorc.ApiModel/ScriptContentVerificationMode.cs
@@ -1,0 +1,34 @@
+namespace Dorc.ApiModel
+{
+    /// <summary>
+    /// How far script content verification is taken.
+    ///
+    /// Three states rather than a boolean, because the interesting question is not "is it on"
+    /// but "does a mismatch stop the deployment". Reporting first and enforcing later is the
+    /// same shape as script path confinement, and for the same reason: the population that would
+    /// be refused on the day of the release is unknown until something reports it.
+    /// </summary>
+    public enum ScriptContentVerificationMode
+    {
+        /// <summary>
+        /// No verification and no recording. Exists so an operator can withdraw the control
+        /// without a rollback if it misbehaves in a way nobody foresaw. Not a resting state.
+        /// </summary>
+        Off,
+
+        /// <summary>
+        /// Verify, record a first-seen hash, report a mismatch — and execute anyway. The
+        /// default. Enforcing on the day of the release would fail every deployment whose script
+        /// had legitimately changed since its hash was recorded, all at once, which is the flag
+        /// day the sequencing rules exist to prevent.
+        /// </summary>
+        Report,
+
+        /// <summary>
+        /// A mismatch refuses the script. An UNRECORDED hash still does not: a script executed
+        /// for the first time after this ships has no recorded hash through nobody's fault, and
+        /// refusing it would be arbitrary.
+        /// </summary>
+        Enforce
+    }
+}

--- a/src/Dorc.Core/Configuration/ConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/ConfigurationSettings.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Dorc.ApiModel;
+using Microsoft.Extensions.Configuration;
 
 namespace Dorc.Core.Configuration
 {
@@ -202,6 +203,23 @@ namespace Dorc.Core.Configuration
             var value = _configuration.GetSection("AppSettings")["EnforceScriptPathConfinement"];
 
             return bool.TryParse(value, out bool enforce) && enforce;
+        }
+
+        /// <summary>
+        /// How far script content verification is taken.
+        ///
+        /// Absence, and any value that is not recognised, means Report. An unreadable setting
+        /// must not be able to turn the control off silently, and must not be able to turn
+        /// enforcement on either — a typo that refused every deployment in the estate would be a
+        /// self-inflicted outage.
+        /// </summary>
+        public ScriptContentVerificationMode GetScriptContentVerificationMode()
+        {
+            var value = _configuration.GetSection("AppSettings")["ScriptContentVerification"];
+
+            return Enum.TryParse<ScriptContentVerificationMode>(value, ignoreCase: true, out var mode)
+                ? mode
+                : ScriptContentVerificationMode.Report;
         }
 
         /// <summary>

--- a/src/Dorc.Core/Configuration/IConfigurationSettings.cs
+++ b/src/Dorc.Core/Configuration/IConfigurationSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Dorc.Core.Configuration
+﻿using Dorc.ApiModel;
+
+namespace Dorc.Core.Configuration
 {
     public interface IConfigurationSettings
     {
@@ -52,6 +54,12 @@
         /// only reported. Absence means report.
         /// </summary>
         bool GetScriptPathEnforcementEnabled();
+
+        /// <summary>
+        /// How far script content verification is taken. Absence, or an unrecognised value,
+        /// means <see cref="ScriptContentVerificationMode.Report"/>.
+        /// </summary>
+        ScriptContentVerificationMode GetScriptContentVerificationMode();
 
         /// <summary>
         /// Whether deployment credentials come from the secrets vault rather than DOrc's own

--- a/src/Dorc.Database/Schema Objects/Schemas/deploy/Tables/Script.table.sql
+++ b/src/Dorc.Database/Schema Objects/Schemas/deploy/Tables/Script.table.sql
@@ -5,7 +5,18 @@
     [InstallScriptName]         VARCHAR (200)  NULL,
 	[IsPathJSON]                BIT            NOT NULL,
     [NonProdOnly]               BIT NOT NULL DEFAULT 0,
-    [PowerShellVersionNumber]   NVARCHAR (4) NULL
+    [PowerShellVersionNumber]   NVARCHAR (4) NULL,
+    -- SHA-256, lower-case hex, of the bytes the runner is expected to execute.
+    --
+    -- NULL means unrecorded, which is the state every existing row is in and is never itself a
+    -- refusal: a script executed for the first time after this shipped has no recorded hash
+    -- through nobody's fault. The deployment path records one on first use and verifies against
+    -- it thereafter, so what this detects is CHANGE after recording - which is the attack, the
+    -- share being written to and every subsequent deployment executing the altered script.
+    --
+    -- Text rather than BINARY(32) because it is compared, displayed and set over an API far more
+    -- often than it is stored, and a promotion pipeline recording one is handing over hex.
+    [ContentHash]               CHAR (64) NULL
 );
 
 

--- a/src/Dorc.PersistentData/Model/Script.cs
+++ b/src/Dorc.PersistentData/Model/Script.cs
@@ -8,6 +8,13 @@
         public bool IsPathJSON { get; set; }
         public bool NonProdOnly { get; set; }
         public string? PowerShellVersionNumber { set; get; }
+
+        /// <summary>
+        /// SHA-256, lower-case hex, of the bytes the runner is expected to execute. Null means
+        /// unrecorded — the state of every row that predates this, and never a refusal on its
+        /// own.
+        /// </summary>
+        public string? ContentHash { set; get; }
         public ICollection<Component> Components { set; get; } = new List<Component>();
     }
 }

--- a/src/Dorc.PersistentData/Sources/Interfaces/IScriptsPersistentSource.cs
+++ b/src/Dorc.PersistentData/Sources/Interfaces/IScriptsPersistentSource.cs
@@ -8,5 +8,11 @@ namespace Dorc.PersistentData.Sources.Interfaces
         GetScriptsListResponseDto GetScriptsByPage(int limit, int page, PagedDataOperators operators);
         ScriptApiModel GetScript(int id);
         bool UpdateScript(ScriptApiModel script, IPrincipal user);
+
+        /// <summary>
+        /// Sets or clears the recorded content hash. A null or empty hash clears it, which means
+        /// "re-record on next execution" rather than "stop verifying this one".
+        /// </summary>
+        bool RecordContentHash(int scriptId, string? contentHash, IPrincipal user);
     }
 }

--- a/src/Dorc.PersistentData/Sources/ScriptsPersistentSource.cs
+++ b/src/Dorc.PersistentData/Sources/ScriptsPersistentSource.cs
@@ -169,6 +169,75 @@ namespace Dorc.PersistentData.Sources
             }
         }
 
+        /// <summary>
+        /// Sets or clears the recorded content hash for a script.
+        ///
+        /// Separate from <see cref="UpdateScript"/> deliberately. The recorded hash decides what
+        /// a script is allowed to BE, and the general edit is where someone renames a script or
+        /// changes its PowerShell version — folding the two together would let an unrelated edit
+        /// silently re-baseline the content, which is precisely the state an attacker with
+        /// script-edit rights would want to reach.
+        ///
+        /// Clearing (a null hash) means "re-record on next execution", not "stop verifying this
+        /// one". There is no per-script opt-out, because a per-script opt-out is a per-script
+        /// hole; withdrawing the control is an estate-wide setting.
+        /// </summary>
+        /// <returns>False when no such script exists, or the hash is not shaped like one.</returns>
+        public bool RecordContentHash(int scriptId, string? contentHash, IPrincipal user)
+        {
+            var recording = string.IsNullOrWhiteSpace(contentHash)
+                ? null
+                : contentHash!.Trim().ToLowerInvariant();
+
+            if (recording != null && !ScriptContentHash.IsWellFormed(recording))
+            {
+                // Refused where it is recorded rather than discovered as a mismatch on the next
+                // deployment, when the report would say the script had changed and it had not.
+                return false;
+            }
+
+            using (var context = _contextFactory.GetContext())
+            {
+                var foundScript = context.Scripts
+                    .Include(s => s.Components).ThenInclude(c => c.Projects)
+                    .FirstOrDefault(s => s.Id == scriptId);
+
+                if (foundScript == null)
+                    return false;
+
+                if (string.Equals(foundScript.ContentHash, recording, StringComparison.Ordinal))
+                {
+                    // Already what it is being set to. Recording it again would add an audit
+                    // entry saying nothing happened, and a pipeline that re-promotes an
+                    // unchanged artefact would fill the audit trail with them.
+                    return true;
+                }
+
+                var fromValue = $"ContentHash={foundScript.ContentHash ?? "(unrecorded)"}";
+                var toValue = $"ContentHash={recording ?? "(unrecorded)"}";
+
+                foundScript.ContentHash = recording;
+
+                var projectNames = string.Join(", ", foundScript.Components
+                    .SelectMany(c => c.Projects)
+                    .Select(p => p.Name)
+                    .Distinct());
+
+                context.SaveChanges();
+
+                // Audited like any other change to a script. A hash that changes without a
+                // promotion behind it is exactly the thing an investigation would want to find,
+                // and an unaudited security baseline is not a baseline.
+                _scriptsAuditPersistentSource.AddRecord(
+                    foundScript.Id, foundScript.Name, fromValue, toValue,
+                    _claimsPrincipalReader.GetUserFullDomainName(user),
+                    recording == null ? "ClearContentHash" : "RecordContentHash",
+                    projectNames);
+
+                return true;
+            }
+        }
+
         private static ScriptApiModel MapToScriptApiModel(Script script)
         {
             if (script == null) return null;
@@ -192,6 +261,7 @@ namespace Dorc.PersistentData.Sources
                 IsPathJSON = script.IsPathJSON,
                 IsEnabled = isEnabled,
                 PowerShellVersionNumber = script.PowerShellVersionNumber,
+                ContentHash = script.ContentHash,
                 ProjectNames = script.Components?.SelectMany(s => s.Projects).Select(p => p.Name).ToList()
             };
         }


### PR DESCRIPTION
Closes #876. Stacked on #875 (`sec/22-config-visibility-ui`) — review that first; this diff shows only its own step.

## What this does

Gives a script a recorded content baseline, an administrator-gated way to set or clear it, and the setting that decides how far verification is taken. **Nothing reads the column yet** — this half changes no behaviour and is reversible by ignoring it. The verify half is the next PR and carries the lockstep release constraint.

It also resolves **U-14**, which had blocked the step since the IS was written. The reasoning is in `SPEC-S-018-script-content-verification.md`; the summary is in #876.

## What reviewers should look at

**Recording is separate from the ordinary script edit, deliberately.** `RecordContentHash` is its own method on its own endpoint. The baseline decides what a script is permitted to *be*; the general edit decides what it is called and how it runs. Folding them together would let an unrelated edit silently re-baseline the content — which is the state an attacker with script-edit rights would want to reach. There is a test for exactly that.

**The endpoint is Admin-only, where the general script edit is PowerUser-or-Admin.** Deliberate: those are not the same authority.

**A malformed hash is refused where it is recorded**, not discovered as a mismatch on the next deployment — when the report would say the script had changed and it had not.

**The hash lives in `Dorc.ApiModel`.** That assembly is netstandard2.0 and shared with the .NET Framework 4.8 runner, which is why `Convert.ToHexString` is written out by hand. It lives there because the API records a baseline and two PowerShell runners on two different frameworks verify against it, and they share no other code — two implementations of "the hash of this file" is two answers waiting to disagree, and a disagreement means refusing a script that was never modified.

**Computed over bytes, never over decoded text.** Decoding introduces each framework's encoding assumptions into the answer; the bytes are what execute.

**Re-recording an identical hash is not audited.** A pipeline that re-promotes an unchanged artefact would otherwise fill the audit trail with entries saying nothing happened, which is how a trail stops being read.

## Verification

`Dorc.Api.Tests` 362 passed (was 344) — 18 new covering recording, clearing, malformed input, the audit entry, the no-op case, that an ordinary script edit leaves the baseline alone, and the SHA-256 test vector pinned so a change of algorithm or hex formatting cannot pass unnoticed. `Dorc.Core.Tests` 261 and `Dorc.Monitor.Tests` 130 (+11 skipped) unchanged and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_