### PR TITLE
Redesign connection status indicator with pill badges

### DIFF
--- a/src/dorc-web/src/components/connection-status-indicator.ts
+++ b/src/dorc-web/src/components/connection-status-indicator.ts
@@ -146,6 +146,12 @@ export class ConnectionStatusIndicator extends LitElement {
   private get titleText() {
     const state = `Connection: ${this.state}`;
     if (this.mode === 'toggle') {
+      if (this.status === 'reconnecting') {
+        return `Reconnecting - live updates will resume automatically\n${state}`;
+      }
+      if (this.status === 'offline') {
+        return `Connection lost - live updates unavailable\n${state}`;
+      }
       return this.autoRefresh
         ? `Live updates on (click to pause)\n${state}`
         : `Live updates paused (click to resume)\n${state}`;

--- a/src/dorc-web/src/components/connection-status-indicator.ts
+++ b/src/dorc-web/src/components/connection-status-indicator.ts
@@ -182,7 +182,7 @@ export class ConnectionStatusIndicator extends LitElement {
         class="${this.pillClass}"
         role="status"
         .title="${this.titleText}"
-        aria-label="${this.label} (${this.state})"
+        aria-label="${this.label}"
       >
         <span class="dot"></span><span>${this.label}</span>
       </span>

--- a/src/dorc-web/src/components/connection-status-indicator.ts
+++ b/src/dorc-web/src/components/connection-status-indicator.ts
@@ -1,56 +1,161 @@
-import { LitElement, css } from 'lit';
+import { LitElement, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { html } from 'lit/html.js';
-import '@vaadin/button';
-import '@vaadin/icon';
-import '../icons/custom-icons.js';
 import { HubConnectionState } from '@microsoft/signalr';
+
+type IndicatorStatus = 'live' | 'paused' | 'reconnecting' | 'offline';
 
 /**
  * Connection Status Indicator
+ *
+ * Compact pill badge with a status dot reflecting the SignalR hub state:
+ *  - Live         connected (auto refresh on in toggle mode), pulsing green dot
+ *  - Paused       auto refresh switched off (toggle mode only), grey dot
+ *  - Reconnecting connecting/reconnecting, pulsing amber dot
+ *  - Offline      disconnected or errored, red dot
+ *
  * Modes:
- *  - toggle: renders a button that toggles auto refresh (emits 'toggle-auto-refresh')
- *  - icon: renders a passive status icon only when state !== HubConnectionState.Connected
+ *  - toggle: clickable pill that toggles auto refresh (emits 'toggle-auto-refresh')
+ *  - icon: passive pill; hidden while Connected unless showWhenConnected is set
  */
 @customElement('connection-status-indicator')
 export class ConnectionStatusIndicator extends LitElement {
   @property({ type: String }) state: string | undefined = HubConnectionState.Disconnected;
   @property({ type: Boolean }) autoRefresh: boolean = false;
   @property({ type: String }) mode: 'toggle' | 'icon' = 'icon';
-  /** When mode=icon, show icon even if Connected */
+  /** When mode=icon, show the pill even if Connected */
   @property({ type: Boolean }) showWhenConnected: boolean = false;
 
   static styles = css`
-    :host { display: inline-flex; }
-    vaadin-button { padding:0; margin:0; }
-    vaadin-icon { width: var(--lumo-icon-size-m); height: var(--lumo-icon-size-m); }
+    :host {
+      display: inline-flex;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      font-family: var(--lumo-font-family, sans-serif);
+      font-size: var(--lumo-font-size-xxs, 0.75rem);
+      font-weight: 500;
+      line-height: 1.4;
+      letter-spacing: 0.02em;
+      white-space: nowrap;
+      user-select: none;
+      cursor: default;
+    }
+
+    button.pill {
+      cursor: pointer;
+    }
+
+    button.pill:hover {
+      filter: brightness(0.95);
+    }
+
+    .dot {
+      position: relative;
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: currentColor;
+      flex: none;
+    }
+
+    .pulse .dot::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 50%;
+      background: currentColor;
+      animation: csi-pulse 2s ease-out infinite;
+    }
+
+    @keyframes csi-pulse {
+      0% {
+        transform: scale(1);
+        opacity: 0.6;
+      }
+      70%,
+      100% {
+        transform: scale(2.6);
+        opacity: 0;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse .dot::after {
+        animation: none;
+        display: none;
+      }
+    }
+
+    .live {
+      color: var(--dorc-success-text, #1a7a2e);
+      background: var(--dorc-success-bg, #b1ffb7);
+      border-color: color-mix(in srgb, currentColor 25%, transparent);
+    }
+
+    .paused {
+      color: var(--dorc-text-secondary, #747f8d);
+      background: var(--dorc-bg-tertiary, #eee);
+      border-color: color-mix(in srgb, currentColor 25%, transparent);
+    }
+
+    .reconnecting {
+      color: var(--dorc-warning-text, #856404);
+      background: var(--dorc-warning-bg, #fff3cd);
+      border-color: color-mix(in srgb, currentColor 25%, transparent);
+    }
+
+    .offline {
+      color: var(--dorc-error-color, #ff3131);
+      background: var(--dorc-failure-bg, #ffd9d9);
+      border-color: color-mix(in srgb, currentColor 25%, transparent);
+    }
   `;
 
-  private get iconName() {
-    if (this.mode === 'toggle') {
-      return this.autoRefresh ? 'custom:refresh-auto' : 'custom:refresh-auto-off';
+  private get status(): IndicatorStatus {
+    if (
+      this.state === HubConnectionState.Connecting ||
+      this.state === HubConnectionState.Reconnecting
+    ) {
+      return 'reconnecting';
     }
-    // passive mode: only one icon variant - reuse off icon when not connected
-    if (this.state !== HubConnectionState.Connected) return 'custom:refresh-auto-off';
-    return 'custom:refresh-auto';
+    if (this.state !== HubConnectionState.Connected) return 'offline';
+    if (this.mode === 'toggle' && !this.autoRefresh) return 'paused';
+    return 'live';
   }
 
-  private get iconColor() {
-    if (this.mode === 'toggle') {
-      if (this.state !== HubConnectionState.Connected) return 'var(--lumo-error-color)';
-      return 'var(--dorc-link-color)';
+  private get label() {
+    switch (this.status) {
+      case 'live':
+        return 'Live';
+      case 'paused':
+        return 'Paused';
+      case 'reconnecting':
+        return 'Reconnecting…';
+      default:
+        return 'Offline';
     }
-    if (this.state !== HubConnectionState.Connected) return 'var(--lumo-error-color)';
-    return 'var(--dorc-link-color)';
   }
 
   private get titleText() {
+    const state = `Connection: ${this.state}`;
     if (this.mode === 'toggle') {
       return this.autoRefresh
-        ? `Auto refresh ON (click to switch to manual)\nState: ${this.state}`
-        : `Manual mode (click to enable auto refresh)\nState: ${this.state}`;
+        ? `Live updates on (click to pause)\n${state}`
+        : `Live updates paused (click to resume)\n${state}`;
     }
-    return this.state;
+    return state;
+  }
+
+  private get pillClass() {
+    const pulse = this.status === 'live' || this.status === 'reconnecting';
+    return `pill ${this.status}${pulse ? ' pulse' : ''}`;
   }
 
   private toggle() {
@@ -60,24 +165,27 @@ export class ConnectionStatusIndicator extends LitElement {
   render() {
     if (this.mode === 'toggle') {
       return html`
-        <vaadin-button
-          theme="icon small tertiary-inline"
-          style="padding:0;margin:0"
+        <button
+          type="button"
+          class="${this.pillClass}"
           .title="${this.titleText}"
+          aria-pressed="${this.autoRefresh}"
           @click="${this.toggle}"
         >
-          <vaadin-icon icon="${this.iconName}" style="color:${this.iconColor}"></vaadin-icon>
-        </vaadin-button>
+          <span class="dot"></span><span>${this.label}</span>
+        </button>
       `;
     }
-    if (!this.showWhenConnected && this.state === HubConnectionState.Connected) return html``;
+    if (!this.showWhenConnected && this.state === HubConnectionState.Connected) return nothing;
     return html`
-      <vaadin-icon
-        icon="${this.iconName}"
+      <span
+        class="${this.pillClass}"
+        role="status"
         .title="${this.titleText}"
-        aria-label="${this.state}"
-        style="color:${this.iconColor}; margin:4px;"
-      ></vaadin-icon>
+        aria-label="${this.label} (${this.state})"
+      >
+        <span class="dot"></span><span>${this.label}</span>
+      </span>
     `;
   }
 }

--- a/src/dorc-web/src/components/environment-tabs/env-monitor.ts
+++ b/src/dorc-web/src/components/environment-tabs/env-monitor.ts
@@ -41,6 +41,10 @@ import type { PropertyValues } from 'lit';
 import type { PageLocation } from '../../helpers/page-element';
 import { PageEnvBase } from './page-env-base';
 import { ResponsiveMixin } from '../../helpers/responsive-mixin';
+import {
+  SilentGridRefresher,
+  silentRefreshStyles
+} from '../../helpers/silent-grid-refresh';
 
 const username = 'Username';
 const status = 'Status';
@@ -52,9 +56,7 @@ const id = 'Id';
 export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploymentsEventsClient{
   @query('#grid') grid: Grid | undefined;
 
-  // since grid is being refreshed with multiple requests (pages) in non-deterministic way,
-  // we need to store the max count of items before refresh to keep grid's cache size
-  maxCountBeforeRefresh: number | undefined;
+  private silentRefresh = new SilentGridRefresher(() => this.grid);
 
   private hubConnection: HubConnection | undefined;
 
@@ -89,7 +91,9 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
   }
 
   static get styles() {
-    return css`
+    return [
+      silentRefreshStyles,
+      css`
       :host {
         display: flex;
         flex-direction: column;
@@ -115,13 +119,6 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
         margin: 0px;
       }
 
-      /* During background (silent) refreshes keep the previous cell content
-         visible instead of Vaadin's hidden loading rows - stops the grid
-         flashing blank on every SignalR-triggered refresh. */
-      vaadin-grid[silent-refresh] vaadin-grid-cell-content {
-        visibility: visible;
-      }
-
       vaadin-grid::part(row) {
         cursor: pointer;
       }
@@ -140,7 +137,8 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
           overflow-wrap: break-word;
         }
       }
-    `;
+    `
+    ];
   }
 
   render() {
@@ -203,6 +201,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
           });
         }
         const api = new RequestStatusesApi();
+        this.silentRefresh.requestStarted();
         api
           .requestStatusesPut({
             pagedDataOperators: {
@@ -227,7 +226,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
               data.Items?.map(
                 item => (item.UserName = getShortLogonName(item.UserName))
               );
-              callback(data.Items ?? [], Math.max(this.maxCountBeforeRefresh ?? 0, data.TotalItems ?? 0));
+              callback(data.Items ?? [], this.silentRefresh.reportedSize(data.TotalItems));
 
               this.dispatchEvent(
                 new CustomEvent('searching-requests-finished', {
@@ -248,6 +247,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
               notification.open();
               console.error(errMessage, err);
               callback([], 0);
+              this.silentRefresh.requestFinished();
               this.dispatchEvent(
                 new CustomEvent('searching-requests-finished', {
                   detail: { TotalItems: 0 },
@@ -257,6 +257,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
               );
             },
             complete: () => {
+              this.silentRefresh.requestFinished();
               this.monitorRequestsLoaded();
             }
           });
@@ -427,14 +428,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
   }
 
   private refreshGrid() {
-    if (!this.grid) return;
-    // Silent in-place refresh: keep the current cached row count so the grid
-    // size doesn't collapse (scroll jump), and flag the grid so loading rows
-    // keep their previous content visible instead of flashing blank.
-    this.maxCountBeforeRefresh =
-      (this.grid as any)._flatSize ?? this.maxCountBeforeRefresh ?? 0;
-    this.grid.setAttribute('silent-refresh', '');
-    this.grid.clearCache();
+    this.silentRefresh.refresh();
   }
 
   private searchingRequestsStarted(event: CustomEvent) {
@@ -464,7 +458,6 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
         default:
           break;
       }
-      this.maxCountBeforeRefresh = 0;
       this.grid?.clearCache();
       this.isSearching = true;
     },
@@ -488,11 +481,6 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
     this.noResults = data.TotalItems === 0;
 
     this.isSearching = false;
-    this.grid?.removeAttribute('silent-refresh');
-    // Drop the preserved size guard now fresh data has arrived so subsequent
-    // responses adopt the server's real total - a shrunk result set must
-    // shrink the grid rather than leave it permanently oversized.
-    this.maxCountBeforeRefresh = 0;
   }
 
   private monitorRequestsLoaded() {
@@ -501,8 +489,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
 
   updateGrid() {
     if (this.grid) {
-      this.maxCountBeforeRefresh = (this.grid as any)._flatSize; // there is no good way to get size of loaded items in vaadin grid(!)
-      this.grid.clearCache();
+      this.silentRefresh.refreshWithLoadingUi();
       this.isLoading = true;
     }
   }

--- a/src/dorc-web/src/components/environment-tabs/env-monitor.ts
+++ b/src/dorc-web/src/components/environment-tabs/env-monitor.ts
@@ -489,6 +489,10 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
 
     this.isSearching = false;
     this.grid?.removeAttribute('silent-refresh');
+    // Drop the preserved size guard now fresh data has arrived so subsequent
+    // responses adopt the server's real total - a shrunk result set must
+    // shrink the grid rather than leave it permanently oversized.
+    this.maxCountBeforeRefresh = 0;
   }
 
   private monitorRequestsLoaded() {

--- a/src/dorc-web/src/components/environment-tabs/env-monitor.ts
+++ b/src/dorc-web/src/components/environment-tabs/env-monitor.ts
@@ -115,6 +115,13 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
         margin: 0px;
       }
 
+      /* During background (silent) refreshes keep the previous cell content
+         visible instead of Vaadin's hidden loading rows - stops the grid
+         flashing blank on every SignalR-triggered refresh. */
+      vaadin-grid[silent-refresh] vaadin-grid-cell-content {
+        visibility: visible;
+      }
+
       vaadin-grid::part(row) {
         cursor: pointer;
       }
@@ -420,9 +427,14 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
   }
 
   private refreshGrid() {
-    // Avoid toggling loading overlays; simply invalidate cache
-    this.maxCountBeforeRefresh = 0;
-    this.grid?.clearCache();
+    if (!this.grid) return;
+    // Silent in-place refresh: keep the current cached row count so the grid
+    // size doesn't collapse (scroll jump), and flag the grid so loading rows
+    // keep their previous content visible instead of flashing blank.
+    this.maxCountBeforeRefresh =
+      (this.grid as any)._flatSize ?? this.maxCountBeforeRefresh ?? 0;
+    this.grid.setAttribute('silent-refresh', '');
+    this.grid.clearCache();
   }
 
   private searchingRequestsStarted(event: CustomEvent) {
@@ -476,6 +488,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
     this.noResults = data.TotalItems === 0;
 
     this.isSearching = false;
+    this.grid?.removeAttribute('silent-refresh');
   }
 
   private monitorRequestsLoaded() {
@@ -484,7 +497,7 @@ export class EnvMonitor extends ResponsiveMixin(PageEnvBase) implements IDeploym
 
   updateGrid() {
     if (this.grid) {
-      this.maxCountBeforeRefresh = (this.grid as any).__data?._flatSize; // there is no good way to get size of loaded items in vaadin grid(!)
+      this.maxCountBeforeRefresh = (this.grid as any)._flatSize; // there is no good way to get size of loaded items in vaadin grid(!)
       this.grid.clearCache();
       this.isLoading = true;
     }

--- a/src/dorc-web/src/components/request-status-card.ts
+++ b/src/dorc-web/src/components/request-status-card.ts
@@ -153,6 +153,7 @@ export class RequestStatusCard extends LitElement {
               <connection-status-indicator
                 mode="icon"
                 .state="${this.hubConnectionState}"
+                .showWhenConnected="${true}"
               ></connection-status-indicator>
             </td>
             ${this.deployRequest.Log !== null && this.deployRequest.Log !== '0'
@@ -444,8 +445,6 @@ export class RequestStatusCard extends LitElement {
   }
 
   private refresh() {
-    this.deployRequest.Status = 'Refreshing...';
-    this.requestUpdate();
     this.dispatchEvent(
       new CustomEvent('refresh-monitor-result', {
         detail: {

--- a/src/dorc-web/src/helpers/silent-grid-refresh.ts
+++ b/src/dorc-web/src/helpers/silent-grid-refresh.ts
@@ -106,13 +106,18 @@ export class SilentGridRefresher {
     if (this.pendingRequests > 0) return;
 
     const grid = this.getGrid();
-    if (!grid) return;
-    grid.removeAttribute('silent-refresh');
-    this.detachInteractionListeners(grid);
-    if (this.sawResponse && this.preservedCount > this.lastTotal) {
-      // The preserved count masked a shrink; snap to the real total so the
-      // grid doesn't keep blank scroll space at the end.
-      grid.size = this.lastTotal;
+    if (grid) {
+      grid.removeAttribute('silent-refresh');
+      this.detachInteractionListeners(grid);
+      if (this.sawResponse && this.preservedCount > this.lastTotal) {
+        // The preserved count masked a shrink; snap to the real total so the
+        // grid doesn't keep blank scroll space at the end.
+        grid.size = this.lastTotal;
+      }
+    } else {
+      // Grid detached/replaced mid-refresh: the listeners died with the old
+      // element, so clear the flag or a future grid never gets them.
+      this.listenersAttached = false;
     }
     this.preservedCount = 0;
   }

--- a/src/dorc-web/src/helpers/silent-grid-refresh.ts
+++ b/src/dorc-web/src/helpers/silent-grid-refresh.ts
@@ -1,0 +1,137 @@
+import { css } from 'lit';
+import type { Grid } from '@vaadin/grid';
+
+/**
+ * Styles that keep the previous cell content visible while a silent refresh
+ * is in flight. Include in the static styles of any component that uses
+ * SilentGridRefresher.
+ *
+ * Vaadin hides the slotted content of loading rows (visibility: hidden),
+ * which makes the whole grid flash blank on every background refresh; an
+ * outer-tree rule overrides the shadow ::slotted rule while the
+ * silent-refresh attribute is present.
+ */
+export const silentRefreshStyles = css`
+  vaadin-grid[silent-refresh] vaadin-grid-cell-content {
+    visibility: visible;
+  }
+`;
+
+/**
+ * Coordinates flash-free background refreshes of a vaadin-grid backed by a
+ * paged data provider.
+ *
+ * During a silent refresh the previously cached row count is preserved (so
+ * the grid size doesn't collapse and jump the scroll position) and the
+ * silent-refresh attribute keeps existing cell content visible. The window
+ * is torn down only once every in-flight page request has settled - tearing
+ * down on the first response would blank the pages still loading. If the
+ * preserved count masked a shrink in the result set, the grid size is
+ * snapped down to the real total at teardown so the grid never stays
+ * oversized.
+ *
+ * The visibility override is also dropped as soon as the user interacts
+ * with the grid (wheel/touch/mouse/keys): recycled rows would otherwise
+ * briefly show another item's content while scrolling, and Vaadin's default
+ * hidden-loading behaviour is the right look mid-interaction.
+ */
+export class SilentGridRefresher {
+  private pendingRequests = 0;
+
+  private preservedCount = 0;
+
+  private lastTotal = 0;
+
+  private sawResponse = false;
+
+  private listenersAttached = false;
+
+  constructor(private readonly getGrid: () => Grid | undefined) {}
+
+  private readonly onUserInteraction = () => {
+    const grid = this.getGrid();
+    if (!grid) return;
+    grid.removeAttribute('silent-refresh');
+    this.detachInteractionListeners(grid);
+  };
+
+  /**
+   * Guarded read of Vaadin grid's private _flatSize (the row count the grid
+   * currently knows about). The previous internal (__data._flatSize) broke
+   * silently on the Vaadin 25 upgrade, so fall back to the preserved count
+   * if this one is ever renamed too.
+   */
+  private get cachedRowCount(): number {
+    return (this.getGrid() as any)?._flatSize ?? this.preservedCount;
+  }
+
+  /** Background (e.g. SignalR-triggered) refresh: no flash, no scroll jump. */
+  refresh(): void {
+    const grid = this.getGrid();
+    if (!grid) return;
+    this.preservedCount = this.cachedRowCount;
+    this.sawResponse = false;
+    grid.setAttribute('silent-refresh', '');
+    this.attachInteractionListeners(grid);
+    grid.clearCache();
+  }
+
+  /** Manual refresh: preserve the size but let the loading UI show. */
+  refreshWithLoadingUi(): void {
+    const grid = this.getGrid();
+    if (!grid) return;
+    this.preservedCount = this.cachedRowCount;
+    this.sawResponse = false;
+    grid.clearCache();
+  }
+
+  /** Call when the data provider issues a page request. */
+  requestStarted(): void {
+    this.pendingRequests += 1;
+  }
+
+  /** Size to report to the grid's data provider callback. */
+  reportedSize(totalItems: number | null | undefined): number {
+    this.lastTotal = totalItems ?? 0;
+    this.sawResponse = true;
+    return Math.max(this.preservedCount, this.lastTotal);
+  }
+
+  /**
+   * Call when a page request settles (success or error). Tears the silent
+   * window down once no requests remain in flight.
+   */
+  requestFinished(): void {
+    this.pendingRequests = Math.max(0, this.pendingRequests - 1);
+    if (this.pendingRequests > 0) return;
+
+    const grid = this.getGrid();
+    if (!grid) return;
+    grid.removeAttribute('silent-refresh');
+    this.detachInteractionListeners(grid);
+    if (this.sawResponse && this.preservedCount > this.lastTotal) {
+      // The preserved count masked a shrink; snap to the real total so the
+      // grid doesn't keep blank scroll space at the end.
+      grid.size = this.lastTotal;
+    }
+    this.preservedCount = 0;
+  }
+
+  private attachInteractionListeners(grid: Grid): void {
+    if (this.listenersAttached) return;
+    this.listenersAttached = true;
+    grid.addEventListener('wheel', this.onUserInteraction, { passive: true });
+    grid.addEventListener('touchstart', this.onUserInteraction, { passive: true });
+    grid.addEventListener('mousedown', this.onUserInteraction);
+    grid.addEventListener('keydown', this.onUserInteraction);
+  }
+
+  private detachInteractionListeners(grid: Grid): void {
+    if (!this.listenersAttached) return;
+    this.listenersAttached = false;
+    grid.removeEventListener('wheel', this.onUserInteraction);
+    grid.removeEventListener('touchstart', this.onUserInteraction);
+    grid.removeEventListener('mousedown', this.onUserInteraction);
+    grid.removeEventListener('keydown', this.onUserInteraction);
+  }
+}

--- a/src/dorc-web/src/pages/page-monitor-requests.ts
+++ b/src/dorc-web/src/pages/page-monitor-requests.ts
@@ -112,6 +112,13 @@ export class PageMonitorRequests
         margin: 0px;
       }
 
+      /* During background (silent) refreshes keep the previous cell content
+         visible instead of Vaadin's hidden loading rows - stops the grid
+         flashing blank on every SignalR-triggered refresh. */
+      vaadin-grid[silent-refresh] vaadin-grid-cell-content {
+        visibility: visible;
+      }
+
       .id-btn {
         font-size: 14px;
         font-family: monospace;
@@ -427,9 +434,14 @@ export class PageMonitorRequests
   }
 
   private refreshGrid() {
-    // Avoid toggling loading overlays; simply invalidate cache
-    this.maxCountBeforeRefresh = 0;
-    this.grid?.clearCache();
+    if (!this.grid) return;
+    // Silent in-place refresh: keep the current cached row count so the grid
+    // size doesn't collapse (scroll jump), and flag the grid so loading rows
+    // keep their previous content visible instead of flashing blank.
+    this.maxCountBeforeRefresh =
+      (this.grid as any)._flatSize ?? this.maxCountBeforeRefresh ?? 0;
+    this.grid.setAttribute('silent-refresh', '');
+    this.grid.clearCache();
   }
 
   private searchingRequestsStarted(event: CustomEvent) {
@@ -489,6 +501,7 @@ export class PageMonitorRequests
     this.noResults = data.TotalItems === 0;
 
     this.isSearching = false;
+    this.grid?.removeAttribute('silent-refresh');
   }
 
   private monitorRequestsLoaded() {
@@ -497,7 +510,7 @@ export class PageMonitorRequests
 
   updateGrid() {
     if (this.grid) {
-      this.maxCountBeforeRefresh = (this.grid as any).__data?._flatSize; // there is no good way to get size of loaded items in vaadin grid(!)
+      this.maxCountBeforeRefresh = (this.grid as any)._flatSize; // there is no good way to get size of loaded items in vaadin grid(!)
       this.grid.clearCache();
       this.isLoading = true;
     }

--- a/src/dorc-web/src/pages/page-monitor-requests.ts
+++ b/src/dorc-web/src/pages/page-monitor-requests.ts
@@ -40,6 +40,10 @@ import { retrieveErrorMessage } from '../helpers/errorMessage-retriever.js';
 import type { PropertyValues } from 'lit';
 import { PageElement, PageLocation } from '../helpers/page-element';
 import { ResponsiveMixin } from '../helpers/responsive-mixin';
+import {
+  SilentGridRefresher,
+  silentRefreshStyles
+} from '../helpers/silent-grid-refresh';
 
 const username = 'Username';
 const status = 'Status';
@@ -56,9 +60,7 @@ export class PageMonitorRequests
 {
   @query('#grid') grid: Grid | undefined;
 
-  // since grid is being refreshed with multiple requests (pages) in non-deterministic way,
-  // we need to store the max count of items before refresh to keep grid's cache size
-  maxCountBeforeRefresh: number | undefined;
+  private silentRefresh = new SilentGridRefresher(() => this.grid);
 
   private hubConnection: HubConnection | undefined;
 
@@ -88,7 +90,9 @@ export class PageMonitorRequests
   buildFilter: string = '';
 
   static get styles() {
-    return css`
+    return [
+      silentRefreshStyles,
+      css`
       :host {
         display: flex;
         flex-direction: column;
@@ -110,13 +114,6 @@ export class PageMonitorRequests
         padding-top: 0px;
         padding-bottom: 0px;
         margin: 0px;
-      }
-
-      /* During background (silent) refreshes keep the previous cell content
-         visible instead of Vaadin's hidden loading rows - stops the grid
-         flashing blank on every SignalR-triggered refresh. */
-      vaadin-grid[silent-refresh] vaadin-grid-cell-content {
-        visibility: visible;
       }
 
       .id-btn {
@@ -145,7 +142,8 @@ export class PageMonitorRequests
         left: 50%;
         transform: translate(-50%, -50%);
       }
-    `;
+    `
+    ];
   }
 
   render() {
@@ -200,6 +198,7 @@ export class PageMonitorRequests
             });
           }
           const api = new RequestStatusesApi();
+          this.silentRefresh.requestStarted();
           api
             .requestStatusesPut({
               pagedDataOperators: {
@@ -226,10 +225,7 @@ export class PageMonitorRequests
                 );
                 callback(
                   data.Items ?? [],
-                  Math.max(
-                    this.maxCountBeforeRefresh ?? 0,
-                    data.TotalItems ?? 0
-                  )
+                  this.silentRefresh.reportedSize(data.TotalItems)
                 );
 
                 this.dispatchEvent(
@@ -248,6 +244,7 @@ export class PageMonitorRequests
                 notification.open();
                 console.error(errMessage, err);
                 callback([], 0);
+                this.silentRefresh.requestFinished();
                 this.dispatchEvent(
                   new CustomEvent('searching-requests-finished', {
                     detail: { TotalItems: 0 },
@@ -257,6 +254,7 @@ export class PageMonitorRequests
                 );
               },
               complete: () => {
+                this.silentRefresh.requestFinished();
                 this.monitorRequestsLoaded();
               }
             });
@@ -434,14 +432,7 @@ export class PageMonitorRequests
   }
 
   private refreshGrid() {
-    if (!this.grid) return;
-    // Silent in-place refresh: keep the current cached row count so the grid
-    // size doesn't collapse (scroll jump), and flag the grid so loading rows
-    // keep their previous content visible instead of flashing blank.
-    this.maxCountBeforeRefresh =
-      (this.grid as any)._flatSize ?? this.maxCountBeforeRefresh ?? 0;
-    this.grid.setAttribute('silent-refresh', '');
-    this.grid.clearCache();
+    this.silentRefresh.refresh();
   }
 
   private searchingRequestsStarted(event: CustomEvent) {
@@ -477,7 +468,6 @@ export class PageMonitorRequests
         default:
           break;
       }
-      this.maxCountBeforeRefresh = 0;
       this.grid?.clearCache();
       this.isSearching = true;
     },
@@ -501,11 +491,6 @@ export class PageMonitorRequests
     this.noResults = data.TotalItems === 0;
 
     this.isSearching = false;
-    this.grid?.removeAttribute('silent-refresh');
-    // Drop the preserved size guard now fresh data has arrived so subsequent
-    // responses adopt the server's real total - a shrunk result set must
-    // shrink the grid rather than leave it permanently oversized.
-    this.maxCountBeforeRefresh = 0;
   }
 
   private monitorRequestsLoaded() {
@@ -514,8 +499,7 @@ export class PageMonitorRequests
 
   updateGrid() {
     if (this.grid) {
-      this.maxCountBeforeRefresh = (this.grid as any)._flatSize; // there is no good way to get size of loaded items in vaadin grid(!)
-      this.grid.clearCache();
+      this.silentRefresh.refreshWithLoadingUi();
       this.isLoading = true;
     }
   }

--- a/src/dorc-web/src/pages/page-monitor-requests.ts
+++ b/src/dorc-web/src/pages/page-monitor-requests.ts
@@ -502,6 +502,10 @@ export class PageMonitorRequests
 
     this.isSearching = false;
     this.grid?.removeAttribute('silent-refresh');
+    // Drop the preserved size guard now fresh data has arrived so subsequent
+    // responses adopt the server's real total - a shrunk result set must
+    // shrink the grid rather than leave it permanently oversized.
+    this.maxCountBeforeRefresh = 0;
   }
 
   private monitorRequestsLoaded() {

--- a/src/dorc-web/src/pages/page-monitor-result.ts
+++ b/src/dorc-web/src/pages/page-monitor-result.ts
@@ -390,7 +390,7 @@ export class PageMonitorResult extends PageElement implements IDeploymentsEvents
               .hubConnectionState="${this.hubConnectionState}"
             ></request-status-card>
             <div class="results-section">
-              ${this.resultsLoading
+              ${this.resultsLoading && !this.resultItems
                 ? html` <div class="small-loader"></div>`
                 : html`
                     <vaadin-details

--- a/src/dorc-web/src/pages/page-monitor-result.ts
+++ b/src/dorc-web/src/pages/page-monitor-result.ts
@@ -278,10 +278,11 @@ export class PageMonitorResult extends PageElement implements IDeploymentsEvents
       },
       error: (err: any) => {
         console.error(err);
-        // 'complete' never runs after an error, so clear the loading flags
-        // here or a failed first load spins the loader forever.
+        // 'complete' never runs after an error, so clear the results loading
+        // flag here or a failed first load spins the loader forever. The
+        // page-level 'loading' flag belongs to the request-details call,
+        // which may still be in flight - leave it alone.
         this.resultItems = this.resultItems ?? [];
-        this.loading = false;
         this.resultsLoading = false;
       },
       complete: () => {

--- a/src/dorc-web/src/pages/page-monitor-result.ts
+++ b/src/dorc-web/src/pages/page-monitor-result.ts
@@ -254,6 +254,8 @@ export class PageMonitorResult extends PageElement implements IDeploymentsEvents
         this.shadowRoot?.appendChild(notification);
         notification.open();
         console.error(err);
+        this.loading = false;
+        this.resultsLoading = false;
       },
       complete: () => {
         console.log('done loading request');
@@ -276,6 +278,11 @@ export class PageMonitorResult extends PageElement implements IDeploymentsEvents
       },
       error: (err: any) => {
         console.error(err);
+        // 'complete' never runs after an error, so clear the loading flags
+        // here or a failed first load spins the loader forever.
+        this.resultItems = this.resultItems ?? [];
+        this.loading = false;
+        this.resultsLoading = false;
       },
       complete: () => {
         console.log('done loading result Statuses');

--- a/src/dorc-web/tests/components/connection-status-indicator.test.ts
+++ b/src/dorc-web/tests/components/connection-status-indicator.test.ts
@@ -89,6 +89,20 @@ describe('ConnectionStatusIndicator', () => {
       expect(toggled).to.be.true;
     });
 
+    it('does not promise live updates in the tooltip while offline', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Disconnected}"
+          .autoRefresh="${false}"
+        ></connection-status-indicator>
+      `);
+
+      const title = (pill(el) as HTMLButtonElement).title;
+      expect(title).to.contain('unavailable');
+      expect(title).to.not.contain('click to resume');
+    });
+
     it('reflects auto refresh state via aria-pressed', async () => {
       const el = await fixture<ConnectionStatusIndicator>(html`
         <connection-status-indicator

--- a/src/dorc-web/tests/components/connection-status-indicator.test.ts
+++ b/src/dorc-web/tests/components/connection-status-indicator.test.ts
@@ -1,0 +1,143 @@
+import { describe, it } from 'vitest';
+import { expect, fixture, html } from '../_helpers';
+import '../../src/components/connection-status-indicator';
+import type { ConnectionStatusIndicator } from '../../src/components/connection-status-indicator';
+import { HubConnectionState } from '@microsoft/signalr';
+
+function pill(el: ConnectionStatusIndicator): HTMLElement | null {
+  return el.shadowRoot!.querySelector('.pill');
+}
+
+describe('ConnectionStatusIndicator', () => {
+  describe('toggle mode', () => {
+    it('shows a pulsing Live pill when connected with auto refresh on', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Connected}"
+          .autoRefresh="${true}"
+        ></connection-status-indicator>
+      `);
+
+      const badge = pill(el)!;
+      expect(badge.textContent).to.contain('Live');
+      expect(badge.classList.contains('live')).to.be.true;
+      expect(badge.classList.contains('pulse')).to.be.true;
+      expect(badge.tagName).to.equal('BUTTON');
+    });
+
+    it('shows a Paused pill when connected with auto refresh off', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Connected}"
+          .autoRefresh="${false}"
+        ></connection-status-indicator>
+      `);
+
+      const badge = pill(el)!;
+      expect(badge.textContent).to.contain('Paused');
+      expect(badge.classList.contains('paused')).to.be.true;
+      expect(badge.classList.contains('pulse')).to.be.false;
+    });
+
+    it('shows a Reconnecting pill while the hub is reconnecting', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Reconnecting}"
+          .autoRefresh="${true}"
+        ></connection-status-indicator>
+      `);
+
+      const badge = pill(el)!;
+      expect(badge.textContent).to.contain('Reconnecting');
+      expect(badge.classList.contains('reconnecting')).to.be.true;
+      expect(badge.classList.contains('pulse')).to.be.true;
+    });
+
+    it('shows an Offline pill when disconnected', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Disconnected}"
+          .autoRefresh="${true}"
+        ></connection-status-indicator>
+      `);
+
+      const badge = pill(el)!;
+      expect(badge.textContent).to.contain('Offline');
+      expect(badge.classList.contains('offline')).to.be.true;
+      expect(badge.classList.contains('pulse')).to.be.false;
+    });
+
+    it('emits toggle-auto-refresh when clicked', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Connected}"
+          .autoRefresh="${true}"
+        ></connection-status-indicator>
+      `);
+
+      let toggled = false;
+      el.addEventListener('toggle-auto-refresh', () => {
+        toggled = true;
+      });
+      (pill(el) as HTMLButtonElement).click();
+
+      expect(toggled).to.be.true;
+    });
+
+    it('reflects auto refresh state via aria-pressed', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="toggle"
+          .state="${HubConnectionState.Connected}"
+          .autoRefresh="${false}"
+        ></connection-status-indicator>
+      `);
+
+      expect(pill(el)!.getAttribute('aria-pressed')).to.equal('false');
+    });
+  });
+
+  describe('icon (passive) mode', () => {
+    it('renders nothing when connected by default', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="icon"
+          .state="${HubConnectionState.Connected}"
+        ></connection-status-indicator>
+      `);
+
+      expect(pill(el)).to.be.null;
+    });
+
+    it('shows a Live pill when connected and showWhenConnected is set', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="icon"
+          .state="${HubConnectionState.Connected}"
+          .showWhenConnected="${true}"
+        ></connection-status-indicator>
+      `);
+
+      const badge = pill(el)!;
+      expect(badge.textContent).to.contain('Live');
+      expect(badge.tagName).to.equal('SPAN');
+      expect(badge.getAttribute('role')).to.equal('status');
+    });
+
+    it('shows an Offline pill when disconnected even without showWhenConnected', async () => {
+      const el = await fixture<ConnectionStatusIndicator>(html`
+        <connection-status-indicator
+          mode="icon"
+          .state="${HubConnectionState.Disconnected}"
+        ></connection-status-indicator>
+      `);
+
+      expect(pill(el)!.textContent).to.contain('Offline');
+    });
+  });
+});

--- a/src/dorc-web/tests/helpers/silent-grid-refresh.test.ts
+++ b/src/dorc-web/tests/helpers/silent-grid-refresh.test.ts
@@ -106,6 +106,31 @@ describe('SilentGridRefresher', () => {
     expect(refresher.reportedSize(150)).to.equal(200);
   });
 
+  it('resets its state when the grid disappears mid-refresh', () => {
+    let grid: StubGrid | undefined = makeGrid(200);
+    const refresher = new SilentGridRefresher(
+      () => grid as unknown as Grid | undefined
+    );
+
+    refresher.refresh();
+    refresher.requestStarted();
+    grid = undefined;
+    refresher.requestFinished();
+
+    // A replacement grid must not inherit the preserved size...
+    const newGrid = makeGrid(50);
+    grid = newGrid;
+    refresher.requestStarted();
+    expect(refresher.reportedSize(30)).to.equal(30);
+    refresher.requestFinished();
+
+    // ...and must still get interaction listeners on the next refresh.
+    refresher.refresh();
+    expect(newGrid.hasAttribute('silent-refresh')).to.be.true;
+    newGrid.dispatchEvent(new Event('wheel'));
+    expect(newGrid.hasAttribute('silent-refresh')).to.be.false;
+  });
+
   it('falls back gracefully when the Vaadin internal is missing', () => {
     const grid = makeGrid();
     grid._flatSize = undefined;

--- a/src/dorc-web/tests/helpers/silent-grid-refresh.test.ts
+++ b/src/dorc-web/tests/helpers/silent-grid-refresh.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, vi } from 'vitest';
+import { expect } from '../_helpers';
+import { SilentGridRefresher } from '../../src/helpers/silent-grid-refresh';
+import type { Grid } from '@vaadin/grid';
+
+type StubGrid = HTMLElement & {
+  clearCache: ReturnType<typeof vi.fn>;
+  _flatSize: number | undefined;
+  size: number;
+};
+
+function makeGrid(flatSize: number | undefined = 200): StubGrid {
+  const grid = document.createElement('div') as unknown as StubGrid;
+  grid.clearCache = vi.fn();
+  grid._flatSize = flatSize;
+  grid.size = flatSize ?? 0;
+  return grid;
+}
+
+function makeRefresher(grid: StubGrid) {
+  return new SilentGridRefresher(() => grid as unknown as Grid);
+}
+
+describe('SilentGridRefresher', () => {
+  it('refresh() flags the grid and invalidates the cache', () => {
+    const grid = makeGrid();
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+
+    expect(grid.hasAttribute('silent-refresh')).to.be.true;
+    expect(grid.clearCache.mock.calls.length).to.equal(1);
+  });
+
+  it('reports the preserved count while the refresh is in flight', () => {
+    const grid = makeGrid(200);
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+    refresher.requestStarted();
+
+    expect(refresher.reportedSize(150)).to.equal(200);
+  });
+
+  it('reports the real total outside a refresh window', () => {
+    const grid = makeGrid(200);
+    const refresher = makeRefresher(grid);
+
+    refresher.requestStarted();
+    expect(refresher.reportedSize(150)).to.equal(150);
+  });
+
+  it('keeps the silent window open until the last in-flight request settles', () => {
+    const grid = makeGrid(200);
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+    refresher.requestStarted();
+    refresher.requestStarted();
+
+    refresher.reportedSize(150);
+    refresher.requestFinished();
+    expect(grid.hasAttribute('silent-refresh')).to.be.true;
+
+    refresher.reportedSize(150);
+    refresher.requestFinished();
+    expect(grid.hasAttribute('silent-refresh')).to.be.false;
+  });
+
+  it('snaps the grid size down when the preserved count masked a shrink', () => {
+    const grid = makeGrid(200);
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+    refresher.requestStarted();
+    expect(refresher.reportedSize(150)).to.equal(200);
+    refresher.requestFinished();
+
+    expect(grid.size).to.equal(150);
+  });
+
+  it('leaves the grid size alone when the result set grew', () => {
+    const grid = makeGrid(100);
+    grid.size = 120;
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+    refresher.requestStarted();
+    expect(refresher.reportedSize(120)).to.equal(120);
+    refresher.requestFinished();
+
+    expect(grid.size).to.equal(120);
+  });
+
+  it('drops the visibility override on user interaction but keeps the size guard', () => {
+    const grid = makeGrid(200);
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+    refresher.requestStarted();
+    grid.dispatchEvent(new Event('wheel'));
+
+    expect(grid.hasAttribute('silent-refresh')).to.be.false;
+    // The size guard still applies until the refresh settles - no mid-scroll
+    // size snap.
+    expect(refresher.reportedSize(150)).to.equal(200);
+  });
+
+  it('falls back gracefully when the Vaadin internal is missing', () => {
+    const grid = makeGrid();
+    grid._flatSize = undefined;
+    grid.size = 0;
+    const refresher = makeRefresher(grid);
+
+    refresher.refresh();
+    refresher.requestStarted();
+
+    expect(refresher.reportedSize(150)).to.equal(150);
+  });
+});


### PR DESCRIPTION
## Summary
Completely redesigned the connection status indicator component from a simple icon to a modern pill badge with status labels, pulsing animations, and improved accessibility. Also improved grid refresh behavior to prevent visual flashing during SignalR-triggered updates.

## Key Changes

### Connection Status Indicator Component
- **Replaced icon-based UI with pill badges**: Changed from Vaadin icon buttons to custom styled pill elements with status dots and text labels
- **Added four distinct status states**: Live (pulsing green), Paused (grey), Reconnecting (pulsing amber), Offline (red)
- **Improved accessibility**: Added proper ARIA attributes (`aria-pressed`, `role="status"`, `aria-label`), semantic HTML (`<button>` for toggle mode), and support for `prefers-reduced-motion`
- **Enhanced visual feedback**: Added pulsing animation for active states, hover effects for toggle mode, and color-coded backgrounds
- **Removed Vaadin dependencies**: Eliminated `@vaadin/button` and `@vaadin/icon` imports in favor of native HTML elements
- **Improved labeling**: Changed from cryptic icon names to clear status labels ("Live", "Paused", "Reconnecting", "Offline")
- **Added comprehensive test suite**: 143 lines of tests covering toggle mode, icon mode, state transitions, and event handling

### Grid Refresh Behavior
- **Silent refresh implementation**: Modified `refreshGrid()` in both `env-monitor.ts` and `page-monitor-requests.ts` to preserve grid row count during SignalR-triggered updates, preventing scroll jumps
- **Visual stability**: Added CSS rule to keep cell content visible during silent refreshes instead of showing blank loading rows
- **Improved UX**: Grid now updates data in-place without flashing or collapsing, providing a smoother real-time experience

### Minor Updates
- Updated `request-status-card.ts` to show connection indicator even when connected by setting `showWhenConnected="true"`
- Fixed grid size detection to use `_flatSize` instead of `__data?._flatSize` for more reliable row counting

## Implementation Details
- Used CSS custom properties for theming (success, warning, error colors)
- Implemented pulse animation with `@keyframes` and respects `prefers-reduced-motion` media query
- Pill styling uses modern CSS features like `color-mix()` for border colors
- Type-safe status handling with `IndicatorStatus` type union

https://claude.ai/code/session_01EyfMNTup4RZjRaewN64mXH