### PR TITLE
S-018b: verify script content against its baseline at the point of read

### DIFF
--- a/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
+++ b/docs/deployment-privilege-containment/IS-deployment-privilege-containment.md
@@ -46,7 +46,7 @@ Four rules determine the order below. They are stated up front because several a
 | ⚙ S-015 | Rotate the deployment credentials | SD-3, W-4 | **Runbook delivered**; gate satisfied, operator-executed |
 | ⚙ S-016 | Remediate off-share script paths | SD-5 precondition | **Worklist queries delivered** (`S-016-off-share-script-paths.sql`); operator-executed |
 | S-017 | Confine script paths at dispatch | SD-5, W-5, SC-05 | **DONE** — reports by default, enforce after S-016 |
-| S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | **U-14 resolved**, see `SPEC-S-018-*`; a) record **DONE**, b) verify **lockstep** |
+| S-018 | Verify script content at the point of read | SD-5, W-5, SC-05 | **DONE** — U-14 resolved in `SPEC-S-018-*`; **b) is a lockstep release** |
 | S-019 | Introduce config-value visibility classification | SD-3b, W-4 | **DONE** — server and web UI |
 | S-020 | Introduce the credential provider abstraction | SD-4 | **DONE** |
 | S-021 | Bind execution identity to the environment | SD-4, W-6, W-15, SC-07, W-8a | **DONE** — opt-in per environment; W-8a closed here |
@@ -409,6 +409,10 @@ Everything in it is read-only except a remediation template that is commented ou
 **The Monitor does not attempt to confirm that verification happened.** The IS asks for that behaviour to be defined, and this is the definition. The runner reports its outcome, the Monitor records what was reported, and records when nothing was. Anything stronger would be a false claim: the Monitor cannot distinguish "verified silently" from "old build" without a protocol version, and an old build ignores a protocol version too. The real guard against a stale runner is the lockstep release, not a runtime check.
 
 **Delivered in two parts.** **S-018a** — schema column, entity, API model, the hash computation in the shared assembly, the mode setting, and the recording endpoint. Nothing reads the column, so it changes no behaviour and ships on its own. **S-018b** — the hash travels in the script group, both PowerShell runners verify before execution, first use records, outcome reported. That half carries the lockstep constraint.
+
+**The baseline is captured by the Monitor at dispatch, not by the runner.** This was decided while implementing and is worth recording, because the obvious alternative is worse in exactly the scenario the step is about: a runner that recorded the bytes in front of it would record *the attacker's* bytes as the baseline and report a match. Capturing at dispatch and verifying at the point of read covers the dispatch-to-read window on the very first deployment too, rather than merely baselining it. Nothing in capture refuses — a share that cannot be read fails the deployment moments later, for its own reasons and with its own message.
+
+**The verification mode travels on the script group.** The runner does not read it from its own configuration: that would let a deployment host with a stale or edited configuration file quietly execute unverified, and the deployment host is the least trustworthy place to keep the answer.
 
 **Two residuals, recorded not closed.** Trust on first use does not authenticate the first read. And verification covers the entry script, not what it dot-sources — a verified script that dot-sources an unverified file from the same share executes unverified code, and no check placed at a single point of read closes that.
 

--- a/docs/deployment-privilege-containment/SPEC-S-018-script-content-verification.md
+++ b/docs/deployment-privilege-containment/SPEC-S-018-script-content-verification.md
@@ -2,7 +2,7 @@
 
 | Field       | Value                                                        |
 |-------------|--------------------------------------------------------------|
-| **Status**  | DRAFT                                                        |
+| **Status**  | DELIVERED                                                    |
 | **Step**    | S-018                                                        |
 | **IS**      | IS-deployment-privilege-containment.md                       |
 | **Address** | W-5 (execution half), SD-5, SC-05                            |
@@ -26,7 +26,9 @@ Verification cannot be done at dispatch. Dispatch happens in the Monitor; the ex
 
 ### 2.1 Who records it
 
-**DOrc records it, on first execution of a script whose hash is unrecorded — trust on first use.**
+**DOrc records it, on first dispatch of a script whose hash is unrecorded — trust on first use.**
+
+More precisely: the **Monitor** captures the baseline from the share at dispatch, and the **runner** verifies against it at the point of read. The split matters and is not an implementation detail — see R-2.
 
 Rejected alternatives, and why:
 
@@ -51,7 +53,7 @@ Three states, one setting, `ScriptContentVerification` in AppSettings:
 
 | Value | Unrecorded hash | Mismatch |
 |---|---|---|
-| `Off` | ignored | ignored — no verification at all |
+| `Off` | not recorded | ignored — no verification at all |
 | `Report` *(default)* | recorded | logged against the deployment result; **script executes** |
 | `Enforce` | recorded | **script does not execute**; deployment result fails |
 
@@ -71,27 +73,37 @@ SHA-256 over the **exact bytes read**, not over decoded text. Hashing decoded te
 
 Recorded as lower-case hexadecimal. A string rather than a binary column, because it is compared, displayed and set over an API far more often than it is stored.
 
-### R-2 — Where verification happens
+### R-2 — Where the baseline is captured, and why not in the runner
+
+The Monitor captures it at dispatch. The obvious alternative — the runner records what it is about to execute when it finds no baseline — is worse, and worse in the exact scenario the step is about: a runner recording the bytes in front of it would record *the attacker's* bytes as the baseline and report a match.
+
+Capturing at dispatch and verifying at the point of read means the first deployment after adoption is covered across the dispatch-to-read window too, not merely baselined. Two processes reading the same file at two moments is not a weaker check than one process reading it once — it is a stronger one, provided the comparison happens at the later read. Which is R-3.
+
+Nothing in capture refuses. A share that cannot be read at that moment, or a script that is not there, fails the deployment moments later for its own reasons and with its own message; failing it at capture would replace that message with a worse one.
+
+### R-3 — Where verification happens
 
 Immediately before the script content is handed to PowerShell, in both `Dorc.PowerShell.PowerShellScriptRunner` and `Dorc.NetFramework.PowerShell.PowerShellScriptRunner`. Not earlier: any gap between the read and the execution is the window the check exists to close. The content is read once and both hashed and executed from that single read.
 
-### R-3 — What the runner is told
+### R-4 — What the runner is told
 
 The expected hash travels in the script group, per script, alongside the path it applies to. A script the Monitor has no hash for carries none, which is the unrecorded case.
 
-### R-4 — The Monitor's behaviour when it cannot confirm verification happened
+**The mode travels with it, on the group.** The runner does not read the estate's setting from its own configuration: that would let a deployment host with a stale or edited configuration file quietly execute unverified, and the deployment host is the least trustworthy place to keep the answer.
+
+### R-5 — The Monitor's behaviour when it cannot confirm verification happened
 
 The IS requires this to be defined. **It is defined as: the Monitor does not attempt to confirm it.**
 
-The runner reports the verification outcome in its result, and the Monitor records it against the deployment result. A runner that performed no verification reports none, and the Monitor records that no verification was reported. It does not refuse, and it does not infer that verification passed.
+The runner writes the outcome to the deployment's own log — a warning for an unrecorded baseline or a reported mismatch, an error for a refusal — and an enforced refusal fails the deployment by refusing to execute. The Monitor does not ask whether verification took place and does not infer that it passed; a runner that performed none simply logs none.
 
 Anything stronger is a false claim. The Monitor cannot distinguish "the runner verified and said nothing" from "the runner is an old build" without a protocol version, and a protocol version that an old build also ignores establishes nothing. The genuine guard against a stale runner is the release constraint below, not a runtime check.
 
-### R-5 — Release constraint
+### R-6 — Release constraint
 
 **Lockstep, not additive.** The script group is deserialized by a serializer that ignores unknown members, so an un-upgraded runner would silently ignore the added hash and execute unverified — the criterion unmet, with no signal. All three runners and both dispatchers ship together. They are packaged in a single installer, so this is achievable; it must not be assumed.
 
-### R-6 — Recording is administrator-gated
+### R-7 — Recording is administrator-gated
 
 Setting or clearing a recorded hash is a write to the script record and follows the existing `RefData` authorization, which already requires `IsAdmin`. Trust-on-first-use recording is performed by the deployment path itself, not by a user.
 
@@ -103,7 +115,7 @@ Two changes, in order, because one is safe to ship alone and the other is not.
 
 **S-018a — the record and its API.** Schema column, entity, API model, the hash computation, the mode setting, and the endpoint that sets or clears a recorded hash. **No behaviour change to dispatch or execution**: nothing reads the column yet. Ships independently and is reversible by ignoring the column.
 
-**S-018b — carry and verify.** The hash travels in the script group; both PowerShell runners verify before execution; first-use recording; outcome reported and recorded. **This is the lockstep half** and carries the release constraint of R-5.
+**S-018b — carry and verify.** The Monitor captures a first-seen baseline and puts it in the script group along with the estate's mode; both PowerShell runners verify the bytes they read before executing them. **This is the lockstep half** and carries the release constraint of R-6.
 
 ---
 

--- a/src/Dorc.Api.Tests/Sources/ScriptContentGateTests.cs
+++ b/src/Dorc.Api.Tests/Sources/ScriptContentGateTests.cs
@@ -1,0 +1,148 @@
+using Dorc.ApiModel;
+using System.Text;
+
+namespace Dorc.Api.Tests.Sources
+{
+    /// <summary>
+    /// The decision the runner makes immediately before executing a script.
+    ///
+    /// It lives in the shared model assembly and is tested here because the two PowerShell
+    /// runners compile for different frameworks and share nothing else. Two implementations of
+    /// "may this run" would be two answers waiting to diverge, and the divergence would be
+    /// silent — one runner refusing what the other executes, on the same script, depending only
+    /// on which PowerShell version a component happens to be pinned to.
+    /// </summary>
+    [TestClass]
+    public class ScriptContentGateTests
+    {
+        private static readonly byte[] Content = Encoding.UTF8.GetBytes("Write-Host 'deploy'");
+
+        private static string BaselineOfContent => ScriptContentHash.Of(Content);
+
+        private const string BaselineOfSomethingElse =
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+        [TestMethod]
+        [DataRow(ScriptContentVerificationMode.Report)]
+        [DataRow(ScriptContentVerificationMode.Enforce)]
+        public void UnmodifiedContentExecutes(ScriptContentVerificationMode mode)
+        {
+            Assert.IsTrue(ScriptContentGate.MayExecute(
+                mode, BaselineOfContent, Content, out var verdict, out _));
+
+            Assert.AreEqual(ScriptContentVerdict.Matched, verdict);
+        }
+
+        [TestMethod]
+        public void ModifiedContentDoesNotExecuteWhenEnforcing()
+        {
+            Assert.IsFalse(ScriptContentGate.MayExecute(
+                ScriptContentVerificationMode.Enforce, BaselineOfSomethingElse, Content,
+                out var verdict, out var explanation));
+
+            Assert.AreEqual(ScriptContentVerdict.Mismatched, verdict);
+            Assert.IsTrue(explanation.Contains("has not been executed"));
+        }
+
+        /// <summary>
+        /// Reporting is the default because enforcing on the day of the release would fail every
+        /// deployment whose script had legitimately changed since its baseline was taken, all at
+        /// once. The mismatch is still a mismatch — it is recorded, and the script runs.
+        /// </summary>
+        [TestMethod]
+        public void ModifiedContentExecutesWhenOnlyReporting()
+        {
+            Assert.IsTrue(ScriptContentGate.MayExecute(
+                ScriptContentVerificationMode.Report, BaselineOfSomethingElse, Content,
+                out var verdict, out var explanation));
+
+            Assert.AreEqual(ScriptContentVerdict.Mismatched, verdict);
+            Assert.IsTrue(explanation.Contains("report rather than enforce"));
+        }
+
+        /// <summary>
+        /// A script executed for the first time after this shipped has no baseline through
+        /// nobody's fault. Refusing it would be arbitrary, and it is exactly the case that makes
+        /// a naive implementation break dispatch on every legitimate update.
+        /// </summary>
+        [TestMethod]
+        [DataRow(ScriptContentVerificationMode.Report, null)]
+        [DataRow(ScriptContentVerificationMode.Report, "")]
+        [DataRow(ScriptContentVerificationMode.Enforce, null)]
+        [DataRow(ScriptContentVerificationMode.Enforce, "   ")]
+        public void AnUnrecordedBaselineIsNeverARefusal(
+            ScriptContentVerificationMode mode, string? baseline)
+        {
+            Assert.IsTrue(ScriptContentGate.MayExecute(
+                mode, baseline!, Content, out var verdict, out _));
+
+            Assert.AreEqual(ScriptContentVerdict.Unrecorded, verdict);
+        }
+
+        [TestMethod]
+        public void NothingIsComparedWhenVerificationIsOff()
+        {
+            Assert.IsTrue(ScriptContentGate.MayExecute(
+                ScriptContentVerificationMode.Off, BaselineOfSomethingElse, Content,
+                out var verdict, out _));
+
+            Assert.AreEqual(ScriptContentVerdict.NotVerified, verdict);
+        }
+
+        /// <summary>
+        /// A mismatch report is written into the log of a deployment that refused to run the
+        /// script. Quoting the difference would put the modified script's content — which is
+        /// whatever an attacker chose to write — into that log.
+        /// </summary>
+        [TestMethod]
+        public void TheExplanationCarriesHashesAndNoScriptContent()
+        {
+            ScriptContentGate.MayExecute(
+                ScriptContentVerificationMode.Enforce, BaselineOfSomethingElse,
+                Encoding.UTF8.GetBytes("Invoke-Expression $env:PAYLOAD"),
+                out _, out var explanation);
+
+            Assert.IsFalse(explanation.Contains("Invoke-Expression"));
+            Assert.IsTrue(explanation.Contains(BaselineOfSomethingElse));
+        }
+    }
+
+    /// <summary>
+    /// Verification and execution have to operate on a single read: reading the file twice, once
+    /// to hash and once to run, leaves a window in which the file can be substituted — which is
+    /// the window the whole step exists to close. Decoding therefore happens from the bytes that
+    /// were verified, and it has to decode them the way File.ReadAllText did before, or scripts
+    /// would change behaviour for reasons unrelated to this.
+    /// </summary>
+    [TestClass]
+    public class ScriptTextTests
+    {
+        [TestMethod]
+        public void DecodesUtf8WithoutAByteOrderMark()
+        {
+            var content = Encoding.UTF8.GetBytes("Write-Host 'héllo'");
+
+            Assert.AreEqual("Write-Host 'héllo'", ScriptText.Decode(content));
+        }
+
+        [TestMethod]
+        public void HonoursAByteOrderMarkAndDoesNotLeaveItInTheText()
+        {
+            var content = Encoding.UTF8.GetPreamble()
+                .Concat(Encoding.UTF8.GetBytes("Write-Host 'x'"))
+                .ToArray();
+
+            Assert.AreEqual("Write-Host 'x'", ScriptText.Decode(content));
+        }
+
+        [TestMethod]
+        public void DecodesAnAlternativeEncodingAnnouncedByItsMark()
+        {
+            var content = Encoding.Unicode.GetPreamble()
+                .Concat(Encoding.Unicode.GetBytes("Write-Host 'x'"))
+                .ToArray();
+
+            Assert.AreEqual("Write-Host 'x'", ScriptText.Decode(content));
+        }
+    }
+}

--- a/src/Dorc.ApiModel/ScriptContentGate.cs
+++ b/src/Dorc.ApiModel/ScriptContentGate.cs
@@ -1,0 +1,117 @@
+using System;
+
+namespace Dorc.ApiModel
+{
+    /// <summary>
+    /// What verification found. Four outcomes rather than a boolean, because three of them are
+    /// not failures and treating them as one would either refuse legitimate deployments or hide
+    /// the case that matters.
+    /// </summary>
+    public enum ScriptContentVerdict
+    {
+        /// <summary>Verification is switched off. Nothing was computed and nothing was compared.</summary>
+        NotVerified,
+
+        /// <summary>
+        /// No baseline had been recorded for this script. Never a refusal: a script executed for
+        /// the first time after this shipped has no baseline through nobody's fault.
+        /// </summary>
+        Unrecorded,
+
+        /// <summary>The bytes about to execute are the bytes that were recorded.</summary>
+        Matched,
+
+        /// <summary>
+        /// The bytes about to execute are NOT the bytes that were recorded. The script changed
+        /// on the share after its baseline was taken — which is either a promotion nobody
+        /// recorded, or the thing this exists to catch.
+        /// </summary>
+        Mismatched
+    }
+
+    /// <summary>
+    /// Decides whether the content a runner has just read may be executed.
+    ///
+    /// One decision, shared. The two PowerShell runners compile for different frameworks and
+    /// share no code but this assembly; two implementations of "may this run" is two answers
+    /// waiting to diverge, and the divergence would be silent — one runner refusing what the
+    /// other executes, on the same script, depending only on which PowerShell version a
+    /// component happens to be pinned to.
+    ///
+    /// The gate is given the CONTENT, not a path. Re-reading the file to hash it would reopen
+    /// the window the whole step exists to close: the caller hashes and executes the same read.
+    /// </summary>
+    public static class ScriptContentGate
+    {
+        /// <summary>
+        /// Evaluates the content against its recorded baseline.
+        /// </summary>
+        /// <param name="mode">How far verification is taken.</param>
+        /// <param name="recordedHash">The baseline, or null when none has been recorded.</param>
+        /// <param name="content">The exact bytes about to be executed.</param>
+        /// <param name="verdict">What was found.</param>
+        /// <param name="explanation">
+        /// What to log, in every outcome but <see cref="ScriptContentVerdict.Matched"/>.
+        /// Contains hashes and no script content: a mismatch report that quoted the difference
+        /// would put the modified script into the log of a deployment that refused to run it.
+        /// </param>
+        /// <returns>False only when the content must not execute.</returns>
+        public static bool MayExecute(
+            ScriptContentVerificationMode mode,
+            string recordedHash,
+            byte[] content,
+            out ScriptContentVerdict verdict,
+            out string explanation)
+        {
+            explanation = string.Empty;
+
+            if (mode == ScriptContentVerificationMode.Off)
+            {
+                verdict = ScriptContentVerdict.NotVerified;
+                explanation = "Script content verification is switched off.";
+                return true;
+            }
+
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            if (string.IsNullOrWhiteSpace(recordedHash))
+            {
+                verdict = ScriptContentVerdict.Unrecorded;
+                explanation =
+                    "No content baseline had been recorded for this script, so there was nothing to"
+                    + " verify against. The baseline is recorded from this execution and verified"
+                    + " from the next one.";
+                return true;
+            }
+
+            var computed = ScriptContentHash.Of(content);
+
+            if (ScriptContentHash.Matches(recordedHash, computed))
+            {
+                verdict = ScriptContentVerdict.Matched;
+                return true;
+            }
+
+            verdict = ScriptContentVerdict.Mismatched;
+
+            if (mode == ScriptContentVerificationMode.Enforce)
+            {
+                explanation =
+                    "The script's content does not match its recorded baseline and has not been"
+                    + $" executed. Recorded '{recordedHash}', found '{computed}'. Either the script"
+                    + " was promoted without its baseline being re-recorded, or it was modified on"
+                    + " the share.";
+                return false;
+            }
+
+            explanation =
+                "The script's content does not match its recorded baseline. It has been executed"
+                + " because script content verification is set to report rather than enforce."
+                + $" Recorded '{recordedHash}', found '{computed}'.";
+            return true;
+        }
+    }
+}

--- a/src/Dorc.ApiModel/ScriptContentVerificationException.cs
+++ b/src/Dorc.ApiModel/ScriptContentVerificationException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Dorc.ApiModel
+{
+    /// <summary>
+    /// Thrown when a script's content does not match its recorded baseline and verification is
+    /// being enforced.
+    ///
+    /// A type of its own rather than a bare exception so that the refusal is distinguishable
+    /// from the script having failed. Those are different outcomes for whoever reads the
+    /// deployment result: one says the deployment did not do what it was meant to, the other
+    /// says the thing it was about to run was not what it was supposed to be.
+    /// </summary>
+    public class ScriptContentVerificationException : Exception
+    {
+        public ScriptContentVerificationException(string message)
+            : base(message)
+        {
+        }
+
+        public ScriptContentVerificationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Dorc.ApiModel/ScriptGroup.cs
+++ b/src/Dorc.ApiModel/ScriptGroup.cs
@@ -30,6 +30,17 @@ namespace Dorc.ApiModel
         public string GitHubRunId { get; set; }
         public string GitHubApiBaseUrl { get; set; }
 
+        /// <summary>
+        /// How far the runner takes content verification.
+        ///
+        /// Carried rather than read by the runner from its own configuration. The Monitor is
+        /// where the estate's setting lives, and a runner reading its own would let a host with
+        /// a stale or edited configuration file quietly execute unverified — which is the
+        /// deployment host, the least trustworthy place to keep the answer.
+        /// </summary>
+        public ScriptContentVerificationMode ContentVerification { get; set; }
+            = ScriptContentVerificationMode.Report;
+
         public IDictionary<string, VariableValue> CommonProperties { get; set; }
         public IList<ScriptProperties> ScriptProperties { get; set; }
     }

--- a/src/Dorc.ApiModel/ScriptProperties.cs
+++ b/src/Dorc.ApiModel/ScriptProperties.cs
@@ -8,6 +8,18 @@ namespace Dorc.ApiModel
     public class ScriptProperties
     {
         public string ScriptPath { get; set; }
+
+        /// <summary>
+        /// The content baseline this script's bytes are verified against, or null when none has
+        /// been recorded.
+        /// </summary>
+        /// <remarks>
+        /// Travels with the path rather than with the group, because it is a property of one
+        /// script. A group holds every script sharing a PowerShell version, and they do not
+        /// share a baseline.
+        /// </remarks>
+        public string ExpectedContentHash { get; set; }
+
         public IDictionary<string, VariableValue> Properties { get; set; }
     }
 }

--- a/src/Dorc.ApiModel/ScriptText.cs
+++ b/src/Dorc.ApiModel/ScriptText.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text;
+
+namespace Dorc.ApiModel
+{
+    /// <summary>
+    /// Turns the bytes that were verified into the text that is executed.
+    ///
+    /// This exists because verification and execution must operate on a single read. Reading the
+    /// file twice — once as bytes to hash and once as text to run — leaves a window between the
+    /// two in which the file can be substituted, which is exactly the window the verification is
+    /// there to close.
+    ///
+    /// The decoding reproduces what <c>File.ReadAllText</c> did before: UTF-8 by default, with
+    /// the byte-order mark of another encoding honoured if one is present. Reproducing it
+    /// exactly matters — a script that decoded one way yesterday and another way today would
+    /// change behaviour for reasons that have nothing to do with this step.
+    /// </summary>
+    public static class ScriptText
+    {
+        public static string Decode(byte[] content)
+        {
+            using (var stream = new MemoryStream(content))
+            using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+    }
+}

--- a/src/Dorc.Monitor.Tests/ScriptContentBaselineTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptContentBaselineTests.cs
@@ -1,0 +1,230 @@
+using Dorc.ApiModel;
+using Dorc.ApiModel.MonitorRunnerApi;
+using Dorc.Core.Configuration;
+using Dorc.Core.Security;
+using Dorc.Monitor.Pipes;
+using Dorc.PersistentData.Security;
+using Dorc.PersistentData.Sources.Interfaces;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.Security.Principal;
+using System.Text;
+
+namespace Dorc.Monitor.Tests
+{
+    /// <summary>
+    /// The Monitor's half of script content verification: it puts the baseline into the group the
+    /// runner receives, and records one from the share when none exists yet.
+    ///
+    /// The split between capture here and verification in the runner is the whole point.
+    /// Verifying here would be defeated by the design — dispatch happens in this process and the
+    /// executed bytes are read later, from a network share, by another one, so anything checked
+    /// here can be swapped in the window by exactly the actor the step exists to stop.
+    ///
+    /// Capturing here, on the other hand, is *better* than capturing in the runner would be. A
+    /// baseline read at dispatch and verified at the point of read covers the dispatch-to-read
+    /// window on the very first deployment too, where a runner recording what it was about to
+    /// execute would be recording the attacker's bytes and reporting a match.
+    /// </summary>
+    [TestClass]
+    public class ScriptContentBaselineTests
+    {
+        private const string RecordedBaseline =
+            "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+        private string _scriptRoot = null!;
+        private string _scriptFile = null!;
+        private IScriptGroupPipeServer _pipeServer = null!;
+        private IConfigurationSettings _settings = null!;
+        private IScriptsPersistentSource _scripts = null!;
+
+        private static IDeploymentCredentialSource CredentialSource()
+        {
+            var source = Substitute.For<IDeploymentCredentialSource>();
+            source.Description.Returns("test");
+            source.Resolve(Arg.Any<DeploymentTier>())
+                .Returns(new DeploymentCredential("svc-dorc", "password"));
+            source.Resolve(Arg.Any<DeploymentTier>(), Arg.Any<string?>())
+                .Returns(new DeploymentCredential("svc-dorc", "password"));
+            return source;
+        }
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _scriptRoot = Path.Join(Path.GetTempPath(), "dorc-script-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_scriptRoot);
+            _scriptFile = Path.Combine(_scriptRoot, "Deploy.ps1");
+            File.WriteAllText(_scriptFile, "Write-Host 'deploy'");
+
+            _pipeServer = Substitute.For<IScriptGroupPipeServer>();
+            _scripts = Substitute.For<IScriptsPersistentSource>();
+            _scripts.RecordContentHash(Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<IPrincipal>())
+                .Returns(true);
+
+            _settings = Substitute.For<IConfigurationSettings>();
+            // Empty domain: the dispatch fails at the security context, which a test host cannot
+            // build. Everything under test happens before that point.
+            _settings.GetConfigurationDomainNameIntra().Returns(string.Empty);
+            _settings.GetScriptContentVerificationMode().Returns(ScriptContentVerificationMode.Report);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_scriptRoot))
+            {
+                Directory.Delete(_scriptRoot, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// Drives dispatch to the point where the security context is built and no further, and
+        /// returns the group that was published on the way. Building that context is Windows
+        /// interop against a real account, which a test host cannot satisfy.
+        /// </summary>
+        private ScriptGroup DispatchAndCaptureGroup(string? recordedBaseline)
+        {
+            ScriptGroup? published = null;
+            _pipeServer
+                .When(server => server.Start(
+                    Arg.Any<string>(), Arg.Any<ScriptGroup>(),
+                    Arg.Any<ScriptGroupReaderIdentity>(), Arg.Any<CancellationToken>()))
+                .Do(call => published = call.ArgAt<ScriptGroup>(1));
+
+            var dispatcher = new ScriptDispatcher(
+                Substitute.For<IDeploymentRequestProcessesPersistentSource>(),
+                Substitute.For<IConfigValuesPersistentSource>(),
+                Substitute.For<ILogger<ScriptDispatcher>>(),
+                _pipeServer,
+                _settings,
+                Substitute.For<IRequestsPersistentSource>(),
+                Substitute.For<IScriptScopeConfigValues>(),
+                CredentialSource(),
+                _scripts);
+
+            try
+            {
+                dispatcher.Dispatch(
+                    _scriptRoot,
+                    new ScriptApiModel
+                    {
+                        Id = 7,
+                        Path = "Deploy.ps1",
+                        PowerShellVersionNumber = "7.4",
+                        ContentHash = recordedBaseline
+                    },
+                    new Dictionary<string, VariableValue>(),
+                    requestId: 42,
+                    deploymentRequestId: 42,
+                    isProduction: false,
+                    environmentName: "SOME-ENV",
+                    executionIdentityReference: null,
+                    new StringBuilder(),
+                    CancellationToken.None);
+            }
+            catch (Exception)
+            {
+                // Expected: the security context cannot be built on a test host. The group has
+                // been published by then, which is what is under test.
+            }
+
+            Assert.IsNotNull(published, "The script group was never published.");
+            return published;
+        }
+
+        [TestMethod]
+        public void CarriesTheRecordedBaselineToTheRunner()
+        {
+            var group = DispatchAndCaptureGroup(RecordedBaseline);
+
+            Assert.AreEqual(RecordedBaseline, group.ScriptProperties.Single().ExpectedContentHash);
+        }
+
+        /// <summary>
+        /// Carried rather than read by the runner from its own configuration. A runner reading
+        /// its own would let a deployment host with a stale or edited configuration file quietly
+        /// execute unverified — and the deployment host is the least trustworthy place to keep
+        /// the answer.
+        /// </summary>
+        [TestMethod]
+        [DataRow(ScriptContentVerificationMode.Report)]
+        [DataRow(ScriptContentVerificationMode.Enforce)]
+        [DataRow(ScriptContentVerificationMode.Off)]
+        public void CarriesTheEstatesModeToTheRunner(ScriptContentVerificationMode mode)
+        {
+            _settings.GetScriptContentVerificationMode().Returns(mode);
+
+            Assert.AreEqual(mode, DispatchAndCaptureGroup(RecordedBaseline).ContentVerification);
+        }
+
+        /// <summary>
+        /// Trust on first use, and worth being plain about what it is: it does not establish that
+        /// the script was legitimate when first seen. What it detects is change AFTER recording,
+        /// which is the actual attack — and it is what makes the control adoptable without an
+        /// inventory of what every script in the estate currently is.
+        /// </summary>
+        [TestMethod]
+        public void RecordsABaselineFromTheShareWhenNoneHasBeenRecorded()
+        {
+            var expected = ScriptContentHash.Of(File.ReadAllBytes(_scriptFile));
+
+            var group = DispatchAndCaptureGroup(recordedBaseline: null);
+
+            _scripts.Received(1).RecordContentHash(7, expected, Arg.Any<IPrincipal>());
+            Assert.AreEqual(expected, group.ScriptProperties.Single().ExpectedContentHash);
+        }
+
+        [TestMethod]
+        public void DoesNotReRecordABaselineThatAlreadyExists()
+        {
+            DispatchAndCaptureGroup(RecordedBaseline);
+
+            _scripts.DidNotReceiveWithAnyArgs()
+                .RecordContentHash(default, default, default!);
+        }
+
+        [TestMethod]
+        public void RecordsNothingAndCarriesNothingWhenVerificationIsOff()
+        {
+            _settings.GetScriptContentVerificationMode().Returns(ScriptContentVerificationMode.Off);
+
+            var group = DispatchAndCaptureGroup(recordedBaseline: null);
+
+            _scripts.DidNotReceiveWithAnyArgs()
+                .RecordContentHash(default, default, default!);
+            Assert.IsNull(group.ScriptProperties.Single().ExpectedContentHash);
+        }
+
+        /// <summary>
+        /// A share that cannot be read at this moment is a deployment failure moments later, for
+        /// its own reasons and with its own message. Failing it here would replace that message
+        /// with a worse one, and baseline capture is not what the deployment is for.
+        /// </summary>
+        [TestMethod]
+        public void DoesNotFailTheDispatchWhenTheScriptCannotBeReadToBaselineIt()
+        {
+            File.Delete(_scriptFile);
+
+            var group = DispatchAndCaptureGroup(recordedBaseline: null);
+
+            Assert.IsNull(group.ScriptProperties.Single().ExpectedContentHash);
+        }
+
+        /// <summary>
+        /// If the baseline could not be stored, carrying it to the runner would mean verifying
+        /// against something no later deployment will agree with — a match today and a mismatch
+        /// tomorrow, for a script nobody touched.
+        /// </summary>
+        [TestMethod]
+        public void CarriesNoBaselineWhenOneCouldNotBeRecorded()
+        {
+            _scripts.RecordContentHash(Arg.Any<int>(), Arg.Any<string?>(), Arg.Any<IPrincipal>())
+                .Returns(false);
+
+            var group = DispatchAndCaptureGroup(recordedBaseline: null);
+
+            Assert.IsNull(group.ScriptProperties.Single().ExpectedContentHash);
+        }
+    }
+}

--- a/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptGroupBundleLifetimeTests.cs
@@ -98,7 +98,8 @@ namespace Dorc.Monitor.Tests
                 _configurationSettings,
                 Substitute.For<IRequestsPersistentSource>(),
                 _scriptScopeConfigValues,
-                _credentialSource);
+                _credentialSource,
+                Substitute.For<IScriptsPersistentSource>());
 
         /// <summary>
         /// Dispatch is driven to the point where the Runner's security context is built and no
@@ -295,7 +296,8 @@ namespace Dorc.Monitor.Tests
                 settings,
                 Substitute.For<IRequestsPersistentSource>(),
                 scopeValues,
-                CredentialSourceFor("svc-dorc", "password"));
+                CredentialSourceFor("svc-dorc", "password"),
+                Substitute.For<IScriptsPersistentSource>());
 
             var properties = new Dictionary<string, VariableValue>
             {

--- a/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
+++ b/src/Dorc.Monitor.Tests/ScriptPathDispatchConfinementTests.cs
@@ -78,7 +78,8 @@ namespace Dorc.Monitor.Tests
                 _settings,
                 Substitute.For<IRequestsPersistentSource>(),
                 Substitute.For<IScriptScopeConfigValues>(),
-                _credentialSource);
+                _credentialSource,
+                Substitute.For<IScriptsPersistentSource>());
 
         private bool Dispatch(string storedScriptPath)
         {

--- a/src/Dorc.Monitor/ScriptDispatcher.cs
+++ b/src/Dorc.Monitor/ScriptDispatcher.cs
@@ -8,6 +8,7 @@ using Dorc.PersistentData.Security;
 using Dorc.PersistentData.Sources.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using System.Security.Principal;
 using System.Text;
 using System.Text.Json;
 using Dorc.Monitor.RunnerProcess;
@@ -26,6 +27,7 @@ namespace Dorc.Monitor
         private readonly IRequestsPersistentSource requestsPersistentSource;
         private readonly IScriptScopeConfigValues _scriptScopeConfigValues;
         private readonly IDeploymentCredentialSource _credentialSource;
+        private readonly IScriptsPersistentSource _scriptsPersistentSource;
 
         private bool isScriptExecutionSuccessful; // This field is needed to be instance-wide since Runner process errors are processed as instance-wide events.
 
@@ -39,8 +41,10 @@ namespace Dorc.Monitor
             IConfigurationSettings configurationSettingsEngine,
             IRequestsPersistentSource requestsPersistentSource,
             IScriptScopeConfigValues scriptScopeConfigValues,
-            IDeploymentCredentialSource credentialSource)
+            IDeploymentCredentialSource credentialSource,
+            IScriptsPersistentSource scriptsPersistentSource)
         {
+            this._scriptsPersistentSource = scriptsPersistentSource;
             this.processesPersistentSource = processesPersistentSource;
             this._configValuesPersistentSource = configValuesPersistentSource;
             this.logger = logger;
@@ -105,6 +109,8 @@ namespace Dorc.Monitor
                 isScriptExecutionSuccessful = false;
                 return isScriptExecutionSuccessful;
             }
+
+            ApplyContentBaseline(script, scriptGroups);
 
             foreach (ScriptGroup scriptGroup in scriptGroups)
             {
@@ -382,6 +388,121 @@ namespace Dorc.Monitor
 
             // Reporting mode reports and proceeds. Only enforcement stops the deployment.
             return confined || !enforcing;
+        }
+
+        /// <summary>
+        /// Puts the script's content baseline into the group the runner will receive, recording
+        /// one from the share when none exists yet.
+        ///
+        /// The baseline is *captured* here and *verified* in the runner, and the split is the
+        /// whole point. Verifying here would be defeated by the design: dispatch happens in this
+        /// process and the executed bytes are read later, from a network share, by another one.
+        /// Anything checked here can be swapped in that window by exactly the actor this exists
+        /// to stop.
+        ///
+        /// Capturing here is a different matter, and capturing here is better than capturing in
+        /// the runner would be. A baseline read at dispatch and verified at the point of read
+        /// covers the dispatch-to-read window on the very first deployment too — where a runner
+        /// that recorded what it was about to execute would be recording the attacker's bytes as
+        /// the baseline and reporting a match.
+        ///
+        /// Nothing here refuses. A share that cannot be read at this moment, or a script that is
+        /// not there, is a deployment failure moments later for its own reasons and with its own
+        /// message; failing it here would replace that message with a worse one.
+        /// </summary>
+        private void ApplyContentBaseline(ScriptApiModel script, IEnumerable<ScriptGroup> scriptGroups)
+        {
+            var mode = configurationSettingsEngine.GetScriptContentVerificationMode();
+
+            foreach (var scriptGroup in scriptGroups)
+            {
+                scriptGroup.ContentVerification = mode;
+            }
+
+            if (mode == ScriptContentVerificationMode.Off)
+            {
+                return;
+            }
+
+            var baseline = script.ContentHash;
+
+            if (string.IsNullOrWhiteSpace(baseline))
+            {
+                baseline = RecordFirstSeenBaseline(script, scriptGroups);
+            }
+
+            if (string.IsNullOrWhiteSpace(baseline))
+            {
+                return;
+            }
+
+            foreach (var scriptGroup in scriptGroups)
+            {
+                foreach (var scriptProperties in scriptGroup.ScriptProperties)
+                {
+                    scriptProperties.ExpectedContentHash = baseline;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Trust on first use. Worth being honest about what this is and is not: it does not
+        /// establish that the script was legitimate when first seen — if the share was already
+        /// compromised, the compromised bytes become the baseline. What it detects is change
+        /// *after* recording, which is the actual attack, and it is what makes the control
+        /// adoptable without an inventory of what every script in the estate currently is.
+        /// </summary>
+        private string? RecordFirstSeenBaseline(ScriptApiModel script, IEnumerable<ScriptGroup> scriptGroups)
+        {
+            var path = scriptGroups
+                .SelectMany(group => group.ScriptProperties)
+                .Select(properties => properties.ScriptPath)
+                .FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate));
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            try
+            {
+                var baseline = ScriptContentHash.Of(File.ReadAllBytes(path));
+
+                // A synthetic principal, because there is no user here — this is the deployment
+                // engine baselining a script, and the audit entry should say so. The Monitor's
+                // claims reader reports the service's own configured identity whatever it is
+                // handed, so the name below is what makes the intent legible in code rather than
+                // what lands in the audit trail.
+                var engine = new GenericPrincipal(new GenericIdentity("DOrc deployment engine"), null);
+
+                if (!_scriptsPersistentSource.RecordContentHash(script.Id, baseline, engine))
+                {
+                    logger.LogWarning(
+                        "Could not record a content baseline for script {ScriptId} ('{ScriptPath}')."
+                        + " It will be verified from whenever one is recorded.",
+                        script.Id, path);
+
+                    return null;
+                }
+
+                logger.LogInformation(
+                    "Recorded a first-seen content baseline for script {ScriptId} ('{ScriptPath}')."
+                    + " Subsequent deployments verify against it.",
+                    script.Id, path);
+
+                return baseline;
+            }
+            catch (Exception ex)
+            {
+                // Reading the share can fail for every ordinary reason. The deployment is about
+                // to fail on its own for the same reason and say so more usefully.
+                logger.LogWarning(ex,
+                    "Could not read '{ScriptPath}' to record a content baseline. The script will be"
+                    + " dispatched without one.",
+                    path);
+
+                return null;
+            }
         }
 
         private void Report(bool enforcing, string? scriptPath, string scriptsLocation, string reason)

--- a/src/Dorc.NetFramework.PowerShell/IPowerShellScriptRunner.cs
+++ b/src/Dorc.NetFramework.PowerShell/IPowerShellScriptRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 
 namespace Dorc.NetFramework.PowerShell
@@ -6,8 +7,9 @@ namespace Dorc.NetFramework.PowerShell
     public interface IPowerShellScriptRunner
     {
         void Run(string scriptsLocation,
-            IEnumerable<(string, IDictionary<string, VariableValue>)> scripts,
-            IDictionary<string, VariableValue> commonProperties
+            IEnumerable<(string, IDictionary<string, VariableValue>, string)> scripts,
+            IDictionary<string, VariableValue> commonProperties,
+            ScriptContentVerificationMode contentVerification
         );
     }
 }

--- a/src/Dorc.NetFramework.PowerShell/PowerShellScriptRunner.cs
+++ b/src/Dorc.NetFramework.PowerShell/PowerShellScriptRunner.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
+using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Runner.Logger;
 using Newtonsoft.Json;
@@ -25,13 +26,35 @@ namespace Dorc.NetFramework.PowerShell
         }
 
         public void Run(string scriptsLocation,
-            IEnumerable<(string, IDictionary<string, VariableValue>)> scripts,
-            IDictionary<string, VariableValue> commonProperties)
+            IEnumerable<(string, IDictionary<string, VariableValue>, string)> scripts,
+            IDictionary<string, VariableValue> commonProperties,
+            ScriptContentVerificationMode contentVerification)
         {
-            foreach ((string, IDictionary<string, VariableValue>) script in scripts)
+            foreach ((string, IDictionary<string, VariableValue>, string) script in scripts)
             {
                 string scriptName = script.Item1;
                 logger.FileLogger.LogInformation("\tStarting execution of script '" + scriptName + "'.");
+
+                // Read once. The content that is hashed is the content that is executed -
+                // re-reading the file to verify it would reopen the very window this closes,
+                // because between the two reads anyone with write access to the share can
+                // substitute the file.
+                byte[] content = File.ReadAllBytes(scriptName);
+
+                ScriptContentVerdict verdict;
+                string explanation;
+                if (!ScriptContentGate.MayExecute(
+                        contentVerification, script.Item3, content, out verdict, out explanation))
+                {
+                    logger.FileLogger.LogError("{0} Script: '{1}'.", explanation, scriptName);
+                    throw new ScriptContentVerificationException(
+                        "Refusing to execute '" + scriptName + "'. " + explanation);
+                }
+
+                if (verdict != ScriptContentVerdict.Matched)
+                {
+                    logger.FileLogger.LogWarning("{0} Script: '{1}'.", explanation, scriptName);
+                }
 
                 IDictionary<string, VariableValue> scriptProperties = script.Item2;
                 IDictionary<string, VariableValue> combinedProperties = this.CombineProperties(scriptProperties, commonProperties);
@@ -59,7 +82,7 @@ namespace Dorc.NetFramework.PowerShell
                                 powerShell.AddCommand("Set-Location").AddParameter("Path", scriptsLocation);
                             }
 
-                            powerShell.AddScript(File.ReadAllText(scriptName));
+                            powerShell.AddScript(ScriptText.Decode(content));
                             logger.FileLogger.LogInformation($"Adding Script for execution '{scriptName}'.");
 
                             // create a data collection for standard output

--- a/src/Dorc.NetFramework.Runner/ScriptGroupProcessor.cs
+++ b/src/Dorc.NetFramework.Runner/ScriptGroupProcessor.cs
@@ -45,8 +45,10 @@ namespace Dorc.NetFramework.Runner
 
                 scriptRunner.Run(
                     scriptGroupProperties.ScriptsLocation,
-                    scriptGroupProperties.ScriptProperties.Select(p => (p.ScriptPath, p.Properties)),
-                   scriptGroupProperties.CommonProperties);
+                    scriptGroupProperties.ScriptProperties.Select(p =>
+                        (p.ScriptPath, p.Properties, p.ExpectedContentHash)),
+                   scriptGroupProperties.CommonProperties,
+                   scriptGroupProperties.ContentVerification);
 
             }
             catch (Exception e)

--- a/src/Dorc.PowerShell/IPowerShellScriptRunner.cs
+++ b/src/Dorc.PowerShell/IPowerShellScriptRunner.cs
@@ -1,4 +1,5 @@
-﻿using Dorc.ApiModel.MonitorRunnerApi;
+﻿using Dorc.ApiModel;
+using Dorc.ApiModel.MonitorRunnerApi;
 
 namespace Dorc.PowerShell
 {
@@ -7,7 +8,9 @@ namespace Dorc.PowerShell
         int Run(string scriptsLocation,
             string scriptName,
             IDictionary<string, VariableValue> scriptProperties,
-            IDictionary<string, VariableValue> commonProperties
+            IDictionary<string, VariableValue> commonProperties,
+            ScriptContentVerificationMode contentVerification,
+            string? expectedContentHash
         );
     }
 }

--- a/src/Dorc.PowerShell/PowerShellScriptRunner.cs
+++ b/src/Dorc.PowerShell/PowerShellScriptRunner.cs
@@ -1,3 +1,4 @@
+using Dorc.ApiModel;
 using Dorc.ApiModel.MonitorRunnerApi;
 using Dorc.Runner.Logger;
 using Newtonsoft.Json;
@@ -19,9 +20,30 @@ namespace Dorc.PowerShell
         public int Run(string scriptsLocation,
             string scriptName,
             IDictionary<string, VariableValue> scriptProperties,
-            IDictionary<string, VariableValue> commonProperties)
+            IDictionary<string, VariableValue> commonProperties,
+            ScriptContentVerificationMode contentVerification,
+            string? expectedContentHash)
         {
             logger.FileLogger.LogInformation("Starting execution of script '{0}'", scriptName);
+
+            // Read once. The content that is hashed is the content that is executed - re-reading
+            // the file to verify it would reopen the very window this closes, because between
+            // the two reads anyone with write access to the share can substitute the file.
+            var content = File.ReadAllBytes(scriptName);
+
+            if (!ScriptContentGate.MayExecute(
+                    contentVerification, expectedContentHash!, content,
+                    out var verdict, out var explanation))
+            {
+                logger.FileLogger.LogError("{0} Script: '{1}'.", explanation, scriptName);
+                throw new ScriptContentVerificationException(
+                    $"Refusing to execute '{scriptName}'. {explanation}");
+            }
+
+            if (verdict != ScriptContentVerdict.Matched)
+            {
+                logger.FileLogger.LogWarning("{0} Script: '{1}'.", explanation, scriptName);
+            }
 
             IDictionary<string, VariableValue> combinedProperties = CombineProperties(scriptProperties, commonProperties);
 
@@ -43,7 +65,7 @@ namespace Dorc.PowerShell
                             powerShell.AddCommand("Set-Location").AddParameter("Path", scriptsLocation);
                         }
 
-                        powerShell.AddScript(File.ReadAllText(scriptName));
+                        powerShell.AddScript(ScriptText.Decode(content));
 
                         var outputCollection = new PSDataCollection<string>();
                         outputCollection.DataAdded += (sender, e) =>

--- a/src/Dorc.Runner/ScriptGroupProcessor.cs
+++ b/src/Dorc.Runner/ScriptGroupProcessor.cs
@@ -41,7 +41,9 @@ namespace Dorc.Runner
                     scriptGroupProperties.ScriptsLocation,
                     scriptProps.ScriptPath,
                     scriptProps.Properties,
-                    scriptGroupProperties.CommonProperties);
+                    scriptGroupProperties.CommonProperties,
+                    scriptGroupProperties.ContentVerification,
+                    scriptProps.ExpectedContentHash);
             }
 
             return sumResult;            


### PR DESCRIPTION
Closes #878. Stacked on #877 (`sec/23-script-content-record`) — review that first; this diff shows only its own step. **This is the last step of the deployment privilege containment sequence.**

## ⚠️ This PR is a lockstep release, not an additive one

The script group is deserialized by a serializer that ignores unknown members. A runner that has not been upgraded will **silently ignore the baseline and execute unverified** — the criterion unmet, with no signal at all. All three runners and both dispatchers must go out together. They are in a single installer, so this is achievable; please confirm it rather than assume it.

## What reviewers should look at

**`ScriptContentGate.MayExecute` is the whole decision, and it is shared.** The two PowerShell runners compile for different frameworks and share nothing but `Dorc.ApiModel`. Two implementations of "may this run" would be two answers waiting to diverge, silently — one runner refusing what the other executes, on the same script, depending only on which PowerShell version a component is pinned to.

**One read, hashed and executed.** `File.ReadAllBytes` replaces `File.ReadAllText`, and `ScriptText.Decode` turns the verified bytes into the text `AddScript` receives. It reproduces `ReadAllText`'s decoding — UTF-8 by default, byte-order mark honoured — so no script changes behaviour for reasons unrelated to this. Reading twice would reopen the window inside the runner.

**Capture is in the Monitor; verification is in the runner.** The reasoning is in `ScriptDispatcher.ApplyContentBaseline` and worth reading before judging the split: a runner that recorded what it was about to execute would record the attacker's bytes as the baseline and report a match.

**Nothing in capture refuses.** A share that cannot be read fails the deployment moments later for its own reasons and with its own message; failing it at capture would replace that message with a worse one. Likewise, if the baseline could not be *stored*, none is carried — verifying against something no later deployment will agree with would give a match today and a mismatch tomorrow for a script nobody touched.

**The mode travels on the group.** The runner does not read it from its own configuration: a deployment host with a stale or edited configuration file would otherwise quietly execute unverified, and that host is the least trustworthy place to keep the answer.

**A refusal throws rather than returning -1.** An enforced mismatch is not the script having failed — it is the thing about to run not being what it was supposed to be — so it gets its own exception type and stops the rest of the group.

**The mismatch message carries hashes and no script content.** That message is written into the log of a deployment that refused to run the script; quoting the difference would put the attacker's chosen bytes into it. There is a test for that.

## Verification

- `Dorc.Monitor.Tests` 154 passed, 11 skipped (was 145/11) — 9 new covering baseline carriage, mode carriage in all three modes, first-use recording, no re-recording when one exists, nothing recorded when off, and the two failure paths above.
- `Dorc.Api.Tests` 375 passed (was 362) — 13 new covering every gate outcome in every mode, that an unrecorded baseline is never a refusal, that the explanation carries no script content, and that decoding reproduces `ReadAllText` including byte-order marks.
- `Dorc.Core.Tests` 261 passed.

**Not verified by compilation: the .NET Framework 4.8 half.** `Dorc.NetFramework.PowerShell` and `Dorc.NetFramework.Runner` cannot be built in this environment — the v4.8 reference assemblies are not installed, so `msbuild` fails before reaching any of my changes. Those two files are edited to mirror the .NET 8 runner exactly (three-element tuple, explicit `out` variables, no C# 8+ syntax, same shared types from `Dorc.ApiModel`), but **they need a build on a Windows agent before this merges.** Flagging it rather than letting a green .NET 8 result imply more than it covers.

## Sequence status

With this, every step S-000 through S-023 is delivered or, for the operational steps (S-000, S-013, S-015, S-016), delivered as a runbook or worklist for an operator to execute. The residuals each step leaves open are recorded in the IS rather than closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT2gJnb8LC4DGHT2bDTCJk)_