### PR TITLE
Keep a drawer shortcut highlighted across environment sub-tabs

### DIFF
--- a/src/dorc-web/src/components/dorc-navbar.ts
+++ b/src/dorc-web/src/components/dorc-navbar.ts
@@ -630,6 +630,11 @@ export class DorcNavbar extends LitElement {
     for (i = 0; i < tabsArray.length; i += 1) {
       const tab = tabsArray[i] as Tab;
       let childPath = '';
+      // An environment shortcut should stay highlighted across ALL of that
+      // environment's sub-tabs, so it matches on this prefix rather than on the
+      // one exact path getEnvDetailPath happens to build. The trailing slash is
+      // what stops "/environment/Foo/" also matching "/environment/FooBar/".
+      let envPrefix = '';
       const tabChild = tab.children[0] as unknown as URL;
       // The Audit parent tab uses href="#"; HTMLAnchorElement.pathname resolves "#" against the
       // current document URL, so without this skip every audit sub-route would match the parent.
@@ -641,6 +646,9 @@ export class DorcNavbar extends LitElement {
         const envDetailTab = tab.children[0] as EnvDetailTab;
         if (envDetailTab.env !== undefined) {
           childPath = this.getEnvDetailPath(envDetailTab.env);
+          envPrefix = `/environment/${String(
+            envDetailTab.env.EnvironmentName
+          )}/`.toLowerCase();
         }
         const projectEnvsTab = tab.children[0] as ProjectEnvsTab;
         if (projectEnvsTab.project !== undefined) {
@@ -659,7 +667,10 @@ export class DorcNavbar extends LitElement {
         idx = 0;
         break;
       }
-      if (pathCorrected === childPathCorrected) {
+      if (
+        pathCorrected === childPathCorrected ||
+        (envPrefix !== '' && pathCorrected.startsWith(envPrefix))
+      ) {
         idx = tabsArray.indexOf(tab);
         break;
       }

--- a/src/dorc-web/tests/components/drawer-shortcut-highlight.test.ts
+++ b/src/dorc-web/tests/components/drawer-shortcut-highlight.test.ts
@@ -1,0 +1,86 @@
+import { expect } from '../_helpers';
+
+// A drawer shortcut for an environment stopped being highlighted the moment you
+// opened any of that environment's sub-tabs other than Metadata.
+//
+// getEnvDetailPath builds exactly one path — the Metadata one — and
+// getIndexOfPath compared for equality, so /environment/Foo/projects matched
+// nothing, returned -1, and `tabs.selected = -1` cleared the drawer's selection
+// entirely. Because setSelectedTab runs from updated(), any re-render at all
+// (the async metaData response, toggling the hamburger) re-triggered it.
+
+interface DrawerNavbar extends HTMLElement {
+  updateComplete: Promise<unknown>;
+  insertEnvTab(env: unknown): void;
+  setSelectedTab(path: string): void;
+}
+
+async function registerRoutes(): Promise<void> {
+  const { router } = await import('../../src/router/router.js');
+  const { routes } = await import('../../src/router/routes.js');
+  await (
+    router as unknown as {
+      setRoutes(r: unknown, skipRender?: boolean): Promise<unknown>;
+    }
+  ).setRoutes(routes, true);
+}
+
+describe('Drawer shortcut highlighting across environment sub-tabs', () => {
+  let container: HTMLDivElement;
+
+  beforeAll(async () => {
+    await registerRoutes();
+    await import('../../src/components/dorc-navbar.js');
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => container.remove());
+
+  const mountWithShortcut = async (name: string) => {
+    const navbar = document.createElement('dorc-navbar') as DrawerNavbar;
+    container.appendChild(navbar);
+    await navbar.updateComplete;
+    navbar.insertEnvTab({ EnvironmentId: 1, EnvironmentName: name });
+    const tabs = navbar.shadowRoot?.getElementById('tabs') as HTMLElement & {
+      selected: number;
+    };
+    if (!tabs) throw new Error('navbar rendered without #tabs');
+    return { navbar, tabs };
+  };
+
+  ['metadata', 'projects', 'variables', 'deployments', 'monitor'].forEach(
+    subTab => {
+      it(`keeps the shortcut selected on the ${subTab} sub-tab`, async () => {
+        const { navbar, tabs } = await mountWithShortcut('PROD-EMEA');
+
+        navbar.setSelectedTab(`/environment/PROD-EMEA/${subTab}`);
+
+        expect(
+          tabs.selected,
+          `selection must not be cleared on /${subTab}`
+        ).to.be.greaterThan(-1);
+      });
+    }
+  );
+
+  it('does not match a different environment whose name shares a prefix', async () => {
+    const { navbar, tabs } = await mountWithShortcut('PROD');
+
+    // Without the trailing slash in the prefix, "PROD" would swallow "PRODUCTION".
+    navbar.setSelectedTab('/environment/PRODUCTION/metadata');
+
+    expect(tabs.selected, 'PROD must not claim PRODUCTION').to.equal(-1);
+  });
+
+  it('still matches nothing for an unrelated route', async () => {
+    const { navbar, tabs } = await mountWithShortcut('PROD-EMEA');
+
+    navbar.setSelectedTab('/environment/SOMETHING-ELSE/metadata');
+
+    expect(tabs.selected).to.equal(-1);
+  });
+});


### PR DESCRIPTION
Closes #893.

Open an environment from the navigation drawer, click any sub-tab other than Metadata, and the drawer stops highlighting where you are.

## Cause

`getEnvDetailPath` builds exactly one path per shortcut — the Metadata one — and `getIndexOfPath` compares the current location against it for **equality**. So `/environment/Foo/projects` matches nothing, returns `-1`, and `setSelectedTab` assigns that straight to `tabs.selected`, clearing the selection rather than leaving it alone.

`setSelectedTab` runs from `updated()`, so this re-triggers on any re-render: the async metadata response landing, toggling the hamburger, or navigating.

## Fix

Environment shortcuts now match on the `/environment/<name>/` prefix instead of one exact path.

The trailing slash is load-bearing — without it a shortcut for `PROD` would also claim `PRODUCTION`. That case has its own test rather than being left to inspection.

## Testing

Red/green verified by stashing the fix:

- **Without it:** the four non-Metadata sub-tab tests fail.
- **With it:** all 7 pass.
- The Metadata case and both negative cases (prefix collision, unrelated route) pass either way — which is what shows the change does not over-match.

Full suite **129 tests across 14 files**, lint and both typechecks clean, build verified.

Verified locally against chromium only, using the sandbox's preinstalled build; `vitest.config.ts` is untouched, so CI runs the full chromium/firefox/webkit matrix.

## Scope

One function, one matching rule, plus a test file. No API, event-contract or markup changes.

This was originally scheduled inside a much larger navigation restructure that is gated on a separate decision. The two turned out to be unrelated — this needs no restructure, and unlike that work it affects every user rather than only screen-reader users — so it should not have been waiting behind it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvMn7KA2ChBFpRzmFbRpev)_